### PR TITLE
Integrate TUI test layers into CI and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
                   name: codecov-umbrella
 
     tui-pr-gate:
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/develop')
         runs-on: ubuntu-latest
 
         steps:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -90,7 +90,7 @@ conda run -n tensor-torch-profiler python -m pytest tests/e2e/test_tui_pty.py -m
 
 CI gating strategy:
 
-- Pull requests (`main`): run the PR-safe TUI gate (`tui_pilot` + `tui_snapshot`).
+- Pull requests (`main`) and pushes to `develop`: run the PR-safe TUI gate (`tui_pilot` + `tui_snapshot`).
 - Pushes to `main` and nightly schedule: run the PTY smoke layer (`tui_pty`).
 
 Equivalent CI commands:


### PR DESCRIPTION
## Summary
- add CI scheduling and event-based gating for TUI layers
- run `tui_pilot` + `tui_snapshot` on pull requests
- run `tui_pty` smoke tests on `main` pushes and nightly schedule
- document the TUI testing pyramid and exact marker commands in testing docs

## Changes
- update CI workflow to:
  - add nightly schedule trigger
  - exclude TUI markers from the general test matrix
  - add `tui-pr-gate` job for PR-safe TUI suites
  - add `tui-pty-smoke` job for `main`/nightly PTY smoke checks
- update testing docs with marker strategy and commands used by CI

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'ci.yml: YAML OK'"`
- `conda run -n tensor-torch-profiler python -m pytest tests/tui/ -m "tui_pilot or tui_snapshot" -v -p no:capture`
  - pilot tests passed
  - snapshot tests mismatched locally (`snapshot_report.html`)
- `conda run -n tensor-torch-profiler python -m pytest tests/e2e/test_tui_pty.py -m tui_pty -v -p no:capture` (passed)


Closes #17


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing documentation with clarified TUI testing framework guidance, including local commands and CI strategies.

* **Chores**
  * Enhanced CI/CD pipeline with improved test separation between PR validation and scheduled periodic testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->