### PR TITLE
docs(v0.2): clean long-form API drift and add stale-snippet guard

### DIFF
--- a/docs/article.md
+++ b/docs/article.md
@@ -356,7 +356,7 @@ from gpumemprof import MemoryTracker
 # Start real-time tracking
 tracker = MemoryTracker(
     sampling_interval=0.1,    # Check every 100ms
-    alert_threshold_mb=8000   # Alert at 8GB
+    enable_alerts=True
 )
 
 tracker.start_tracking()
@@ -365,7 +365,7 @@ tracker.start_tracking()
 train_model()
 
 tracker.stop_tracking()
-results = tracker.get_tracking_results()
+results = tracker.get_statistics()
 ```
 
 **What it monitors:**
@@ -916,19 +916,20 @@ RuntimeError: CUDA out of memory. Tried to allocate 2.00 GiB
 
 ```python
 # Use our profiler to find the exact memory bottleneck
-tracker = MemoryTracker(alert_threshold_mb=1024)
+tracker = MemoryTracker(enable_alerts=True)
 tracker.start_tracking()
 
 try:
     train_model()
 except RuntimeError as e:
     if "out of memory" in str(e):
-        results = tracker.stop_tracking()
-        print(f"Peak memory before crash: {results.peak_memory:.1f} MB")
+        tracker.stop_tracking()
+        stats = tracker.get_statistics()
+        print(f"Peak memory before crash: {stats.get('peak_memory', 0) / (1024**2):.1f} MB")
 
         # Get specific recommendations
         analyzer = MemoryAnalyzer()
-        suggestions = analyzer.generate_optimization_report(profiler.results)["recommendations"]
+        suggestions = analyzer.generate_optimization_report()["recommendations"]
         print("Try these optimizations:")
         for suggestion in suggestions:
             print(f"- {suggestion}")

--- a/docs/tensorflow_testing_guide.md
+++ b/docs/tensorflow_testing_guide.md
@@ -264,13 +264,13 @@ for context, stats in results.function_profiles.items():
 #### Real-Time Monitoring
 
 ```python
-from tfmemprof import MemoryTracker
+from tfmemprof import TensorFlowMemoryTracker
 
 # Setup tracker with TensorFlow-specific alerts
-tracker = MemoryTracker(
+tracker = TensorFlowMemoryTracker(
     sampling_interval=0.1,     # Sample every 100ms
     alert_threshold_mb=3000,   # Alert at 3GB
-    enable_alerts=True
+    enable_logging=True
 )
 
 # Start tracking
@@ -288,10 +288,9 @@ try:
             )
         print(f"TensorFlow iteration {i+1}/10")
 finally:
-    tracker.stop_tracking()
+    results = tracker.stop_tracking()
 
 # Analyze results
-results = tracker.get_tracking_results()
 print(f"Peak memory: {results.peak_memory_mb:.2f} MB")
 ```
 
@@ -844,7 +843,11 @@ model = tf.keras.Sequential([
 batch_size = 16  # Smaller batches for CPU
 
 # 4. Increase sampling interval
-tracker = TFCPUMemoryTracker(interval=1.0)  # Sample every second
+tracker = TensorFlowMemoryTracker(
+    sampling_interval=1.0,
+    device='/CPU:0',
+    enable_logging=False,
+)
 ```
 
 ---

--- a/tests/test_docs_regressions.py
+++ b/tests/test_docs_regressions.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_BANNED_DOC_SNIPPETS = {
+    "docs/pytorch_testing_guide.md": [
+        "alert_threshold_mb=2000",
+        "tracker.get_tracking_results()",
+        "results['memory_samples']",
+        "python -m gpumemprof.cli analyze --input",
+        "--detect-leaks --visualize",
+    ],
+    "docs/article.md": [
+        "MemoryTracker(alert_threshold_mb=",
+        "results = tracker.stop_tracking()",
+    ],
+    "docs/tensorflow_testing_guide.md": [
+        "from tfmemprof import MemoryTracker",
+        "enable_alerts=True",
+        "TFCPUMemoryTracker",
+    ],
+}
+
+_PARAMS = [
+    (relative_path, snippet)
+    for relative_path, snippets in _BANNED_DOC_SNIPPETS.items()
+    for snippet in snippets
+]
+
+
+@pytest.mark.parametrize(("relative_path", "snippet"), _PARAMS)
+def test_docs_do_not_reintroduce_known_stale_api_snippets(
+    relative_path: str, snippet: str
+) -> None:
+    content = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+    assert snippet not in content, (
+        f"{relative_path} contains stale docs snippet: {snippet!r}"
+    )


### PR DESCRIPTION
## Summary
- align remaining PyTorch/TensorFlow long-form docs with current runtime API/CLI behavior
- replace stale gpumemprof MemoryTracker examples with get_statistics()/get_events() usage
- add docs regression guard test for known stale snippets to prevent reintroduction

## Issue
Closes #53

## Validation
- ran stale-snippet regression check script in tensor-torch-profiler env

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API usage examples across guides to reflect changes in memory tracking configuration and result retrieval methods
  * Updated command-line interface flag names in examples

* **Tests**
  * Added regression test to prevent deprecated code snippets from being reintroduced into documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->