### PR TITLE
fix release workflow tag versioning and update PyPI docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  fetch-tags: true
 
             - name: Set up Python
               uses: actions/setup-python@v4

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ A production-ready, open source tool for real-time GPU memory profiling, leak de
 
 ## Installation
 
-### From PyPI (when released)
+### From PyPI
+
+Package page: <https://pypi.org/project/gpu-memory-profiler/>
 
 ```bash
 # Basic installation

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,8 +14,7 @@ This guide covers different installation methods for GPU Memory Profiler.
 
 ### 1. From PyPI
 
-> **Note:** The package is not yet published on PyPI. Use the source
-> installation below until the first release is available.
+Package page: <https://pypi.org/project/gpu-memory-profiler/>
 
 ```bash
 # Basic installation (includes PyTorch and TensorFlow)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,7 +16,7 @@ This guide helps you resolve common issues with GPU Memory Profiler.
 # Install the package
 pip install -e .
 
-# Or install from PyPI (when available)
+# Or install from PyPI
 pip install gpu-memory-profiler
 ```
 


### PR DESCRIPTION
## Summary
- fetch full git history + tags in release workflow checkout so setuptools_scm resolves tag versions on release builds
- update docs to remove pre-release PyPI wording and point to the live package page

Closes #63  

## Why
The v0.2.0 release workflow failed because PyPI rejects local/dev versions (for example `0.2.1.dev0+...`). Fetching tags during checkout prevents this for future release publishes.

## Changes
- `.github/workflows/release.yml`: checkout now uses `fetch-depth: 0` and `fetch-tags: true`
- `README.md`: "From PyPI" section now points to `https://pypi.org/project/gpu-memory-profiler/`
- `docs/installation.md`: removed "not yet published" note and added package link
- `docs/troubleshooting.md`: removed "(when available)" wording for PyPI install

## Validation
- `v0.2.0` is live on PyPI: https://pypi.org/project/gpu-memory-profiler/0.2.0/
- Local `setuptools_scm` resolves the tagged version as `0.2.0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated installation documentation to reflect the package's availability on PyPI.
  * Added a direct link to the package page for easier access and reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->