### PR TITLE
feat(telemetry): add append-only always-on sink (#90)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -64,6 +64,7 @@ gpumemprof monitor --duration 30 --interval 0.5 --output monitor.json --format j
 gpumemprof track --duration 30 --interval 0.5 --output track.json --format json
 gpumemprof track --warning-threshold 75 --critical-threshold 90 --output alerts.csv
 gpumemprof track --job-id train-42 --rank 1 --local-rank 1 --world-size 8 --output rank1.json --format json
+gpumemprof track --telemetry-sink-dir ./live_sink --telemetry-rollover-mb 32 --telemetry-retention-total-mb 256
 ```
 
 For long-running tracking sessions, Stormlog now degrades gracefully when a
@@ -73,6 +74,20 @@ collector becomes unhealthy:
 - exported telemetry includes `collector_degraded` / `collector_recovered` events
 - per-event metadata marks partial or unhealthy collector state
 - retries use bounded exponential backoff instead of crashing the tracker loop
+
+For always-on sessions, `gpumemprof track` can also stream append-only
+telemetry into a sink directory during the run instead of waiting for shutdown.
+The sink writes JSONL segments plus a manifest, rolls segments when they hit the
+configured size limit, and prunes the oldest closed segments to stay within the
+retention budget.
+
+Useful sink options:
+
+- `--telemetry-sink-dir`
+- `--telemetry-flush-seconds`
+- `--telemetry-rollover-mb`
+- `--telemetry-retention-files`
+- `--telemetry-retention-total-mb`
 
 Optional OOM flight-recorder support:
 
@@ -90,9 +105,13 @@ gpumemprof track \
 ```bash
 gpumemprof analyze track.json --format txt --output analysis.txt
 gpumemprof analyze track.json --visualization --plot-dir plots
+gpumemprof analyze ./live_sink
 ```
 
-`gpumemprof analyze` uses a positional input file. If you add `--visualization`, plots are written to the directory passed via `--plot-dir` or to `plots/` by default.
+`gpumemprof analyze` uses a positional input file. It can now read a normal JSON
+telemetry export, a sink JSONL segment, or a sink directory containing the
+current and rolled append-only outputs. If you add `--visualization`, plots are
+written to the directory passed via `--plot-dir` or to `plots/` by default.
 
 ### Produce a diagnose bundle
 
@@ -147,11 +166,14 @@ tfmemprof track --interval 0.5 --threshold 4096 --device /CPU:0 --output tf_trac
 ```bash
 tfmemprof track --interval 0.5 --threshold 4096 --output tf_track.json
 tfmemprof track --interval 0.5 --threshold 4096 --job-id train-42 --rank 3 --local-rank 1 --world-size 8 --output tf_rank3.json
+tfmemprof track --interval 0.5 --threshold 4096 --output tf_track.json --telemetry-sink-dir ./tf_live_sink
 ```
 
 `tfmemprof track` follows the same degraded-mode rules as the PyTorch tracker:
 collector failures pause new sample emission, status events remain visible in the
 artifact stream, and normal sampling resumes automatically after recovery.
+The same append-only sink options are available when you need bounded,
+interrupt-tolerant TensorFlow telemetry during a long-running session.
 
 ### Analyze TensorFlow results
 

--- a/docs/telemetry_schema.md
+++ b/docs/telemetry_schema.md
@@ -140,3 +140,30 @@ from stormlog.telemetry import (
 - `validate_telemetry_record(record)`
 
 These APIs normalize legacy records to `schema_version: 2` and enforce required fields.
+
+## Append-only sink layout
+
+Always-on `track` sessions can also write append-only telemetry into a sink
+directory during the run. The sink format is:
+
+```text
+telemetry_sink/
+  manifest.json
+  segment-000001.jsonl
+  segment-000002.jsonl
+```
+
+- each JSONL line is one canonical telemetry record
+- `manifest.json` tracks segment ordering and rollover state
+- closed segments may be pruned when file-count or total-size retention limits are hit
+
+`load_telemetry_events()` can read:
+
+- a normal JSON export
+- a sink directory
+- `manifest.json`
+- an individual JSONL segment
+
+If the final JSONL line is truncated because the process was interrupted during a
+write, the loader ignores that incomplete tail and still returns the fully
+written records ahead of it.

--- a/stormlog/cli.py
+++ b/stormlog/cli.py
@@ -859,6 +859,14 @@ def _json_default(value: Any) -> Any:
     raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
 
 
+def _input_artifact_size_bytes(path: Path) -> int:
+    if path.is_file():
+        return int(path.stat().st_size)
+    if path.is_dir():
+        return sum(entry.stat().st_size for entry in path.rglob("*") if entry.is_file())
+    return 0
+
+
 def _build_analyze_summary(
     input_file: str, file_size_bytes: int, report: dict[str, Any]
 ) -> str:
@@ -959,30 +967,44 @@ def cmd_analyze(args: argparse.Namespace) -> int:
         print(f"Error: Input file '{input_file}' not found")
         return 1
 
-    try:
-        with input_path.open("r", encoding="utf-8") as handle:
-            data = json.load(handle)
-    except Exception as e:
-        print(f"Error loading input file: {e}")
-        return 1
-
     (load_telemetry_events,) = _import_runtime_symbols(
         ".telemetry", ("load_telemetry_events",), "The analyze command"
     )
 
     events: list[Any] | None = None
     telemetry_note: str | None = None
+    data: Any = None
     try:
         events = load_telemetry_events(input_path, permissive_legacy=True)
     except ValueError as exc:
+        if input_path.is_dir() or input_path.suffix.lower() == ".jsonl":
+            print(f"Error parsing telemetry events: {exc}")
+            return 1
+        try:
+            with input_path.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+        except Exception as error:
+            print(f"Error loading input file: {error}")
+            return 1
         if not _json_payload_looks_like_telemetry(data):
             telemetry_note = "JSON payload does not contain telemetry events"
         else:
             print(f"Error parsing telemetry events: {exc}")
             return 1
     except Exception as exc:
-        print(f"Error parsing telemetry events: {exc}")
-        return 1
+        if input_path.is_dir() or input_path.suffix.lower() == ".jsonl":
+            print(f"Error parsing telemetry events: {exc}")
+            return 1
+        try:
+            with input_path.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+        except Exception as error:
+            print(f"Error loading input file: {error}")
+            return 1
+        if _json_payload_looks_like_telemetry(data):
+            print(f"Error parsing telemetry events: {exc}")
+            return 1
+        telemetry_note = "JSON payload does not contain telemetry events"
 
     if events is not None:
         (MemoryAnalyzer,) = _import_runtime_symbols(
@@ -1005,7 +1027,7 @@ def cmd_analyze(args: argparse.Namespace) -> int:
 
     summary_text = _build_analyze_summary(
         input_file=input_file,
-        file_size_bytes=input_path.stat().st_size,
+        file_size_bytes=_input_artifact_size_bytes(input_path),
         report=report,
     )
     print(summary_text)

--- a/stormlog/cli.py
+++ b/stormlog/cli.py
@@ -13,6 +13,7 @@ from typing import Any, Optional, Union, cast
 
 import psutil
 
+from .telemetry_sink import TelemetrySinkConfig
 from .utils import (
     _detect_gpu_hardware,
     format_bytes,
@@ -114,6 +115,27 @@ def _is_visualization_dependency_error(exc: BaseException) -> bool:
         current = next_exc
 
     return False
+
+
+def _build_telemetry_sink_config(
+    args: argparse.Namespace,
+) -> Optional[TelemetrySinkConfig]:
+    sink_dir = getattr(args, "telemetry_sink_dir", None)
+    if not sink_dir:
+        return None
+    return TelemetrySinkConfig(
+        root_dir=Path(sink_dir),
+        flush_every_seconds=float(getattr(args, "telemetry_flush_seconds", 2.0)),
+        rollover_max_bytes=int(getattr(args, "telemetry_rollover_mb", 64))
+        * 1024
+        * 1024,
+        retention_max_files=int(getattr(args, "telemetry_retention_files", 8)),
+        retention_max_total_bytes=int(
+            getattr(args, "telemetry_retention_total_mb", 512)
+        )
+        * 1024
+        * 1024,
+    )
 
 
 def main() -> None:
@@ -273,6 +295,36 @@ Examples:
         type=int,
         default=256,
         help="Maximum retained OOM dump storage in MB (default: 256)",
+    )
+    track_parser.add_argument(
+        "--telemetry-sink-dir",
+        type=str,
+        default=None,
+        help="Directory for append-only telemetry sink segments",
+    )
+    track_parser.add_argument(
+        "--telemetry-flush-seconds",
+        type=float,
+        default=2.0,
+        help="Maximum seconds between telemetry sink flushes (default: 2.0)",
+    )
+    track_parser.add_argument(
+        "--telemetry-rollover-mb",
+        type=int,
+        default=64,
+        help="Telemetry sink segment rollover size in MB (default: 64)",
+    )
+    track_parser.add_argument(
+        "--telemetry-retention-files",
+        type=int,
+        default=8,
+        help="Maximum retained telemetry sink segments (default: 8)",
+    )
+    track_parser.add_argument(
+        "--telemetry-retention-total-mb",
+        type=int,
+        default=512,
+        help="Maximum retained telemetry sink size in MB (default: 512)",
     )
 
     # Analyze command
@@ -631,6 +683,9 @@ def cmd_track(args: argparse.Namespace) -> None:
 
     runtime_backend = str(get_system_info().get("detected_backend", "cpu"))
     gpu_runtime = runtime_backend in {"cuda", "rocm", "mps"}
+    telemetry_sink_config = _build_telemetry_sink_config(args)
+    if telemetry_sink_config is not None:
+        print(f"Append-only telemetry sink: {telemetry_sink_config.root_dir}")
     tracker: Any
     watchdog: Optional[Any] = None
     if gpu_runtime:
@@ -660,6 +715,7 @@ def cmd_track(args: argparse.Namespace) -> None:
             rank=rank,
             local_rank=local_rank,
             world_size=world_size,
+            telemetry_sink_config=telemetry_sink_config,
         )
 
         if args.oom_flight_recorder:
@@ -704,6 +760,7 @@ def cmd_track(args: argparse.Namespace) -> None:
             rank=rank,
             local_rank=local_rank,
             world_size=world_size,
+            telemetry_sink_config=telemetry_sink_config,
         )
         print("Running CPU memory tracker (no GPU backend available).")
 

--- a/stormlog/cpu_profiler.py
+++ b/stormlog/cpu_profiler.py
@@ -21,6 +21,7 @@ from stormlog.telemetry import (
     telemetry_event_from_record,
     telemetry_event_to_dict,
 )
+from stormlog.telemetry_sink import AppendOnlyTelemetrySink, TelemetrySinkConfig
 
 logger = logging.getLogger(__name__)
 
@@ -222,6 +223,7 @@ class CPUMemoryTracker:
         rank: Optional[int] = None,
         local_rank: Optional[int] = None,
         world_size: Optional[int] = None,
+        telemetry_sink_config: Optional[TelemetrySinkConfig] = None,
     ) -> None:
         if sampling_interval <= 0:
             raise ValueError("sampling_interval must be > 0")
@@ -236,6 +238,11 @@ class CPUMemoryTracker:
         self._stop_event = threading.Event()
         self._tracking_thread: Optional[threading.Thread] = None
         self.enable_alerts = enable_alerts
+        self._telemetry_sink = (
+            AppendOnlyTelemetrySink(telemetry_sink_config)
+            if telemetry_sink_config is not None
+            else None
+        )
         self.distributed_identity = resolve_distributed_identity(
             job_id=job_id,
             rank=rank,
@@ -276,6 +283,7 @@ class CPUMemoryTracker:
         if self._tracking_thread:
             self._tracking_thread.join(timeout=1.0)
         self._add_event("stop", 0, "CPU memory tracking stopped")
+        self._close_telemetry_sink()
 
     def _tracking_loop(self) -> None:
         last_rss = self._current_rss()
@@ -316,6 +324,7 @@ class CPUMemoryTracker:
                 )
 
             last_rss = current_rss
+            self._flush_telemetry_sink()
 
     def _add_event(self, event_type: str, memory_change: int, context: str) -> None:
         rss = self._current_rss()
@@ -334,6 +343,50 @@ class CPUMemoryTracker:
         )
         with self._events_lock:
             self.events.append(event)
+        self._append_to_telemetry_sink(event)
+
+    def _telemetry_record_from_event(self, event: TrackingEvent) -> Dict[str, Any]:
+        host = socket.gethostname()
+        pid = os.getpid()
+        sampling_interval_ms = int(round(self.sampling_interval * 1000))
+        return telemetry_event_to_dict(
+            telemetry_event_from_record(
+                {
+                    "timestamp": event.timestamp,
+                    "event_type": event.event_type,
+                    "memory_allocated": event.memory_allocated,
+                    "memory_reserved": event.memory_reserved,
+                    "memory_change": event.memory_change,
+                    "device_id": event.device_id,
+                    "context": event.context,
+                    "job_id": event.job_id,
+                    "rank": event.rank,
+                    "local_rank": event.local_rank,
+                    "world_size": event.world_size,
+                    "collector": "stormlog.cpu_tracker",
+                    "sampling_interval_ms": sampling_interval_ms,
+                    "pid": pid,
+                    "host": host,
+                },
+                default_collector="stormlog.cpu_tracker",
+                default_sampling_interval_ms=sampling_interval_ms,
+            )
+        )
+
+    def _append_to_telemetry_sink(self, event: TrackingEvent) -> None:
+        if self._telemetry_sink is None:
+            return
+        self._telemetry_sink.append(self._telemetry_record_from_event(event))
+
+    def _flush_telemetry_sink(self, *, force: bool = False) -> None:
+        if self._telemetry_sink is None:
+            return
+        self._telemetry_sink.flush(force=force)
+
+    def _close_telemetry_sink(self) -> None:
+        if self._telemetry_sink is None:
+            return
+        self._telemetry_sink.close()
 
     def get_events(
         self,
@@ -411,35 +464,8 @@ class CPUMemoryTracker:
         with self._events_lock:
             events_snapshot = list(self.events)
 
-        host = socket.gethostname()
-        pid = os.getpid()
-        sampling_interval_ms = int(round(self.sampling_interval * 1000))
-
         records = [
-            telemetry_event_to_dict(
-                telemetry_event_from_record(
-                    {
-                        "timestamp": event.timestamp,
-                        "event_type": event.event_type,
-                        "memory_allocated": event.memory_allocated,
-                        "memory_reserved": event.memory_reserved,
-                        "memory_change": event.memory_change,
-                        "device_id": event.device_id,
-                        "context": event.context,
-                        "job_id": event.job_id,
-                        "rank": event.rank,
-                        "local_rank": event.local_rank,
-                        "world_size": event.world_size,
-                        "collector": "stormlog.cpu_tracker",
-                        "sampling_interval_ms": sampling_interval_ms,
-                        "pid": pid,
-                        "host": host,
-                    },
-                    default_collector="stormlog.cpu_tracker",
-                    default_sampling_interval_ms=sampling_interval_ms,
-                )
-            )
-            for event in events_snapshot
+            self._telemetry_record_from_event(event) for event in events_snapshot
         ]
 
         if not records:

--- a/stormlog/cpu_profiler.py
+++ b/stormlog/cpu_profiler.py
@@ -376,17 +376,47 @@ class CPUMemoryTracker:
     def _append_to_telemetry_sink(self, event: TrackingEvent) -> None:
         if self._telemetry_sink is None:
             return
-        self._telemetry_sink.append(self._telemetry_record_from_event(event))
+        try:
+            self._telemetry_sink.append(self._telemetry_record_from_event(event))
+        except Exception as exc:
+            self._disable_telemetry_sink("append", exc)
 
     def _flush_telemetry_sink(self, *, force: bool = False) -> None:
         if self._telemetry_sink is None:
             return
-        self._telemetry_sink.flush(force=force)
+        try:
+            self._telemetry_sink.flush(force=force)
+        except Exception as exc:
+            self._disable_telemetry_sink("flush", exc)
 
     def _close_telemetry_sink(self) -> None:
         if self._telemetry_sink is None:
             return
-        self._telemetry_sink.close()
+        try:
+            self._telemetry_sink.close()
+        except Exception as exc:
+            self._disable_telemetry_sink("close", exc)
+        else:
+            self._telemetry_sink = None
+
+    def _disable_telemetry_sink(self, operation: str, exc: Exception) -> None:
+        sink = self._telemetry_sink
+        if sink is None:
+            return
+        self._telemetry_sink = None
+        logger.warning(
+            "Disabling CPU telemetry sink after %s failure: %s",
+            operation,
+            exc,
+        )
+        try:
+            sink.close()
+        except Exception as close_exc:
+            logger.debug(
+                "CPU telemetry sink close failed after %s error: %s",
+                operation,
+                close_exc,
+            )
 
     def get_events(
         self,

--- a/stormlog/telemetry.py
+++ b/stormlog/telemetry.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal, Mapping, Optional
 
+from .telemetry_sink import resolve_telemetry_sink_segment_paths
+
 SCHEMA_VERSION_V2: Literal[2] = 2
 UNKNOWN_PID = -1
 UNKNOWN_HOST = "unknown"
@@ -758,6 +760,38 @@ def _looks_like_event_record(payload: Mapping[str, Any]) -> bool:
     return any(key in payload for key in candidate_keys)
 
 
+def _load_jsonl_events(
+    path: Path,
+    *,
+    permissive_legacy: bool,
+) -> list[TelemetryEventV2]:
+    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    output: list[TelemetryEventV2] = []
+
+    for index, line in enumerate(lines, start=1):
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            if index == len(lines) and not line.endswith("\n"):
+                break
+            raise ValueError(
+                f"Malformed telemetry JSONL record in {path} at line {index}"
+            ) from exc
+        if not isinstance(payload, Mapping):
+            raise ValueError(
+                f"Telemetry record in {path} at line {index} must be an object"
+            )
+        output.append(
+            telemetry_event_from_record(
+                payload,
+                permissive_legacy=permissive_legacy,
+            )
+        )
+    return output
+
+
 def load_telemetry_events(
     path: str | Path,
     permissive_legacy: bool = True,
@@ -766,6 +800,18 @@ def load_telemetry_events(
     """Load telemetry events from JSON and normalize to v2 payloads."""
 
     payload_path = Path(path)
+    segment_paths = resolve_telemetry_sink_segment_paths(payload_path)
+    if segment_paths:
+        segment_events: list[TelemetryEventV2] = []
+        for segment_path in segment_paths:
+            segment_events.extend(
+                _load_jsonl_events(
+                    segment_path,
+                    permissive_legacy=permissive_legacy,
+                )
+            )
+        return segment_events
+
     with payload_path.open("r", encoding="utf-8") as handle:
         payload = json.load(handle)
 

--- a/stormlog/telemetry_sink.py
+++ b/stormlog/telemetry_sink.py
@@ -213,17 +213,18 @@ class AppendOnlyTelemetrySink:
         return self._handle
 
     def _load_existing_state(self) -> None:
+        discovered = _discover_segment_paths(self.root_dir)
         if self._manifest_path.exists():
             payload = json.loads(self._manifest_path.read_text(encoding="utf-8"))
-            self._segments = [
+            manifest_segments = [
                 _SegmentState(**dict(segment))
                 for segment in payload.get("segments", [])
                 if isinstance(segment, dict)
             ]
+            self._segments = self._merge_segment_state(manifest_segments, discovered)
             self._next_segment_index = self._compute_next_segment_index()
             return
 
-        discovered = sorted(self.root_dir.glob(f"{SEGMENT_PREFIX}*{SEGMENT_SUFFIX}"))
         if not discovered:
             return
 
@@ -283,6 +284,46 @@ class AppendOnlyTelemetrySink:
 
         current.size_bytes = len(payload)
         current.event_count = self._count_records(segment_path)
+
+    def _merge_segment_state(
+        self,
+        manifest_segments: list[_SegmentState],
+        discovered_segments: list[Path],
+    ) -> list[_SegmentState]:
+        manifest_by_name = {
+            segment.filename: _SegmentState(
+                filename=segment.filename,
+                event_count=segment.event_count,
+                size_bytes=segment.size_bytes,
+                closed=segment.closed,
+            )
+            for segment in manifest_segments
+        }
+        discovered_by_name = {path.name: path for path in discovered_segments}
+        merged_names = sorted(set(manifest_by_name) | set(discovered_by_name))
+        merged: list[_SegmentState] = []
+
+        for name in merged_names:
+            manifest_segment = manifest_by_name.get(name)
+            if manifest_segment is not None:
+                merged.append(manifest_segment)
+                continue
+
+            path = discovered_by_name[name]
+            merged.append(
+                _SegmentState(
+                    filename=name,
+                    event_count=self._count_records(path),
+                    size_bytes=path.stat().st_size,
+                    closed=False,
+                )
+            )
+
+        for segment in merged[:-1]:
+            segment.closed = True
+        if merged and merged[-1].filename not in manifest_by_name:
+            merged[-1].closed = False
+        return merged
 
 
 def resolve_telemetry_sink_segment_paths(path: str | Path) -> list[Path]:

--- a/stormlog/telemetry_sink.py
+++ b/stormlog/telemetry_sink.py
@@ -1,0 +1,247 @@
+"""Append-only telemetry sink with rollover and retention bounds."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, TextIO
+
+MANIFEST_FILENAME = "manifest.json"
+SEGMENT_PREFIX = "segment-"
+SEGMENT_SUFFIX = ".jsonl"
+SINK_SCHEMA_VERSION = 1
+
+
+@dataclass
+class TelemetrySinkConfig:
+    """Runtime policy for append-only telemetry persistence."""
+
+    root_dir: Path
+    flush_every_events: int = 50
+    flush_every_seconds: float = 2.0
+    rollover_max_bytes: int = 64 * 1024 * 1024
+    rollover_max_events: int = 10000
+    retention_max_files: int = 8
+    retention_max_total_bytes: int = 512 * 1024 * 1024
+
+    def __post_init__(self) -> None:
+        self.root_dir = Path(self.root_dir)
+        if self.flush_every_events <= 0:
+            raise ValueError("flush_every_events must be >= 1")
+        if self.flush_every_seconds <= 0:
+            raise ValueError("flush_every_seconds must be > 0")
+        if self.rollover_max_bytes <= 0:
+            raise ValueError("rollover_max_bytes must be >= 1")
+        if self.rollover_max_events <= 0:
+            raise ValueError("rollover_max_events must be >= 1")
+        if self.retention_max_files <= 0:
+            raise ValueError("retention_max_files must be >= 1")
+        if self.retention_max_total_bytes <= 0:
+            raise ValueError("retention_max_total_bytes must be >= 1")
+        if self.retention_max_total_bytes < self.rollover_max_bytes:
+            raise ValueError("retention_max_total_bytes must be >= rollover_max_bytes")
+
+
+@dataclass
+class _SegmentState:
+    filename: str
+    event_count: int
+    size_bytes: int
+    closed: bool
+
+
+class AppendOnlyTelemetrySink:
+    """Write telemetry records to newline-delimited JSON segments."""
+
+    def __init__(self, config: TelemetrySinkConfig) -> None:
+        self.config = config
+        self.root_dir = config.root_dir
+        self.root_dir.mkdir(parents=True, exist_ok=True)
+        self._manifest_path = self.root_dir / MANIFEST_FILENAME
+        self._segments: list[_SegmentState] = []
+        self._next_segment_index = 1
+        self._buffer: list[str] = []
+        self._buffered_event_count = 0
+        self._handle: TextIO | None = None
+        self._lock = threading.Lock()
+        self._last_flush_monotonic = time.monotonic()
+        self._closed = False
+        self._load_existing_state()
+
+    def append(self, record: Mapping[str, Any]) -> None:
+        with self._lock:
+            self._closed = False
+            self._buffer.append(json.dumps(dict(record), sort_keys=True) + "\n")
+            self._buffered_event_count += 1
+            self._flush_locked(force=False)
+
+    def flush(self, force: bool = False) -> None:
+        with self._lock:
+            self._flush_locked(force=force)
+
+    def close(self) -> None:
+        with self._lock:
+            self._flush_locked(force=True)
+            if self._handle is not None:
+                self._handle.close()
+                self._handle = None
+            current = self._current_segment()
+            if current is not None and not current.closed:
+                current.closed = True
+                self._write_manifest_locked()
+            self._closed = True
+
+    def _flush_locked(self, force: bool) -> None:
+        if not self._buffer:
+            return
+
+        now = time.monotonic()
+        if not force:
+            if self._buffered_event_count < self.config.flush_every_events and (
+                now - self._last_flush_monotonic < self.config.flush_every_seconds
+            ):
+                return
+
+        current = self._ensure_current_segment_locked()
+        payload = "".join(self._buffer)
+        payload_bytes = payload.encode("utf-8")
+        handle = self._ensure_handle_locked(current)
+        handle.write(payload)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+        current.event_count += self._buffered_event_count
+        current.size_bytes += len(payload_bytes)
+        self._buffer.clear()
+        self._buffered_event_count = 0
+        self._last_flush_monotonic = now
+
+        self._rollover_locked(current)
+        self._prune_retention_locked()
+        self._write_manifest_locked()
+
+    def _rollover_locked(self, current: _SegmentState) -> None:
+        if (
+            current.event_count < self.config.rollover_max_events
+            and current.size_bytes < self.config.rollover_max_bytes
+        ):
+            return
+        current.closed = True
+        if self._handle is not None:
+            self._handle.close()
+            self._handle = None
+
+    def _prune_retention_locked(self) -> None:
+        while True:
+            total_bytes = sum(segment.size_bytes for segment in self._segments)
+            over_file_limit = len(self._segments) > self.config.retention_max_files
+            over_size_limit = total_bytes > self.config.retention_max_total_bytes
+            if not over_file_limit and not over_size_limit:
+                return
+
+            removable = next(
+                (segment for segment in self._segments if segment.closed), None
+            )
+            if removable is None:
+                return
+
+            path = self.root_dir / removable.filename
+            if path.exists():
+                path.unlink()
+            self._segments.remove(removable)
+
+    def _current_segment(self) -> _SegmentState | None:
+        if not self._segments:
+            return None
+        current = self._segments[-1]
+        if current.closed:
+            return None
+        return current
+
+    def _ensure_current_segment_locked(self) -> _SegmentState:
+        current = self._current_segment()
+        if current is not None:
+            return current
+
+        segment = _SegmentState(
+            filename=f"{SEGMENT_PREFIX}{self._next_segment_index:06d}{SEGMENT_SUFFIX}",
+            event_count=0,
+            size_bytes=0,
+            closed=False,
+        )
+        self._next_segment_index += 1
+        self._segments.append(segment)
+        return segment
+
+    def _ensure_handle_locked(self, current: _SegmentState) -> TextIO:
+        if self._handle is None:
+            segment_path = self.root_dir / current.filename
+            self._handle = segment_path.open("a", encoding="utf-8")
+        return self._handle
+
+    def _load_existing_state(self) -> None:
+        if self._manifest_path.exists():
+            payload = json.loads(self._manifest_path.read_text(encoding="utf-8"))
+            self._segments = [
+                _SegmentState(**dict(segment))
+                for segment in payload.get("segments", [])
+                if isinstance(segment, dict)
+            ]
+            self._next_segment_index = self._compute_next_segment_index()
+            return
+
+        discovered = sorted(self.root_dir.glob(f"{SEGMENT_PREFIX}*{SEGMENT_SUFFIX}"))
+        if not discovered:
+            return
+
+        for index, path in enumerate(discovered):
+            self._segments.append(
+                _SegmentState(
+                    filename=path.name,
+                    event_count=self._count_records(path),
+                    size_bytes=path.stat().st_size,
+                    closed=index < len(discovered) - 1,
+                )
+            )
+        self._next_segment_index = self._compute_next_segment_index()
+        self._write_manifest_locked()
+
+    def _compute_next_segment_index(self) -> int:
+        max_index = 0
+        for segment in self._segments:
+            stem = Path(segment.filename).stem
+            if not stem.startswith(SEGMENT_PREFIX):
+                continue
+            suffix = stem[len(SEGMENT_PREFIX) :]
+            if suffix.isdigit():
+                max_index = max(max_index, int(suffix))
+        return max_index + 1
+
+    def _write_manifest_locked(self) -> None:
+        payload = {
+            "schema_version": SINK_SCHEMA_VERSION,
+            "format": "stormlog.append_only_telemetry_sink",
+            "segments": [asdict(segment) for segment in self._segments],
+        }
+        temp_path = self._manifest_path.with_suffix(".tmp")
+        temp_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        temp_path.replace(self._manifest_path)
+
+    @staticmethod
+    def _count_records(path: Path) -> int:
+        with path.open("r", encoding="utf-8") as handle:
+            return sum(1 for line in handle if line.strip())
+
+
+__all__ = [
+    "AppendOnlyTelemetrySink",
+    "MANIFEST_FILENAME",
+    "SEGMENT_PREFIX",
+    "SEGMENT_SUFFIX",
+    "SINK_SCHEMA_VERSION",
+    "TelemetrySinkConfig",
+]

--- a/stormlog/telemetry_sink.py
+++ b/stormlog/telemetry_sink.py
@@ -237,6 +237,48 @@ class AppendOnlyTelemetrySink:
             return sum(1 for line in handle if line.strip())
 
 
+def resolve_telemetry_sink_segment_paths(path: str | Path) -> list[Path]:
+    """Resolve append-only sink inputs to ordered JSONL segment paths."""
+    resolved_path = Path(path)
+    if resolved_path.is_file():
+        if resolved_path.suffix == SEGMENT_SUFFIX:
+            return [resolved_path]
+        if resolved_path.name == MANIFEST_FILENAME:
+            return _segment_paths_from_manifest(resolved_path)
+        return []
+
+    if not resolved_path.is_dir():
+        return []
+
+    manifest_path = resolved_path / MANIFEST_FILENAME
+    manifest_segments = _segment_paths_from_manifest(manifest_path)
+    if manifest_segments:
+        return manifest_segments
+    return sorted(resolved_path.glob(f"{SEGMENT_PREFIX}*{SEGMENT_SUFFIX}"))
+
+
+def _segment_paths_from_manifest(manifest_path: Path) -> list[Path]:
+    if not manifest_path.exists():
+        return []
+
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+
+    root_dir = manifest_path.parent
+    segments = []
+    for segment in payload.get("segments", []):
+        if not isinstance(segment, dict):
+            continue
+        filename = segment.get("filename")
+        if isinstance(filename, str):
+            candidate = root_dir / filename
+            if candidate.exists():
+                segments.append(candidate)
+    return segments
+
+
 __all__ = [
     "AppendOnlyTelemetrySink",
     "MANIFEST_FILENAME",
@@ -244,4 +286,5 @@ __all__ = [
     "SEGMENT_SUFFIX",
     "SINK_SCHEMA_VERSION",
     "TelemetrySinkConfig",
+    "resolve_telemetry_sink_segment_paths",
 ]

--- a/stormlog/telemetry_sink.py
+++ b/stormlog/telemetry_sink.py
@@ -68,12 +68,15 @@ class AppendOnlyTelemetrySink:
         self._buffered_event_count = 0
         self._handle: TextIO | None = None
         self._lock = threading.Lock()
+        self._flush_stop_event = threading.Event()
+        self._flush_thread: threading.Thread | None = None
         self._last_flush_monotonic = time.monotonic()
         self._closed = False
         self._load_existing_state()
 
     def append(self, record: Mapping[str, Any]) -> None:
         with self._lock:
+            self._ensure_flush_thread_locked()
             self._closed = False
             self._buffer.append(json.dumps(dict(record), sort_keys=True) + "\n")
             self._buffered_event_count += 1
@@ -94,6 +97,7 @@ class AppendOnlyTelemetrySink:
                 current.closed = True
                 self._write_manifest_locked()
             self._closed = True
+        self._stop_flush_thread()
 
     def _flush_locked(self, force: bool) -> None:
         if not self._buffer:
@@ -161,6 +165,30 @@ class AppendOnlyTelemetrySink:
         if current.closed:
             return None
         return current
+
+    def _ensure_flush_thread_locked(self) -> None:
+        if self._flush_thread is not None and self._flush_thread.is_alive():
+            return
+        self._flush_stop_event = threading.Event()
+        self._flush_thread = threading.Thread(
+            target=self._run_flush_loop,
+            name="stormlog-telemetry-sink-flush",
+            daemon=True,
+        )
+        self._flush_thread.start()
+
+    def _stop_flush_thread(self) -> None:
+        thread = self._flush_thread
+        if thread is None:
+            return
+        self._flush_stop_event.set()
+        thread.join(timeout=self.config.flush_every_seconds + 1.0)
+        self._flush_thread = None
+
+    def _run_flush_loop(self) -> None:
+        while not self._flush_stop_event.wait(timeout=self.config.flush_every_seconds):
+            with self._lock:
+                self._flush_locked(force=False)
 
     def _ensure_current_segment_locked(self) -> _SegmentState:
         current = self._current_segment()

--- a/stormlog/telemetry_sink.py
+++ b/stormlog/telemetry_sink.py
@@ -180,6 +180,7 @@ class AppendOnlyTelemetrySink:
     def _ensure_handle_locked(self, current: _SegmentState) -> TextIO:
         if self._handle is None:
             segment_path = self.root_dir / current.filename
+            self._recover_segment_tail_locked(segment_path, current)
             self._handle = segment_path.open("a", encoding="utf-8")
         return self._handle
 
@@ -235,6 +236,25 @@ class AppendOnlyTelemetrySink:
     def _count_records(path: Path) -> int:
         with path.open("r", encoding="utf-8") as handle:
             return sum(1 for line in handle if line.strip())
+
+    def _recover_segment_tail_locked(
+        self,
+        segment_path: Path,
+        current: _SegmentState,
+    ) -> None:
+        if not segment_path.exists():
+            current.event_count = 0
+            current.size_bytes = 0
+            return
+
+        payload = segment_path.read_bytes()
+        if payload and not payload.endswith(b"\n"):
+            last_newline = payload.rfind(b"\n")
+            payload = payload[: last_newline + 1] if last_newline >= 0 else b""
+            segment_path.write_bytes(payload)
+
+        current.size_bytes = len(payload)
+        current.event_count = self._count_records(segment_path)
 
 
 def resolve_telemetry_sink_segment_paths(path: str | Path) -> list[Path]:

--- a/stormlog/telemetry_sink.py
+++ b/stormlog/telemetry_sink.py
@@ -244,7 +244,10 @@ def resolve_telemetry_sink_segment_paths(path: str | Path) -> list[Path]:
         if resolved_path.suffix == SEGMENT_SUFFIX:
             return [resolved_path]
         if resolved_path.name == MANIFEST_FILENAME:
-            return _segment_paths_from_manifest(resolved_path)
+            return _merge_segment_paths(
+                _segment_paths_from_manifest(resolved_path),
+                _discover_segment_paths(resolved_path.parent),
+            )
         return []
 
     if not resolved_path.is_dir():
@@ -253,8 +256,25 @@ def resolve_telemetry_sink_segment_paths(path: str | Path) -> list[Path]:
     manifest_path = resolved_path / MANIFEST_FILENAME
     manifest_segments = _segment_paths_from_manifest(manifest_path)
     if manifest_segments:
-        return manifest_segments
-    return sorted(resolved_path.glob(f"{SEGMENT_PREFIX}*{SEGMENT_SUFFIX}"))
+        return _merge_segment_paths(
+            manifest_segments,
+            _discover_segment_paths(resolved_path),
+        )
+    return _discover_segment_paths(resolved_path)
+
+
+def _discover_segment_paths(root_dir: Path) -> list[Path]:
+    return sorted(root_dir.glob(f"{SEGMENT_PREFIX}*{SEGMENT_SUFFIX}"))
+
+
+def _merge_segment_paths(
+    manifest_segments: list[Path],
+    discovered_segments: list[Path],
+) -> list[Path]:
+    merged_by_name = {path.name: path for path in discovered_segments}
+    for path in manifest_segments:
+        merged_by_name[path.name] = path
+    return [merged_by_name[name] for name in sorted(merged_by_name)]
 
 
 def _segment_paths_from_manifest(manifest_path: Path) -> list[Path]:

--- a/stormlog/tensorflow/cli.py
+++ b/stormlog/tensorflow/cli.py
@@ -21,6 +21,7 @@ except ImportError:
     tf = None
 
 from stormlog.telemetry import telemetry_event_from_record, telemetry_event_to_dict
+from stormlog.telemetry_sink import TelemetrySinkConfig
 
 from .analyzer import MemoryAnalyzer
 from .diagnose import run_diagnose
@@ -51,6 +52,27 @@ def _normalize_telemetry_events(
         )
         normalized.append(telemetry_event_to_dict(event))
     return normalized
+
+
+def _build_telemetry_sink_config(
+    args: argparse.Namespace,
+) -> TelemetrySinkConfig | None:
+    sink_dir = getattr(args, "telemetry_sink_dir", None)
+    if not sink_dir:
+        return None
+    return TelemetrySinkConfig(
+        root_dir=Path(sink_dir),
+        flush_every_seconds=float(getattr(args, "telemetry_flush_seconds", 2.0)),
+        rollover_max_bytes=int(getattr(args, "telemetry_rollover_mb", 64))
+        * 1024
+        * 1024,
+        retention_max_files=int(getattr(args, "telemetry_retention_files", 8)),
+        retention_max_total_bytes=int(
+            getattr(args, "telemetry_retention_total_mb", 512)
+        )
+        * 1024
+        * 1024,
+    )
 
 
 def cmd_info(args: argparse.Namespace) -> int:
@@ -220,6 +242,7 @@ def cmd_track(args: argparse.Namespace) -> int:
     rank = getattr(args, "rank", None)
     local_rank = getattr(args, "local_rank", None)
     world_size = getattr(args, "world_size", None)
+    telemetry_sink_config = _build_telemetry_sink_config(args)
 
     tracker = MemoryTracker(
         sampling_interval=args.interval,
@@ -230,7 +253,10 @@ def cmd_track(args: argparse.Namespace) -> int:
         rank=rank,
         local_rank=local_rank,
         world_size=world_size,
+        telemetry_sink_config=telemetry_sink_config,
     )
+    if telemetry_sink_config is not None:
+        print(f"Append-only telemetry sink: {telemetry_sink_config.root_dir}")
 
     # Add alert callback
     def alert_callback(alert: Dict[str, Any]) -> None:
@@ -587,6 +613,35 @@ def main() -> int:
     )
     track_parser.add_argument(
         "--output", required=True, help="Output file for tracking results"
+    )
+    track_parser.add_argument(
+        "--telemetry-sink-dir",
+        default=None,
+        help="Directory for append-only telemetry sink segments",
+    )
+    track_parser.add_argument(
+        "--telemetry-flush-seconds",
+        type=float,
+        default=2.0,
+        help="Maximum seconds between telemetry sink flushes (default: 2.0)",
+    )
+    track_parser.add_argument(
+        "--telemetry-rollover-mb",
+        type=int,
+        default=64,
+        help="Telemetry sink segment rollover size in MB (default: 64)",
+    )
+    track_parser.add_argument(
+        "--telemetry-retention-files",
+        type=int,
+        default=8,
+        help="Maximum retained telemetry sink segments (default: 8)",
+    )
+    track_parser.add_argument(
+        "--telemetry-retention-total-mb",
+        type=int,
+        default=512,
+        help="Maximum retained telemetry sink size in MB (default: 512)",
     )
 
     # Analyze command

--- a/stormlog/tensorflow/tracker.py
+++ b/stormlog/tensorflow/tracker.py
@@ -529,17 +529,47 @@ class MemoryTracker:
     def _append_to_telemetry_sink(self, record: Dict[str, Any]) -> None:
         if self._telemetry_sink is None:
             return
-        self._telemetry_sink.append(record)
+        try:
+            self._telemetry_sink.append(record)
+        except Exception as exc:
+            self._disable_telemetry_sink("append", exc)
 
     def _flush_telemetry_sink(self, *, force: bool = False) -> None:
         if self._telemetry_sink is None:
             return
-        self._telemetry_sink.flush(force=force)
+        try:
+            self._telemetry_sink.flush(force=force)
+        except Exception as exc:
+            self._disable_telemetry_sink("flush", exc)
 
     def _close_telemetry_sink(self) -> None:
         if self._telemetry_sink is None:
             return
-        self._telemetry_sink.close()
+        try:
+            self._telemetry_sink.close()
+        except Exception as exc:
+            self._disable_telemetry_sink("close", exc)
+        else:
+            self._telemetry_sink = None
+
+    def _disable_telemetry_sink(self, operation: str, exc: Exception) -> None:
+        sink = self._telemetry_sink
+        if sink is None:
+            return
+        self._telemetry_sink = None
+        logging.warning(
+            "Disabling TensorFlow telemetry sink after %s failure: %s",
+            operation,
+            exc,
+        )
+        try:
+            sink.close()
+        except Exception as close_exc:
+            logging.debug(
+                "TensorFlow telemetry sink close failed after %s error: %s",
+                operation,
+                close_exc,
+            )
 
     def set_alert_threshold(self, threshold_mb: float) -> None:
         """Update alert threshold."""

--- a/stormlog/tensorflow/tracker.py
+++ b/stormlog/tensorflow/tracker.py
@@ -36,6 +36,7 @@ from stormlog.telemetry import (
     telemetry_event_from_record,
     telemetry_event_to_dict,
 )
+from stormlog.telemetry_sink import AppendOnlyTelemetrySink, TelemetrySinkConfig
 
 
 @dataclass
@@ -78,6 +79,7 @@ class MemoryTracker:
         rank: Optional[int] = None,
         local_rank: Optional[int] = None,
         world_size: Optional[int] = None,
+        telemetry_sink_config: Optional[TelemetrySinkConfig] = None,
     ):
         """
         Initialize memory tracker.
@@ -97,6 +99,11 @@ class MemoryTracker:
         self.alert_threshold_mb = alert_threshold_mb
         self.device = device or self._get_default_device()
         self.enable_logging = enable_logging
+        self._telemetry_sink = (
+            AppendOnlyTelemetrySink(telemetry_sink_config)
+            if telemetry_sink_config is not None
+            else None
+        )
         self.distributed_identity = resolve_distributed_identity(
             job_id=job_id,
             rank=rank,
@@ -241,16 +248,16 @@ class MemoryTracker:
         context: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
+        record = self._build_telemetry_event_record(
+            timestamp=timestamp,
+            memory_mb=memory_mb,
+            event_type=event_type,
+            context=context,
+            metadata=metadata,
+        )
         with self._lock:
-            self.events.append(
-                self._build_telemetry_event_record(
-                    timestamp=timestamp,
-                    memory_mb=memory_mb,
-                    event_type=event_type,
-                    context=context,
-                    metadata=metadata,
-                )
-            )
+            self.events.append(record)
+        self._append_to_telemetry_sink(record)
 
     def _transition_to_failure(self, timestamp: float, exc: BaseException) -> None:
         previous_health = self._collector_health
@@ -331,13 +338,11 @@ class MemoryTracker:
         with self._lock:
             self.memory_usage.append(current_memory)
             self.timestamps.append(current_time)
-            self.events.append(
-                self._build_telemetry_event_record(
-                    timestamp=current_time,
-                    memory_mb=current_memory,
-                    event_type="sample",
-                )
-            )
+        self._append_event(
+            timestamp=current_time,
+            memory_mb=current_memory,
+            event_type="sample",
+        )
 
         if self.alert_threshold_mb and current_memory > self.alert_threshold_mb:
             self._trigger_alert(current_memory, current_time)
@@ -347,10 +352,12 @@ class MemoryTracker:
         while not self._stop_event.is_set():
             try:
                 self._run_tracking_iteration()
+                self._flush_telemetry_sink()
                 self._stop_event.wait(self.sampling_interval)
             except Exception as e:
                 if self.enable_logging:
                     logging.error(f"Error in tracking loop: {e}")
+                self._flush_telemetry_sink(force=True)
                 self._stop_event.wait(self.sampling_interval)
 
     def _trigger_alert(self, memory_mb: float, timestamp: float) -> None:
@@ -429,6 +436,7 @@ class MemoryTracker:
             self.tracking_thread.join(timeout=5.0)
 
         self._session_end_time = time.time()
+        self._close_telemetry_sink()
         # Create result
         result = self._create_tracking_result()
 
@@ -517,6 +525,21 @@ class MemoryTracker:
             "tracking_duration_seconds": tracking_duration,
             **self._collector_health.to_dict(),
         }
+
+    def _append_to_telemetry_sink(self, record: Dict[str, Any]) -> None:
+        if self._telemetry_sink is None:
+            return
+        self._telemetry_sink.append(record)
+
+    def _flush_telemetry_sink(self, *, force: bool = False) -> None:
+        if self._telemetry_sink is None:
+            return
+        self._telemetry_sink.flush(force=force)
+
+    def _close_telemetry_sink(self) -> None:
+        if self._telemetry_sink is None:
+            return
+        self._telemetry_sink.close()
 
     def set_alert_threshold(self, threshold_mb: float) -> None:
         """Update alert threshold."""

--- a/stormlog/tracker.py
+++ b/stormlog/tracker.py
@@ -45,6 +45,7 @@ from .telemetry import (
     telemetry_event_from_record,
     telemetry_event_to_dict,
 )
+from .telemetry_sink import AppendOnlyTelemetrySink, TelemetrySinkConfig
 from .utils import format_bytes, get_gpu_info
 
 logger = logging.getLogger(__name__)
@@ -94,6 +95,7 @@ class MemoryTracker:
         world_size: Optional[int] = None,
         enable_native_cuda_history: bool = False,
         native_history_max_entries: int = DEFAULT_TRACE_ALLOC_MAX_ENTRIES,
+        telemetry_sink_config: Optional[TelemetrySinkConfig] = None,
     ):
         """
         Initialize the memory tracker.
@@ -125,6 +127,11 @@ class MemoryTracker:
         self.enable_alerts = enable_alerts
         self.enable_native_cuda_history = enable_native_cuda_history
         self.native_history_max_entries = native_history_max_entries
+        self._telemetry_sink = (
+            AppendOnlyTelemetrySink(telemetry_sink_config)
+            if telemetry_sink_config is not None
+            else None
+        )
         self.last_oom_dump_path: Optional[str] = None
         self.distributed_identity = resolve_distributed_identity(
             job_id=job_id,
@@ -509,6 +516,7 @@ class MemoryTracker:
 
         # Add final event
         self._add_event("stop", 0, "Memory tracking stopped")
+        self._close_telemetry_sink()
 
     def _tracking_loop(self) -> None:
         """Main tracking loop running in background thread."""
@@ -517,8 +525,10 @@ class MemoryTracker:
         while not self._stop_event.wait(self.sampling_interval):
             try:
                 last_allocated = self._run_tracking_iteration(last_allocated)
+                self._flush_telemetry_sink()
             except Exception as exc:
                 self._add_event("error", 0, f"Tracking error: {str(exc)}")
+                self._flush_telemetry_sink(force=True)
                 time.sleep(1.0)  # Back off on unexpected tracker logic errors
 
     def _add_event(
@@ -559,6 +569,7 @@ class MemoryTracker:
 
         self.events.append(event)
         self._oom_flight_recorder.record_event(self._tracking_event_payload(event))
+        self._append_to_telemetry_sink(event)
 
         # Trigger callbacks for alerts
         if event_type in ["warning", "critical", "error"]:
@@ -656,6 +667,86 @@ class MemoryTracker:
             "device_total": event.device_total,
             "backend": event.backend,
         }
+
+    def _telemetry_record_from_event(self, event: TrackingEvent) -> Dict[str, Any]:
+        host = socket.gethostname()
+        pid = os.getpid()
+        sampling_interval_ms = int(round(self.sampling_interval * 1000))
+        default_collector = str(
+            self.collector_capabilities.get(
+                "telemetry_collector", "stormlog.cuda_tracker"
+            )
+        )
+        capability_metadata = {
+            "backend": self.backend,
+            "supports_device_total": bool(
+                self.collector_capabilities.get("supports_device_total", False)
+            ),
+            "supports_device_free": bool(
+                self.collector_capabilities.get("supports_device_free", False)
+            ),
+            "sampling_source": str(
+                self.collector_capabilities.get("sampling_source", "unknown")
+            ),
+        }
+        metadata = dict(event.metadata or {})
+        metadata.update(capability_metadata)
+        partial_fields = set(metadata.get("collector_partial_fields", []) or [])
+        device_used = event.device_used
+        if device_used is None:
+            device_used = max(event.memory_allocated, event.memory_reserved)
+        event_total = event.device_total
+        if (
+            event_total is None
+            and "device_total_bytes" not in partial_fields
+            and self.total_memory
+        ):
+            event_total = self.total_memory
+        legacy = {
+            "timestamp": event.timestamp,
+            "event_type": event.event_type,
+            "memory_allocated": event.memory_allocated,
+            "memory_reserved": event.memory_reserved,
+            "memory_change": event.memory_change,
+            "allocator_active_bytes": event.active_memory,
+            "allocator_inactive_bytes": event.inactive_memory,
+            "device_used_bytes": device_used,
+            "device_free_bytes": event.device_free,
+            "device_total_bytes": event_total,
+            "device_id": event.device_id,
+            "context": event.context,
+            "job_id": event.job_id,
+            "rank": event.rank,
+            "local_rank": event.local_rank,
+            "world_size": event.world_size,
+            "metadata": metadata,
+            "total_memory": event_total,
+            "pid": pid,
+            "host": host,
+            "collector": default_collector,
+            "sampling_interval_ms": sampling_interval_ms,
+        }
+        telemetry_event = telemetry_event_from_record(
+            legacy,
+            default_collector=default_collector,
+            default_sampling_interval_ms=sampling_interval_ms,
+        )
+        return telemetry_event_to_dict(telemetry_event)
+
+    def _append_to_telemetry_sink(self, event: TrackingEvent) -> None:
+        if self._telemetry_sink is None:
+            return
+        self._telemetry_sink.append(self._telemetry_record_from_event(event))
+
+    def _flush_telemetry_sink(self, *, force: bool = False) -> None:
+        if self._telemetry_sink is None:
+            return
+        self._telemetry_sink.flush(force=force)
+
+    def _close_telemetry_sink(self) -> None:
+        if self._telemetry_sink is None:
+            return
+        self._telemetry_sink.close()
 
     def handle_exception(
         self,
@@ -962,73 +1053,8 @@ class MemoryTracker:
         if not self.events:
             return
 
-        host = socket.gethostname()
-        pid = os.getpid()
-        sampling_interval_ms = int(round(self.sampling_interval * 1000))
-        default_collector = str(
-            self.collector_capabilities.get(
-                "telemetry_collector", "stormlog.cuda_tracker"
-            )
-        )
-        capability_metadata = {
-            "backend": self.backend,
-            "supports_device_total": bool(
-                self.collector_capabilities.get("supports_device_total", False)
-            ),
-            "supports_device_free": bool(
-                self.collector_capabilities.get("supports_device_free", False)
-            ),
-            "sampling_source": str(
-                self.collector_capabilities.get("sampling_source", "unknown")
-            ),
-        }
-
         # Convert events to canonical telemetry records.
-        records = []
-        for event in self.events:
-            metadata = dict(event.metadata or {})
-            metadata.update(capability_metadata)
-            partial_fields = set(metadata.get("collector_partial_fields", []) or [])
-            device_used = event.device_used
-            if device_used is None:
-                device_used = max(event.memory_allocated, event.memory_reserved)
-            event_total = event.device_total
-            if (
-                event_total is None
-                and "device_total_bytes" not in partial_fields
-                and self.total_memory
-            ):
-                event_total = self.total_memory
-            legacy = {
-                "timestamp": event.timestamp,
-                "event_type": event.event_type,
-                "memory_allocated": event.memory_allocated,
-                "memory_reserved": event.memory_reserved,
-                "memory_change": event.memory_change,
-                "allocator_active_bytes": event.active_memory,
-                "allocator_inactive_bytes": event.inactive_memory,
-                "device_used_bytes": device_used,
-                "device_free_bytes": event.device_free,
-                "device_total_bytes": event_total,
-                "device_id": event.device_id,
-                "context": event.context,
-                "job_id": event.job_id,
-                "rank": event.rank,
-                "local_rank": event.local_rank,
-                "world_size": event.world_size,
-                "metadata": metadata,
-                "total_memory": event_total,
-                "pid": pid,
-                "host": host,
-                "collector": default_collector,
-                "sampling_interval_ms": sampling_interval_ms,
-            }
-            telemetry_event = telemetry_event_from_record(
-                legacy,
-                default_collector=default_collector,
-                default_sampling_interval_ms=sampling_interval_ms,
-            )
-            records.append(telemetry_event_to_dict(telemetry_event))
+        records = [self._telemetry_record_from_event(event) for event in self.events]
 
         if format == "csv":
             df = pd.DataFrame(records)

--- a/stormlog/tracker.py
+++ b/stormlog/tracker.py
@@ -736,17 +736,45 @@ class MemoryTracker:
     def _append_to_telemetry_sink(self, event: TrackingEvent) -> None:
         if self._telemetry_sink is None:
             return
-        self._telemetry_sink.append(self._telemetry_record_from_event(event))
+        try:
+            self._telemetry_sink.append(self._telemetry_record_from_event(event))
+        except Exception as exc:
+            self._disable_telemetry_sink("append", exc)
 
     def _flush_telemetry_sink(self, *, force: bool = False) -> None:
         if self._telemetry_sink is None:
             return
-        self._telemetry_sink.flush(force=force)
+        try:
+            self._telemetry_sink.flush(force=force)
+        except Exception as exc:
+            self._disable_telemetry_sink("flush", exc)
 
     def _close_telemetry_sink(self) -> None:
         if self._telemetry_sink is None:
             return
-        self._telemetry_sink.close()
+        try:
+            self._telemetry_sink.close()
+        except Exception as exc:
+            self._disable_telemetry_sink("close", exc)
+        else:
+            self._telemetry_sink = None
+
+    def _disable_telemetry_sink(self, operation: str, exc: Exception) -> None:
+        sink = self._telemetry_sink
+        if sink is None:
+            return
+        self._telemetry_sink = None
+        logger.warning(
+            "Disabling telemetry sink after %s failure: %s",
+            operation,
+            exc,
+        )
+        try:
+            sink.close()
+        except Exception as close_exc:
+            logger.debug(
+                "Telemetry sink close failed after %s error: %s", operation, close_exc
+            )
 
     def handle_exception(
         self,

--- a/stormlog/tui/monitor.py
+++ b/stormlog/tui/monitor.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, cast
 
 from stormlog.telemetry import TelemetryEventV2, telemetry_event_from_record
+from stormlog.telemetry_sink import TelemetrySinkConfig
 
 from ..utils import format_bytes
 
@@ -70,6 +71,7 @@ class TrackerSession:
         auto_cleanup: bool = False,
         max_events_per_poll: int = 50,
         max_events: int = 10_000,
+        telemetry_sink_config: Optional[TelemetrySinkConfig] = None,
     ) -> None:
         # Defensive check: ensure at least one tracker is available
         # (In normal operation, imports are required and will raise ImportError if missing.
@@ -83,6 +85,7 @@ class TrackerSession:
         self.auto_cleanup = auto_cleanup
         self.max_events_per_poll = max_events_per_poll
         self.max_events = max_events
+        self.telemetry_sink_config = telemetry_sink_config
         self._tracker: Optional[Any] = None
         self._watchdog: Optional[Any] = None
         self._last_seen_ts: Optional[float] = None
@@ -103,6 +106,7 @@ class TrackerSession:
 
         tracker_kwargs.setdefault("sampling_interval", self.sampling_interval)
         tracker_kwargs.setdefault("enable_alerts", True)
+        tracker_kwargs.setdefault("telemetry_sink_config", self.telemetry_sink_config)
 
         tracker: Optional[Any] = None
         backend = "gpu"
@@ -126,6 +130,7 @@ class TrackerSession:
                 sampling_interval=tracker_kwargs["sampling_interval"],
                 max_events=self.max_events,
                 enable_alerts=tracker_kwargs.get("enable_alerts", True),
+                telemetry_sink_config=tracker_kwargs.get("telemetry_sink_config"),
             )
 
         if tracker is None:

--- a/tests/test_cli_analyze.py
+++ b/tests/test_cli_analyze.py
@@ -13,6 +13,7 @@ import pytest
 import stormlog.cli as gpumemprof_cli
 from stormlog.cli import cmd_analyze
 from stormlog.telemetry import telemetry_event_to_dict
+from stormlog.telemetry_sink import AppendOnlyTelemetrySink, TelemetrySinkConfig
 from tests.gap_test_helpers import BASE_NS, INTERVAL_NS, build_gap_event
 
 matplotlib.use("Agg")
@@ -133,6 +134,36 @@ def test_cmd_analyze_non_telemetry_array_falls_back_gracefully(
     assert "Analyzing profiling results from:" in stdout
     assert "Notes: JSON payload does not contain telemetry events" in stdout
     assert "Error parsing telemetry events" not in stdout
+
+
+def test_cmd_analyze_reads_append_only_sink_directory(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    sink = AppendOnlyTelemetrySink(
+        TelemetrySinkConfig(
+            root_dir=tmp_path / "sink",
+            flush_every_events=1,
+            flush_every_seconds=1.0,
+        )
+    )
+    for event in _build_cross_rank_events():
+        sink.append(telemetry_event_to_dict(event))
+    sink.close()
+
+    exit_code = cmd_analyze(
+        argparse.Namespace(
+            input_file=str(tmp_path / "sink"),
+            output=None,
+            format="json",
+            visualization=False,
+            plot_dir=str(tmp_path / "plots"),
+        )
+    )
+
+    assert exit_code == 0
+    stdout = capsys.readouterr().out
+    assert "Distributed Analysis:" in stdout
+    assert "Top first-cause suspect: rank 2" in stdout
 
 
 def test_cmd_analyze_missing_input_returns_failure(

--- a/tests/test_cli_oom_flight_recorder.py
+++ b/tests/test_cli_oom_flight_recorder.py
@@ -42,6 +42,16 @@ def test_main_parses_oom_track_flags(monkeypatch: pytest.MonkeyPatch) -> None:
             "0",
             "--world-size",
             "8",
+            "--telemetry-sink-dir",
+            "telemetry_sink",
+            "--telemetry-flush-seconds",
+            "3.5",
+            "--telemetry-rollover-mb",
+            "32",
+            "--telemetry-retention-files",
+            "4",
+            "--telemetry-retention-total-mb",
+            "128",
         ],
     )
 
@@ -57,6 +67,11 @@ def test_main_parses_oom_track_flags(monkeypatch: pytest.MonkeyPatch) -> None:
     assert args.rank == 2
     assert args.local_rank == 0
     assert args.world_size == 8
+    assert args.telemetry_sink_dir == "telemetry_sink"
+    assert args.telemetry_flush_seconds == 3.5
+    assert args.telemetry_rollover_mb == 32
+    assert args.telemetry_retention_files == 4
+    assert args.telemetry_retention_total_mb == 128
 
 
 def test_cmd_track_passes_oom_config_to_memorytracker(
@@ -130,6 +145,11 @@ def test_cmd_track_passes_oom_config_to_memorytracker(
         rank=2,
         local_rank=0,
         world_size=8,
+        telemetry_sink_dir="telemetry_sink",
+        telemetry_flush_seconds=3.5,
+        telemetry_rollover_mb=32,
+        telemetry_retention_files=4,
+        telemetry_retention_total_mb=128,
     )
 
     gpumemprof_cli.cmd_track(args)
@@ -145,9 +165,84 @@ def test_cmd_track_passes_oom_config_to_memorytracker(
     assert created["rank"] == 2
     assert created["local_rank"] == 0
     assert created["world_size"] == 8
+    telemetry_sink_config = created["telemetry_sink_config"]
+    assert telemetry_sink_config.root_dir == gpumemprof_cli.Path("telemetry_sink")
+    assert telemetry_sink_config.flush_every_seconds == 3.5
+    assert telemetry_sink_config.rollover_max_bytes == 32 * 1024 * 1024
+    assert telemetry_sink_config.retention_max_files == 4
+    assert telemetry_sink_config.retention_max_total_bytes == 128 * 1024 * 1024
     assert created["capture_context"] == "stormlog.track"
     assert created["capture_metadata"]["command"] == "track"
     assert created["capture_metadata"]["runtime_backend"] == "cuda"
+
+
+def test_cmd_track_passes_telemetry_sink_config_to_cpu_tracker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: dict[str, Any] = {}
+
+    class _FakeCPUTracker:
+        def __init__(self, **kwargs: object) -> None:
+            created.update(kwargs)
+
+        def start_tracking(self) -> None:
+            return None
+
+        def stop_tracking(self) -> None:
+            return None
+
+        def get_statistics(self) -> dict[str, object]:
+            return {
+                "current_memory_allocated": 0,
+                "peak_memory": 0,
+                "memory_utilization_percent": 0,
+                "total_events": 0,
+            }
+
+        def export_events(self, output: str, fmt: str) -> None:
+            _ = (output, fmt)
+
+    monkeypatch.setattr(gpumemprof_cli, "CPUMemoryTracker", _FakeCPUTracker)
+    monkeypatch.setattr(
+        gpumemprof_cli, "get_system_info", lambda: {"detected_backend": "cpu"}
+    )
+    monkeypatch.setattr(
+        gpumemprof_cli.time, "sleep", lambda _: (_ for _ in ()).throw(KeyboardInterrupt)
+    )
+
+    gpumemprof_cli.cmd_track(
+        Namespace(
+            device=None,
+            duration=None,
+            interval=0.5,
+            output=None,
+            format="json",
+            watchdog=False,
+            warning_threshold=70.0,
+            critical_threshold=90.0,
+            oom_flight_recorder=False,
+            oom_dump_dir="oom_test_dir",
+            oom_buffer_size=None,
+            oom_max_dumps=9,
+            oom_max_total_mb=512,
+            job_id=None,
+            rank=None,
+            local_rank=None,
+            world_size=None,
+            telemetry_sink_dir="cpu_sink",
+            telemetry_flush_seconds=2.5,
+            telemetry_rollover_mb=16,
+            telemetry_retention_files=3,
+            telemetry_retention_total_mb=64,
+        )
+    )
+
+    telemetry_sink_config = created["telemetry_sink_config"]
+    assert telemetry_sink_config.root_dir == gpumemprof_cli.Path("cpu_sink")
+    assert telemetry_sink_config.flush_every_seconds == 2.5
+    assert telemetry_sink_config.rollover_max_bytes == 16 * 1024 * 1024
+    assert telemetry_sink_config.retention_max_files == 3
+    assert telemetry_sink_config.retention_max_total_bytes == 64 * 1024 * 1024
 
 
 def test_cmd_track_reports_collector_health_in_output(

--- a/tests/test_cpu_profiler.py
+++ b/tests/test_cpu_profiler.py
@@ -20,6 +20,7 @@ from stormlog.cpu_profiler import (
     CPUMemoryTracker,
     CPUProfileResult,
 )
+from stormlog.telemetry_sink import TelemetrySinkConfig
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -489,6 +490,30 @@ class TestCPUMemoryTracker:
 
         tracker.export_events(str(filepath), format="csv")
         assert not filepath.exists()
+
+    @patch("stormlog.cpu_profiler.psutil.Process")
+    def test_tracker_streams_events_to_append_only_sink(
+        self, mock_cls: Any, tmp_path: Path
+    ) -> None:
+        mock_cls.return_value = _make_mock_process(rss=2048)
+        tracker = CPUMemoryTracker(
+            telemetry_sink_config=TelemetrySinkConfig(
+                root_dir=tmp_path / "sink",
+                flush_every_events=1,
+                flush_every_seconds=1.0,
+                rollover_max_bytes=1024,
+                retention_max_total_bytes=1024 * 1024,
+            )
+        )
+
+        tracker._add_event("allocation", 10, "sink_test")
+        tracker._close_telemetry_sink()
+
+        segment = tmp_path / "sink" / "segment-000001.jsonl"
+        payload = json.loads(segment.read_text(encoding="utf-8").splitlines()[0])
+        assert payload["collector"] == "stormlog.cpu_tracker"
+        assert payload["event_type"] == "allocation"
+        assert payload["context"] == "sink_test"
 
     @patch("stormlog.cpu_profiler.psutil.Process")
     def test_export_events_with_timestamp(self, mock_cls: Any, tmp_path: Path) -> None:

--- a/tests/test_cpu_profiler.py
+++ b/tests/test_cpu_profiler.py
@@ -60,6 +60,31 @@ def _wait_until(
     return predicate()
 
 
+class _FailingSink:
+    def __init__(self, *, fail_on: set[str]) -> None:
+        self.fail_on = fail_on
+        self.append_calls = 0
+        self.flush_calls = 0
+        self.close_calls = 0
+
+    def append(self, record: dict[str, object]) -> None:
+        _ = record
+        self.append_calls += 1
+        if "append" in self.fail_on:
+            raise OSError("disk full")
+
+    def flush(self, *, force: bool = False) -> None:
+        _ = force
+        self.flush_calls += 1
+        if "flush" in self.fail_on:
+            raise OSError("disk full")
+
+    def close(self) -> None:
+        self.close_calls += 1
+        if "close" in self.fail_on:
+            raise OSError("disk full")
+
+
 # ---------------------------------------------------------------------------
 # CPUMemorySnapshot
 # ---------------------------------------------------------------------------
@@ -514,6 +539,50 @@ class TestCPUMemoryTracker:
         assert payload["collector"] == "stormlog.cpu_tracker"
         assert payload["event_type"] == "allocation"
         assert payload["context"] == "sink_test"
+
+    @patch("stormlog.cpu_profiler.psutil.Process")
+    def test_tracker_disables_sink_after_append_failure(self, mock_cls: Any) -> None:
+        mock_cls.return_value = _make_mock_process(rss=2048)
+        tracker = CPUMemoryTracker()
+        sink = _FailingSink(fail_on={"append"})
+        tracker._telemetry_sink = sink
+
+        tracker._add_event("allocation", 10, "sink_failure")
+
+        assert len(tracker.events) == 1
+        assert tracker.events[-1].context == "sink_failure"
+        assert sink.append_calls == 1
+        assert sink.close_calls == 1
+        assert tracker._telemetry_sink is None
+
+    @patch("stormlog.cpu_profiler.psutil.Process")
+    def test_tracker_disables_sink_after_flush_failure(self, mock_cls: Any) -> None:
+        mock_cls.return_value = _make_mock_process(rss=2048)
+        tracker = CPUMemoryTracker()
+        sink = _FailingSink(fail_on={"flush"})
+        tracker._telemetry_sink = sink
+
+        tracker._flush_telemetry_sink()
+
+        assert sink.flush_calls == 1
+        assert sink.close_calls == 1
+        assert tracker._telemetry_sink is None
+
+    @patch("stormlog.cpu_profiler.psutil.Process")
+    def test_stop_tracking_disables_sink_after_close_failure(
+        self, mock_cls: Any
+    ) -> None:
+        mock_cls.return_value = _make_mock_process(rss=2048)
+        tracker = CPUMemoryTracker()
+        tracker.is_tracking = True
+        sink = _FailingSink(fail_on={"close"})
+        tracker._telemetry_sink = sink
+
+        tracker.stop_tracking()
+
+        assert tracker.events[-1].event_type == "stop"
+        assert sink.close_calls >= 1
+        assert tracker._telemetry_sink is None
 
     @patch("stormlog.cpu_profiler.psutil.Process")
     def test_export_events_with_timestamp(self, mock_cls: Any, tmp_path: Path) -> None:

--- a/tests/test_telemetry_sink.py
+++ b/tests/test_telemetry_sink.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 
 import pytest
@@ -84,6 +85,30 @@ def test_append_only_sink_prunes_oldest_closed_segments(tmp_path: Path) -> None:
     filenames = [segment["filename"] for segment in manifest["segments"]]
     assert filenames == ["segment-000002.jsonl", "segment-000003.jsonl"]
     assert not (tmp_path / "segment-000001.jsonl").exists()
+
+
+def test_append_only_sink_flushes_without_new_events(tmp_path: Path) -> None:
+    sink = AppendOnlyTelemetrySink(
+        TelemetrySinkConfig(
+            root_dir=tmp_path,
+            flush_every_events=10,
+            flush_every_seconds=0.05,
+        )
+    )
+
+    try:
+        sink.append({"seq": 1})
+
+        segment_path = tmp_path / "segment-000001.jsonl"
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline:
+            if segment_path.exists() and _segment_records(segment_path) == [{"seq": 1}]:
+                break
+            time.sleep(0.01)
+        else:
+            pytest.fail("append-only sink did not flush buffered records in time")
+    finally:
+        sink.close()
 
 
 def test_telemetry_sink_config_rejects_total_retention_below_rollover() -> None:

--- a/tests/test_telemetry_sink.py
+++ b/tests/test_telemetry_sink.py
@@ -111,6 +111,54 @@ def test_append_only_sink_flushes_without_new_events(tmp_path: Path) -> None:
         sink.close()
 
 
+def test_append_only_sink_resume_skips_stale_manifest_segment_reuse(
+    tmp_path: Path,
+) -> None:
+    first = tmp_path / "segment-000001.jsonl"
+    second = tmp_path / "segment-000002.jsonl"
+    third = tmp_path / "segment-000003.jsonl"
+    first.write_text(json.dumps({"seq": 1}) + "\n", encoding="utf-8")
+    second.write_text(json.dumps({"seq": 2}) + "\n", encoding="utf-8")
+    third.write_text(json.dumps({"seq": 3}) + "\n", encoding="utf-8")
+    (tmp_path / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "format": "stormlog.append_only_telemetry_sink",
+                "segments": [
+                    {
+                        "filename": "segment-000001.jsonl",
+                        "event_count": 1,
+                        "size_bytes": first.stat().st_size,
+                        "closed": True,
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    sink = AppendOnlyTelemetrySink(
+        TelemetrySinkConfig(
+            root_dir=tmp_path,
+            flush_every_events=1,
+            flush_every_seconds=1.0,
+        )
+    )
+    sink.append({"seq": 4})
+    sink.close()
+
+    assert _segment_records(second) == [{"seq": 2}]
+
+    resumed_records = _segment_records(third)
+    next_segment = tmp_path / "segment-000004.jsonl"
+    if next_segment.exists():
+        resumed_records.extend(_segment_records(next_segment))
+
+    assert [record["seq"] for record in resumed_records] == [3, 4]
+
+
 def test_telemetry_sink_config_rejects_total_retention_below_rollover() -> None:
     with pytest.raises(
         ValueError, match="retention_max_total_bytes must be >= rollover_max_bytes"

--- a/tests/test_telemetry_sink.py
+++ b/tests/test_telemetry_sink.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from stormlog.telemetry_sink import AppendOnlyTelemetrySink, TelemetrySinkConfig
+
+
+def _segment_records(path: Path) -> list[dict[str, object]]:
+    with path.open("r", encoding="utf-8") as handle:
+        return [json.loads(line) for line in handle if line.strip()]
+
+
+def test_append_only_sink_writes_jsonl_segment_and_manifest(tmp_path: Path) -> None:
+    sink = AppendOnlyTelemetrySink(
+        TelemetrySinkConfig(
+            root_dir=tmp_path,
+            flush_every_events=1,
+            flush_every_seconds=1.0,
+        )
+    )
+
+    sink.append({"schema_version": 2, "event_type": "start", "seq": 1})
+    sink.close()
+
+    manifest = json.loads((tmp_path / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == 1
+    assert len(manifest["segments"]) == 1
+    assert manifest["segments"][0]["event_count"] == 1
+    assert manifest["segments"][0]["closed"] is True
+
+    records = _segment_records(tmp_path / manifest["segments"][0]["filename"])
+    assert records == [{"event_type": "start", "schema_version": 2, "seq": 1}]
+
+
+def test_append_only_sink_rolls_over_by_event_count(tmp_path: Path) -> None:
+    sink = AppendOnlyTelemetrySink(
+        TelemetrySinkConfig(
+            root_dir=tmp_path,
+            flush_every_events=1,
+            flush_every_seconds=1.0,
+            rollover_max_events=2,
+            retention_max_files=4,
+        )
+    )
+
+    sink.append({"seq": 1})
+    sink.append({"seq": 2})
+    sink.append({"seq": 3})
+    sink.close()
+
+    manifest = json.loads((tmp_path / "manifest.json").read_text(encoding="utf-8"))
+    segments = manifest["segments"]
+    assert [segment["event_count"] for segment in segments] == [2, 1]
+    assert [segment["closed"] for segment in segments] == [True, True]
+
+    first = _segment_records(tmp_path / segments[0]["filename"])
+    second = _segment_records(tmp_path / segments[1]["filename"])
+    assert [record["seq"] for record in first] == [1, 2]
+    assert [record["seq"] for record in second] == [3]
+
+
+def test_append_only_sink_prunes_oldest_closed_segments(tmp_path: Path) -> None:
+    sink = AppendOnlyTelemetrySink(
+        TelemetrySinkConfig(
+            root_dir=tmp_path,
+            flush_every_events=1,
+            flush_every_seconds=1.0,
+            rollover_max_events=1,
+            rollover_max_bytes=1024,
+            retention_max_files=2,
+            retention_max_total_bytes=1024 * 1024,
+        )
+    )
+
+    sink.append({"seq": 1})
+    sink.append({"seq": 2})
+    sink.append({"seq": 3})
+    sink.close()
+
+    manifest = json.loads((tmp_path / "manifest.json").read_text(encoding="utf-8"))
+    filenames = [segment["filename"] for segment in manifest["segments"]]
+    assert filenames == ["segment-000002.jsonl", "segment-000003.jsonl"]
+    assert not (tmp_path / "segment-000001.jsonl").exists()
+
+
+def test_telemetry_sink_config_rejects_total_retention_below_rollover() -> None:
+    with pytest.raises(
+        ValueError, match="retention_max_total_bytes must be >= rollover_max_bytes"
+    ):
+        TelemetrySinkConfig(
+            root_dir=Path("/tmp/telemetry"),
+            rollover_max_bytes=2048,
+            retention_max_total_bytes=1024,
+        )

--- a/tests/test_telemetry_v2.py
+++ b/tests/test_telemetry_v2.py
@@ -20,6 +20,7 @@ from stormlog.telemetry import (
     telemetry_event_to_dict,
     validate_telemetry_record,
 )
+from stormlog.telemetry_sink import AppendOnlyTelemetrySink, TelemetrySinkConfig
 
 
 def _schema() -> dict[str, object]:
@@ -349,6 +350,42 @@ def test_load_telemetry_events_reads_dict_events_payload(tmp_path: Path) -> None
 
     assert len(events) == 1
     assert events[0].schema_version == SCHEMA_VERSION_V2
+
+
+def test_load_telemetry_events_reads_append_only_sink_directory(tmp_path: Path) -> None:
+    sink = AppendOnlyTelemetrySink(
+        TelemetrySinkConfig(
+            root_dir=tmp_path / "sink",
+            flush_every_events=1,
+            flush_every_seconds=1.0,
+        )
+    )
+    first = telemetry_event_to_dict(_make_valid_event())
+    second = telemetry_event_to_dict(_make_valid_event())
+    second["timestamp_ns"] = first["timestamp_ns"] + 1
+    sink.append(first)
+    sink.append(second)
+    sink.close()
+
+    events = load_telemetry_events(tmp_path / "sink")
+
+    assert len(events) == 2
+    assert events[0].timestamp_ns == first["timestamp_ns"]
+    assert events[1].timestamp_ns == second["timestamp_ns"]
+
+
+def test_load_telemetry_events_ignores_truncated_jsonl_tail(tmp_path: Path) -> None:
+    record = telemetry_event_to_dict(_make_valid_event())
+    segment = tmp_path / "segment-000001.jsonl"
+    segment.write_text(
+        json.dumps(record) + "\n" + '{"schema_version": 2, "timestamp_ns":',
+        encoding="utf-8",
+    )
+
+    events = load_telemetry_events(segment)
+
+    assert len(events) == 1
+    assert events[0].timestamp_ns == record["timestamp_ns"]
 
 
 def test_legacy_conversion_can_be_disabled() -> None:

--- a/tests/test_telemetry_v2.py
+++ b/tests/test_telemetry_v2.py
@@ -412,6 +412,61 @@ def test_load_telemetry_events_reads_unlisted_sink_segments(tmp_path: Path) -> N
     assert events[1].timestamp_ns == second["timestamp_ns"]
 
 
+def test_append_only_sink_truncates_partial_segment_tail_on_resume(
+    tmp_path: Path,
+) -> None:
+    sink_dir = tmp_path / "sink"
+    sink_dir.mkdir()
+
+    first = telemetry_event_to_dict(_make_valid_event())
+    second = telemetry_event_to_dict(_make_valid_event())
+    second["timestamp_ns"] = first["timestamp_ns"] + 1
+
+    first_payload = json.dumps(first) + "\n"
+    partial_payload = '{"schema_version": 2, "timestamp_ns":'
+    segment_path = sink_dir / "segment-000001.jsonl"
+    segment_path.write_text(
+        first_payload + partial_payload,
+        encoding="utf-8",
+    )
+    (sink_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "format": "stormlog.append_only_telemetry_sink",
+                "segments": [
+                    {
+                        "filename": segment_path.name,
+                        "event_count": 1,
+                        "size_bytes": len(
+                            (first_payload + partial_payload).encode("utf-8")
+                        ),
+                        "closed": False,
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    sink = AppendOnlyTelemetrySink(
+        TelemetrySinkConfig(
+            root_dir=sink_dir,
+            flush_every_events=1,
+            flush_every_seconds=1.0,
+        )
+    )
+    sink.append(second)
+    sink.close()
+
+    events = load_telemetry_events(sink_dir)
+
+    assert len(events) == 2
+    assert events[0].timestamp_ns == first["timestamp_ns"]
+    assert events[1].timestamp_ns == second["timestamp_ns"]
+
+
 def test_load_telemetry_events_ignores_truncated_jsonl_tail(tmp_path: Path) -> None:
     record = telemetry_event_to_dict(_make_valid_event())
     segment = tmp_path / "segment-000001.jsonl"

--- a/tests/test_telemetry_v2.py
+++ b/tests/test_telemetry_v2.py
@@ -374,6 +374,44 @@ def test_load_telemetry_events_reads_append_only_sink_directory(tmp_path: Path) 
     assert events[1].timestamp_ns == second["timestamp_ns"]
 
 
+def test_load_telemetry_events_reads_unlisted_sink_segments(tmp_path: Path) -> None:
+    sink_dir = tmp_path / "sink"
+    sink_dir.mkdir()
+
+    first = telemetry_event_to_dict(_make_valid_event())
+    second = telemetry_event_to_dict(_make_valid_event())
+    second["timestamp_ns"] = first["timestamp_ns"] + 1
+
+    first_payload = json.dumps(first) + "\n"
+    second_payload = json.dumps(second) + "\n"
+    (sink_dir / "segment-000001.jsonl").write_text(first_payload, encoding="utf-8")
+    (sink_dir / "segment-000002.jsonl").write_text(second_payload, encoding="utf-8")
+    (sink_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "format": "stormlog.append_only_telemetry_sink",
+                "segments": [
+                    {
+                        "filename": "segment-000001.jsonl",
+                        "event_count": 1,
+                        "size_bytes": len(first_payload.encode("utf-8")),
+                        "closed": False,
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    events = load_telemetry_events(sink_dir)
+
+    assert len(events) == 2
+    assert events[0].timestamp_ns == first["timestamp_ns"]
+    assert events[1].timestamp_ns == second["timestamp_ns"]
+
+
 def test_load_telemetry_events_ignores_truncated_jsonl_tail(tmp_path: Path) -> None:
     record = telemetry_event_to_dict(_make_valid_event())
     segment = tmp_path / "segment-000001.jsonl"

--- a/tests/test_tf_telemetry_export.py
+++ b/tests/test_tf_telemetry_export.py
@@ -41,6 +41,31 @@ class _NoOpThread:
         _ = timeout
 
 
+class _FailingSink:
+    def __init__(self, *, fail_on: set[str]) -> None:
+        self.fail_on = fail_on
+        self.append_calls = 0
+        self.flush_calls = 0
+        self.close_calls = 0
+
+    def append(self, record: dict[str, object]) -> None:
+        _ = record
+        self.append_calls += 1
+        if "append" in self.fail_on:
+            raise OSError("disk full")
+
+    def flush(self, *, force: bool = False) -> None:
+        _ = force
+        self.flush_calls += 1
+        if "flush" in self.fail_on:
+            raise OSError("disk full")
+
+    def close(self) -> None:
+        self.close_calls += 1
+        if "close" in self.fail_on:
+            raise OSError("disk full")
+
+
 def test_tf_tracker_emits_v2_event_records(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(tf_tracker, "TF_AVAILABLE", True)
 
@@ -335,6 +360,71 @@ def test_tf_tracker_streams_events_to_append_only_sink(
     assert payload["collector"] == "stormlog.tensorflow.memory_tracker"
     assert payload["event_type"] == "sample"
     assert payload["allocator_allocated_bytes"] == 32 * 1024 * 1024
+
+
+def test_tf_tracker_disables_sink_after_append_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(tf_tracker, "TF_AVAILABLE", True)
+
+    tracker = tf_tracker.MemoryTracker(
+        sampling_interval=0.01,
+        device="/GPU:0",
+        enable_logging=False,
+    )
+    sink = _FailingSink(fail_on={"append"})
+    tracker._telemetry_sink = sink  # type: ignore[assignment]
+
+    tracker._append_event(
+        timestamp=1.0,
+        memory_mb=32.0,
+        event_type="sample",
+    )
+
+    assert tracker.events
+    assert tracker._telemetry_sink is None
+    assert sink.append_calls == 1
+
+
+def test_tf_tracker_disables_sink_after_flush_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(tf_tracker, "TF_AVAILABLE", True)
+
+    tracker = tf_tracker.MemoryTracker(
+        sampling_interval=0.01,
+        device="/GPU:0",
+        enable_logging=False,
+    )
+    sink = _FailingSink(fail_on={"flush"})
+    tracker._telemetry_sink = sink  # type: ignore[assignment]
+
+    tracker._flush_telemetry_sink()
+
+    assert tracker._telemetry_sink is None
+    assert sink.flush_calls == 1
+
+
+def test_tf_tracker_stop_tracking_disables_sink_after_close_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(tf_tracker, "TF_AVAILABLE", True)
+    monkeypatch.setattr(tf_tracker.threading, "Thread", _NoOpThread)
+
+    tracker = tf_tracker.MemoryTracker(
+        sampling_interval=0.01,
+        device="/GPU:0",
+        enable_logging=False,
+    )
+    tracker.start_tracking()
+    sink = _FailingSink(fail_on={"close"})
+    tracker._telemetry_sink = sink  # type: ignore[assignment]
+
+    result = tracker.stop_tracking()
+
+    assert result.events == []
+    assert tracker._telemetry_sink is None
+    assert sink.close_calls >= 1
 
 
 def test_tf_tracker_persistent_failure_preserves_status_events_without_samples(

--- a/tests/test_tf_telemetry_export.py
+++ b/tests/test_tf_telemetry_export.py
@@ -199,6 +199,76 @@ def test_tf_cli_track_passes_distributed_identity_to_tracker(
     assert created["world_size"] == 8
 
 
+def test_tf_cli_track_passes_telemetry_sink_config_to_tracker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(tf_cli, "TF_AVAILABLE", True)
+    created: dict[str, object] = {}
+
+    class _FakeResult:
+        peak_memory = 0.0
+        average_memory = 0.0
+        duration = 0.0
+        memory_usage: list[float] = []
+        timestamps: list[float] = []
+        alerts_triggered: list[object] = []
+        events: list[dict[str, object]] = []
+
+    class _FakeTracker:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            _ = args
+            created.update(kwargs)
+
+        def add_alert_callback(self, callback: object) -> None:
+            _ = callback
+
+        def start_tracking(self) -> None:
+            return None
+
+        def get_current_memory(self) -> float:
+            return 0.0
+
+        def get_statistics(self) -> dict[str, object]:
+            return {
+                "current_memory_mb": 0.0,
+                "collector_health_status": "healthy",
+            }
+
+        def stop_tracking(self) -> "_FakeResult":
+            return _FakeResult()
+
+    monkeypatch.setattr(tf_cli, "MemoryTracker", _FakeTracker)
+    monkeypatch.setattr(
+        tf_cli.time, "sleep", lambda _: (_ for _ in ()).throw(KeyboardInterrupt)
+    )
+
+    exit_code = tf_cli.cmd_track(
+        Namespace(
+            interval=0.25,
+            threshold=4000,
+            device="/GPU:0",
+            output="ignored.json",
+            job_id=None,
+            rank=None,
+            local_rank=None,
+            world_size=None,
+            telemetry_sink_dir="tf_sink",
+            telemetry_flush_seconds=4.0,
+            telemetry_rollover_mb=12,
+            telemetry_retention_files=5,
+            telemetry_retention_total_mb=96,
+        )
+    )
+
+    assert exit_code == 0
+    telemetry_sink_config = created["telemetry_sink_config"]
+    assert telemetry_sink_config.root_dir == tf_cli.Path("tf_sink")
+    assert telemetry_sink_config.flush_every_seconds == 4.0
+    assert telemetry_sink_config.rollover_max_bytes == 12 * 1024 * 1024
+    assert telemetry_sink_config.retention_max_files == 5
+    assert telemetry_sink_config.retention_max_total_bytes == 96 * 1024 * 1024
+
+
 def test_tf_tracker_records_degrade_and_recover_events(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_tf_telemetry_export.py
+++ b/tests/test_tf_telemetry_export.py
@@ -14,6 +14,7 @@ import stormlog.tensorflow.cli as tf_cli
 import stormlog.tensorflow.tracker as tf_tracker
 from stormlog.collector_health import COLLECTOR_HEALTH_UNHEALTHY
 from stormlog.telemetry import validate_telemetry_record
+from stormlog.telemetry_sink import TelemetrySinkConfig
 
 
 def _wait_until_events(
@@ -234,6 +235,36 @@ def test_tf_tracker_records_degrade_and_recover_events(
     assert event_types == ["collector_degraded", "collector_recovered", "sample"]
     assert tracker.memory_usage == [16.0]
     assert tracker.get_statistics()["collector_health_status"] == "healthy"
+
+
+def test_tf_tracker_streams_events_to_append_only_sink(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(tf_tracker, "TF_AVAILABLE", True)
+
+    tracker = tf_tracker.MemoryTracker(
+        sampling_interval=0.01,
+        device="/GPU:0",
+        enable_logging=False,
+        telemetry_sink_config=TelemetrySinkConfig(
+            root_dir=tmp_path / "sink",
+            flush_every_events=1,
+            flush_every_seconds=1.0,
+            rollover_max_bytes=1024,
+            retention_max_total_bytes=1024 * 1024,
+        ),
+    )
+    monkeypatch.setattr(tracker, "_get_current_memory", lambda: 32.0)
+
+    tracker._run_tracking_iteration()
+    tracker._close_telemetry_sink()
+
+    segment = tmp_path / "sink" / "segment-000001.jsonl"
+    payload = json.loads(segment.read_text(encoding="utf-8").splitlines()[0])
+    assert payload["collector"] == "stormlog.tensorflow.memory_tracker"
+    assert payload["event_type"] == "sample"
+    assert payload["allocator_allocated_bytes"] == 32 * 1024 * 1024
 
 
 def test_tf_tracker_persistent_failure_preserves_status_events_without_samples(

--- a/tests/test_tracker_input_guards.py
+++ b/tests/test_tracker_input_guards.py
@@ -35,7 +35,8 @@ def test_gpu_tracker_rejects_non_positive_max_events() -> None:
 def test_gpu_tracker_appends_native_history_options_after_identity() -> None:
     parameters = list(inspect.signature(MemoryTracker.__init__).parameters)
 
-    assert parameters[-2:] == [
+    assert parameters[-3:] == [
         "enable_native_cuda_history",
         "native_history_max_entries",
+        "telemetry_sink_config",
     ]

--- a/tests/test_tracker_resilience.py
+++ b/tests/test_tracker_resilience.py
@@ -12,6 +12,7 @@ from stormlog.collector_health import (
     COLLECTOR_HEALTH_UNHEALTHY,
 )
 from stormlog.device_collectors import DeviceMemorySample, DeviceMemorySampleResult
+from stormlog.telemetry_sink import TelemetrySinkConfig
 
 
 def _sample(
@@ -87,6 +88,7 @@ class _NoOpThread:
 def _build_tracker(
     monkeypatch: pytest.MonkeyPatch,
     collector: _SequencedCollector,
+    **kwargs: object,
 ) -> tracker_mod.MemoryTracker:
     monkeypatch.setattr(
         tracker_mod.MemoryTracker,
@@ -103,7 +105,11 @@ def _build_tracker(
         "get_gpu_info",
         lambda _device: {"total_memory": 4096},
     )
-    return tracker_mod.MemoryTracker(sampling_interval=0.01, enable_alerts=False)
+    return tracker_mod.MemoryTracker(
+        sampling_interval=0.01,
+        enable_alerts=False,
+        **kwargs,
+    )
 
 
 def test_memory_tracker_recovers_after_transient_collector_failure(
@@ -281,6 +287,37 @@ def test_memory_tracker_export_preserves_health_metadata(
     assert "collector_health_status" in payload
     assert "collector_degraded" in payload
     assert "device_total_bytes" in payload
+
+
+def test_memory_tracker_streams_events_to_append_only_sink(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    collector = _SequencedCollector(
+        [DeviceMemorySampleResult(sample=_sample(allocated=128, reserved=256))]
+    )
+    tracker = _build_tracker(
+        monkeypatch,
+        collector,
+        telemetry_sink_config=TelemetrySinkConfig(
+            root_dir=tmp_path / "sink",
+            flush_every_events=1,
+            flush_every_seconds=1.0,
+            rollover_max_bytes=1024,
+            retention_max_total_bytes=1024 * 1024,
+        ),
+    )
+
+    tracker._run_tracking_iteration(0)
+    tracker._close_telemetry_sink()
+
+    segment = tmp_path / "sink" / "segment-000001.jsonl"
+    lines = [line for line in segment.read_text(encoding="utf-8").splitlines() if line]
+    assert len(lines) == 2
+    payload = tracker_mod.json.loads(lines[-1])
+    assert payload["collector"] == "stormlog.cuda_tracker"
+    assert payload["event_type"] == "allocation"
+    assert payload["allocator_allocated_bytes"] == 128
 
 
 def test_memory_tracker_start_tracking_resets_collector_session_state(

--- a/tests/test_tracker_resilience.py
+++ b/tests/test_tracker_resilience.py
@@ -85,6 +85,41 @@ class _NoOpThread:
         _ = timeout
 
 
+class _SequencedStopEvent:
+    def __init__(self, waits: list[bool]) -> None:
+        self._waits = deque(waits)
+
+    def wait(self, timeout: float | None = None) -> bool:
+        _ = timeout
+        if self._waits:
+            return self._waits.popleft()
+        return True
+
+    def set(self) -> None:
+        return None
+
+    def clear(self) -> None:
+        return None
+
+
+class _FailingFlushSink:
+    def __init__(self) -> None:
+        self.flush_calls = 0
+        self.close_calls = 0
+
+    def append(self, record: dict[str, object]) -> None:
+        _ = record
+        return None
+
+    def flush(self, *, force: bool = False) -> None:
+        _ = force
+        self.flush_calls += 1
+        raise OSError("disk full")
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
 def _build_tracker(
     monkeypatch: pytest.MonkeyPatch,
     collector: _SequencedCollector,
@@ -318,6 +353,33 @@ def test_memory_tracker_streams_events_to_append_only_sink(
     assert payload["collector"] == "stormlog.cuda_tracker"
     assert payload["event_type"] == "allocation"
     assert payload["allocator_allocated_bytes"] == 128
+
+
+def test_memory_tracker_disables_failing_sink_and_keeps_tracking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    collector = _SequencedCollector(
+        [DeviceMemorySampleResult(sample=_sample(allocated=128, reserved=256))]
+    )
+    tracker = _build_tracker(monkeypatch, collector)
+    sink = _FailingFlushSink()
+    tracker._telemetry_sink = sink
+    tracker._stop_event = _SequencedStopEvent([False, False, True])
+    iteration_inputs: list[int] = []
+
+    def _run_iteration(last_allocated: int) -> int:
+        iteration_inputs.append(last_allocated)
+        return last_allocated + 1
+
+    monkeypatch.setattr(tracker, "_run_tracking_iteration", _run_iteration)
+    monkeypatch.setattr(tracker_mod.time, "sleep", lambda _: None)
+
+    tracker._tracking_loop()
+
+    assert iteration_inputs == [0, 1]
+    assert sink.flush_calls == 1
+    assert sink.close_calls == 1
+    assert tracker._telemetry_sink is None
 
 
 def test_memory_tracker_start_tracking_resets_collector_session_state(

--- a/tests/tui/test_monitor.py
+++ b/tests/tui/test_monitor.py
@@ -1,7 +1,9 @@
 import types
+from pathlib import Path
 
 import pytest
 
+from stormlog.telemetry_sink import TelemetrySinkConfig
 from stormlog.tui import monitor
 
 
@@ -13,10 +15,12 @@ class DummyCPUTracker:
         sampling_interval: float = 0.5,
         max_events: int = 10_000,
         enable_alerts: bool = True,
+        telemetry_sink_config: object | None = None,
     ) -> None:
         self.sampling_interval = sampling_interval
         self.max_events = max_events
         self.enable_alerts = enable_alerts
+        self.telemetry_sink_config = telemetry_sink_config
         self.is_tracking = False
         self.events: list[object] = []
 
@@ -184,3 +188,21 @@ def test_tracker_session_preserves_collector_health_metadata(
     assert first.metadata["collector_health_status"] == "degraded"
     assert first.metadata["telemetry_partial"] is True
     assert first.metadata["collector_partial_fields"] == ["device_total_bytes"]
+
+
+def test_tracker_session_passes_telemetry_sink_config_to_cpu_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(monitor, "MemoryTracker", BrokenGPUTracker)
+    monkeypatch.setattr(monitor, "MemoryWatchdog", None)
+    monkeypatch.setattr(monitor, "CPUMemoryTracker", DummyCPUTracker)
+    monkeypatch.setattr(monitor, "torch", _stub_torch(False))
+
+    sink_config = TelemetrySinkConfig(root_dir=Path("/tmp/tui_sink"))
+    session = monitor.TrackerSession(telemetry_sink_config=sink_config)
+    session.start()
+
+    assert isinstance(session._tracker, DummyCPUTracker)
+    assert session._tracker.telemetry_sink_config == sink_config
+
+    session.stop()


### PR DESCRIPTION
## Summary
- add an append-only JSONL telemetry sink with rollover, retention, and manifest-backed segment discovery
- stream always-on telemetry into the sink from the PyTorch, CPU, TensorFlow, and TUI tracker paths
- teach telemetry loading and analyze flows to read sink directories, manifests, and rolled segments
- document the artifact layout and operational bounds for long-running telemetry capture

## Durability And Recovery
- merge manifest-listed segments with any additional on-disk segments so stale manifests do not hide valid data
- truncate torn JSONL tails before resuming an open segment so restarted runs remain readable
- honor `flush_every_seconds` with a sink-local background flush loop so sparse sessions still persist on schedule

## Validation
- ran `black --check`, `isort --check-only`, `flake8`, and `mypy stormlog/telemetry_sink.py`
- executed focused append-only sink, loader, and tracker regression coverage in the `tensor-torch-profiler` environment

Closes #90
