### PR TITLE
fix: unblock PyPI release publish metadata check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,7 @@ jobs:
                   fi
 
             - name: Publish to PyPI with Trusted Publishing
-              uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0 # v1.9.0
+              uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
               with:
                   skip-existing: true
 


### PR DESCRIPTION
## Summary
- update `pypa/gh-action-pypi-publish` from `v1.9.0` to `v1.14.0`
- keep SHA pinning while picking up support for Core Metadata v2.4
- unblock Trusted Publishing for the current `0.3.1` release build

## Validation
- `pytest tests/test_release_workflow_contracts.py -q`
- `uvx zizmor .github/workflows/release.yml`
- reproduced the current `main` release build locally and confirmed the wheel contains `Name`, `Version`, and `Metadata-Version: 2.4`

## Why
The failed run on `main` is no longer a Trusted Publisher configuration issue. The publish step is using an older `gh-action-pypi-publish` runtime that rejects distributions using Core Metadata v2.4. Official `gh-action-pypi-publish` release notes state support for metadata v2.4 was added in `v1.12.3` by bumping `Twine` and `pkginfo`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release pipeline tooling to improve the distribution publishing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->