### PR TITLE
Issue 94/structured monitor phases for long running analysis

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,13 +4,10 @@ repos:
       hooks:
           - id: isort
             args: ["--profile", "black"]
-    - repo: local
+    - repo: https://github.com/psf/black
+      rev: 24.3.0
       hooks:
           - id: black
-            name: black
-            entry: .venv/bin/python -m black
-            language: system
-            files: \.pyi?$
     - repo: https://github.com/PyCQA/flake8
       rev: 7.0.0
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,10 +4,13 @@ repos:
       hooks:
           - id: isort
             args: ["--profile", "black"]
-    - repo: https://github.com/psf/black
-      rev: 24.3.0
+    - repo: local
       hooks:
           - id: black
+            name: black
+            entry: .venv/bin/python -m black
+            language: system
+            files: \.pyi?$
     - repo: https://github.com/PyCQA/flake8
       rev: 7.0.0
       hooks:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -78,6 +78,11 @@ session begins after tracker startup succeeds and before the first record is
 persisted, and it is marked `completed` only after clean shutdown finalization
 finishes.
 
+If your Python workload instruments phases with `tracker.phase(...)` or
+`tracker.enter_phase(...)`, the same `track` output also includes structured
+`phase_enter` / `phase_exit` companion records. Phase records are optional and
+do not change the `track` CLI surface in v1.
+
 For long-running tracking sessions, Stormlog now degrades gracefully when a
 collector becomes unhealthy:
 
@@ -155,6 +160,15 @@ When multiple sessions are present, `gpumemprof analyze` selects:
 3. otherwise the newest `incomplete` session
 
 Use `--session-id` to analyze a specific capture instead of the default one.
+
+When phase records are present, `gpumemprof analyze` also reports the top
+phase-attributed gap finding and the top first-cause suspect phase in the text
+summary. The JSON report keeps the structured `phase_attribution` payload next
+to:
+
+- `gap_analysis`
+- `collective_attribution`
+- `cross_rank_analysis.first_cause_suspects`
 
 For always-on deployment posture and incident response checklists, continue with
 [Always-on Tracking](cookbook/always_on.md) and
@@ -247,6 +261,10 @@ The same session rules apply to TensorFlow tracking:
 - one session id per `tfmemprof track` run
 - sink recovery marks old running sessions as `interrupted`
 - loaders and diagnostics separate same-host runs by `session_id`, not by job or rank alone
+
+Like the PyTorch and CPU trackers, TensorFlow tracking also preserves optional
+structured phase companion records when you instrument the tracker through the
+Python API.
 
 ### Analyze TensorFlow results
 

--- a/docs/cookbook/always_on.md
+++ b/docs/cookbook/always_on.md
@@ -52,6 +52,42 @@ What this gives you:
 - rollover and pruning under a bounded artifact budget
 - `collector_degraded` and `collector_recovered` events instead of synthetic zero samples
 
+## Add workload phases when timestamps are not enough
+
+Use structured phases when you want long-running artifacts to answer what part
+of the workload was active when a hidden-memory anomaly appeared.
+
+```python
+from stormlog import MemoryTracker
+
+tracker = MemoryTracker(
+    sampling_interval=0.5,
+    telemetry_sink_config=...,
+)
+
+tracker.start_tracking()
+
+for epoch in range(num_epochs):
+    with tracker.phase("train", metadata={"epoch": epoch}):
+        with tracker.phase("load_batch"):
+            batch = next(loader)
+        with tracker.phase("forward"):
+            loss = model(batch).sum()
+        with tracker.phase("backward"):
+            loss.backward()
+        with tracker.phase("optimizer_step"):
+            optimizer.step()
+
+tracker.stop_tracking()
+```
+
+What changes when phases are present:
+
+- `track` writes companion `phase_enter` / `phase_exit` records with deterministic nested paths
+- `gpumemprof analyze` adds phase-aware summaries beside timestamps
+- the TUI Diagnostics tab shows the first anomaly phase path for each rank
+- when you omit instrumentation entirely, the same workflow stays valid and low-overhead
+
 ## TensorFlow always-on baseline
 
 ```bash

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -103,6 +103,19 @@ This demo shows:
 - watchdog cleanup flow
 - exported CSV and JSON tracker events
 
+### Phase-aware tracking
+
+```bash
+python -m examples.advanced.phase_tracking_demo
+```
+
+This demo shows:
+
+- nested `phase()` scopes on a long-running tracker
+- deterministic phase paths such as `train / epoch / forward`
+- exported JSON telemetry that can be reloaded by `gpumemprof analyze`
+- a portable CPU-only way to validate phase-aware instrumentation
+
 ## Scenario modules
 
 These are the closest examples to real operational workflows:

--- a/docs/telemetry_schema.md
+++ b/docs/telemetry_schema.md
@@ -111,10 +111,90 @@ Tracker exports may also emit these lifecycle events:
 - `collector_recovered`
 - `start`
 - `stop`
+- `phase_enter`
+- `phase_exit`
 
 When the collector cannot produce core metrics, Stormlog pauses sample emission
 until the next retry window and records the degraded state instead of exporting
 synthetic zero-valued samples.
+
+## Phase scope records
+
+Long-running trackers can optionally emit structured workload phases as
+companion telemetry records instead of duplicating phase labels on every sample.
+
+Phase boundaries use normal canonical records with:
+
+- `event_type: "phase_enter"`
+- `event_type: "phase_exit"`
+- the normal top-level session, rank, host, pid, collector, and allocator/device fields
+- authoritative structured phase data under `metadata["phase_scope"]`
+
+The `phase_scope` payload contains:
+
+- `action` (`"enter"` or `"exit"`)
+- `name`
+- `path` (ordered list of nested phase names)
+- `depth`
+- `scope_id`
+- `parent_scope_id`
+- `thread_id`
+- `thread_name`
+- `sequence`
+- optional `attributes` (user-supplied phase metadata)
+
+Example:
+
+```json
+{
+  "schema_version": 3,
+  "session_id": "run-123",
+  "timestamp_ns": 1700000000000000000,
+  "event_type": "phase_enter",
+  "collector": "stormlog.cuda_tracker",
+  "sampling_interval_ms": 100,
+  "pid": 1234,
+  "host": "trainer-a",
+  "device_id": 0,
+  "allocator_allocated_bytes": 2147483648,
+  "allocator_reserved_bytes": 2415919104,
+  "allocator_active_bytes": 2147483648,
+  "allocator_inactive_bytes": 268435456,
+  "allocator_change_bytes": 0,
+  "device_used_bytes": 2684354560,
+  "device_free_bytes": 14495514624,
+  "device_total_bytes": 17179869184,
+  "context": "Phase entered: train / forward",
+  "job_id": "train-42",
+  "rank": 0,
+  "local_rank": 0,
+  "world_size": 8,
+  "metadata": {
+    "phase_scope": {
+      "action": "enter",
+      "name": "forward",
+      "path": ["train", "forward"],
+      "depth": 2,
+      "scope_id": "run-123:9",
+      "parent_scope_id": "run-123:4",
+      "thread_id": 140735,
+      "thread_name": "MainThread",
+      "sequence": 9,
+      "attributes": {"microbatch": 12}
+    }
+  }
+}
+```
+
+Semantics:
+
+- phase records are optional; existing workflows remain valid when they are absent
+- nesting is deterministic per `(session_id, rank, thread_id)`
+- `path` is authoritative; `context` is only a human-readable mirror
+- if multiple threads expose overlapping active paths at the same timestamp,
+  analysis reports the attribution as ambiguous instead of inventing one path
+- if a capture ends with an open phase, analysis treats it as active until the
+  session end for attribution only; the raw record stream is unchanged
 
 ## Legacy compatibility
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -82,6 +82,7 @@ The export buttons only work after timeline samples exist. If you have not start
 - rebuilds rank-level diagnostics
 - supports rank filters such as `all`, `0,2,4-7`
 - highlights anomaly indicators and focused rank timelines
+- surfaces the first anomaly phase path when the capture includes structured phase records
 
 ![Diagnostics tab](tui-diagnostics-current.png)
 
@@ -89,6 +90,12 @@ The artifact input field accepts comma-separated paths. Use `Load Artifacts`
 first, then `Refresh` after changing the path set. When multiple sessions are
 found, the Diagnostics tab defaults to the newest `completed` session and lets
 you switch to another one by entering its session id.
+
+If the loaded capture includes `phase_enter` / `phase_exit` telemetry, the
+Diagnostics table shows the first anomaly phase path per rank and the indicator
+details include the resolved phase label. If multiple threads have overlapping
+active phases at the same timestamp, the UI preserves that ambiguity instead of
+guessing one synthetic path.
 
 ### CLI & Actions
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -189,6 +189,39 @@ print(f"Peak memory: {stats.get('peak_memory', 0) / (1024**3):.2f} GB")
 print(f"Events: {stats.get('total_events', 0)}")
 ```
 
+### Mark workload phases explicitly
+
+Use structured phases when you want later analysis to answer not only when
+memory changed, but what part of the workload was active at that time.
+
+```python
+from stormlog import MemoryTracker
+
+tracker = MemoryTracker(sampling_interval=0.5)
+tracker.start_tracking()
+
+with tracker.phase("train", metadata={"epoch": 3}):
+    with tracker.phase("load_batch"):
+        load_next_batch()
+    with tracker.phase("forward"):
+        loss = model(batch).sum()
+    with tracker.phase("backward"):
+        loss.backward()
+
+tracker.stop_tracking()
+tracker.export_events("track.json", format="json")
+```
+
+Notes:
+
+- `phase(name, metadata=None)` is a nested context manager
+- `enter_phase(name, metadata=None)` returns a `PhaseHandle` for manual enter/exit control
+- phases are optional; if you never instrument them, exported telemetry and analysis still work as before
+- nested paths are deterministic per thread, for example `train / forward`
+
+When phase records are present, `gpumemprof analyze` and the TUI Diagnostics tab
+surface phase-aware anomaly summaries instead of only raw timestamps.
+
 If the underlying collector becomes unstable, `MemoryTracker` keeps the tracking
 session alive, exposes collector health through `get_statistics()`, and emits
 `collector_degraded` / `collector_recovered` events instead of exporting
@@ -245,6 +278,10 @@ print(stats["total_events"])
 print(stats["final_retained_files"])
 print(stats["history_dropped_events"])
 ```
+
+`CPUMemoryTracker` supports the same `phase()` and `enter_phase()` APIs, which
+makes it a convenient place to validate phase-aware instrumentation on machines
+without a GPU runtime.
 
 ## Reusing a sink directory across runs
 

--- a/examples/advanced/phase_tracking_demo.py
+++ b/examples/advanced/phase_tracking_demo.py
@@ -1,0 +1,68 @@
+"""Phase-aware tracking demo using nested tracker scopes."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from examples.common import print_header, print_kv, print_section
+from stormlog import CPUMemoryTracker
+
+
+def _load_batch() -> list[list[int]]:
+    batch = [list(range(20_000)) for _ in range(8)]
+    time.sleep(0.05)
+    return batch
+
+
+def _forward_pass(batch: list[list[int]]) -> list[int]:
+    outputs = [sum(chunk) for chunk in batch]
+    time.sleep(0.05)
+    return outputs
+
+
+def _backward_pass(outputs: list[int]) -> list[float]:
+    gradients = [value / 1_000.0 for value in outputs]
+    time.sleep(0.05)
+    return gradients
+
+
+def main() -> None:
+    print_header("Stormlog - Phase Tracking Demo")
+    print_section("Tracking")
+
+    tracker = CPUMemoryTracker(sampling_interval=0.1, max_events=2_000)
+    tracker.start_tracking()
+
+    try:
+        with tracker.phase("train", metadata={"epochs": 2}):
+            for epoch in range(2):
+                with tracker.phase("epoch", metadata={"epoch": epoch}):
+                    with tracker.phase("load_batch"):
+                        batch = _load_batch()
+                    with tracker.phase("forward"):
+                        outputs = _forward_pass(batch)
+                    with tracker.phase("backward"):
+                        _ = _backward_pass(outputs)
+        time.sleep(0.2)
+    finally:
+        tracker.stop_tracking()
+
+    output_dir = Path("artifacts/phase_tracking_demo")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    json_path = output_dir / "phase_track.json"
+    tracker.export_events(str(json_path), format="json")
+
+    stats = tracker.get_statistics()
+    print_section("Summary")
+    print_kv("Total events", stats.get("total_events", 0))
+    print_kv("Dropped events", stats.get("history_dropped_events", 0))
+    print_kv("JSON export", json_path)
+    print(
+        "Next step: run `gpumemprof analyze artifacts/phase_tracking_demo/phase_track.json` "
+        "to inspect phase-aware summaries."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cli/benchmark_harness.py
+++ b/examples/cli/benchmark_harness.py
@@ -10,6 +10,7 @@ import math
 import shutil
 import time
 from collections.abc import Callable, Mapping, Sequence
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional, TypedDict
@@ -381,7 +382,6 @@ def _run_tracked_scenario(
     session = spec.factory(scenario_dir, spec.default_interval, sink_overrides)
     session_started = False
     session_report: dict[str, Any] | None = None
-    scenario_failed = False
     try:
         session.start()
         session_started = True
@@ -412,15 +412,10 @@ def _run_tracked_scenario(
 
         session_report = session.finish()
     except Exception:
-        scenario_failed = True
-        raise
-    finally:
-        if session_started and session_report is None:
-            try:
+        if session_started:
+            with suppress(Exception):
                 session.finish()
-            except Exception:
-                if not scenario_failed:
-                    raise
+        raise
 
     assert session_report is not None
     stats = dict(session_report["stats"])
@@ -584,7 +579,6 @@ def _run_soak_scenario(
     session = spec.factory(scenario_dir, spec.default_interval, None)
     session_started = False
     session_report: dict[str, Any] | None = None
-    scenario_failed = False
     try:
         session.start()
         session_started = True
@@ -612,15 +606,10 @@ def _run_soak_scenario(
 
         session_report = session.finish()
     except Exception:
-        scenario_failed = True
-        raise
-    finally:
-        if session_started and session_report is None:
-            try:
+        if session_started:
+            with suppress(Exception):
                 session.finish()
-            except Exception:
-                if not scenario_failed:
-                    raise
+        raise
 
     assert session_report is not None
     final_rss = _process_rss_bytes()
@@ -675,7 +664,6 @@ def _run_retention_validation(
     session = spec.factory(scenario_dir, spec.default_interval, overrides)
     session_started = False
     session_report: dict[str, Any] | None = None
-    scenario_failed = False
     try:
         session.start()
         session_started = True
@@ -696,15 +684,10 @@ def _run_retention_validation(
 
         session_report = session.finish()
     except Exception:
-        scenario_failed = True
-        raise
-    finally:
-        if session_started and session_report is None:
-            try:
+        if session_started:
+            with suppress(Exception):
                 session.finish()
-            except Exception:
-                if not scenario_failed:
-                    raise
+        raise
 
     assert session_report is not None
     stats = dict(session_report["stats"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,6 @@ stormlog = ["*.txt", "*.md"]
 # Code formatting and linting
 [tool.black]
 line-length = 88
-required-version = "24.3.0"
 target-version = ['py310', 'py311', 'py312']
 include = '\.pyi?$'
 extend-exclude = '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dev = [
     "pexpect>=4.9.0",
     "pytest-textual-snapshot>=1.1.0",
     "jsonschema>=4.0.0",
-    "black>=21.0.0",
+    "black==24.3.0",
     "flake8>=3.8.0",
     "mypy>=0.910",
     "isort>=5.9.0",
@@ -143,6 +143,7 @@ stormlog = ["*.txt", "*.md"]
 # Code formatting and linting
 [tool.black]
 line-length = 88
+required-version = "24.3.0"
 target-version = ['py310', 'py311', 'py312']
 include = '\.pyi?$'
 extend-exclude = '''

--- a/stormlog/analyzer.py
+++ b/stormlog/analyzer.py
@@ -16,6 +16,7 @@ from .collective_attribution import (
 )
 from .distributed_analysis import summarize_cross_rank_analysis
 from .gap_analysis import GapFinding, analyze_hidden_memory_gaps
+from .phases import PhaseTimelineResolver
 from .profiler import GPUMemoryProfiler, ProfileResult
 from .telemetry import TelemetryEventV2
 from .utils import format_bytes
@@ -700,7 +701,12 @@ class MemoryAnalyzer:
     # Hidden-memory gap analysis (operates on TelemetryEventV2 series)
     # ------------------------------------------------------------------
 
-    def analyze_memory_gaps(self, events: List[TelemetryEventV2]) -> List[GapFinding]:
+    def analyze_memory_gaps(
+        self,
+        events: List[TelemetryEventV2],
+        *,
+        phase_resolver: PhaseTimelineResolver | None = None,
+    ) -> List[GapFinding]:
         """Classify allocator-vs-device hidden memory gaps over time.
 
         Args:
@@ -714,22 +720,30 @@ class MemoryAnalyzer:
             thresholds=self.thresholds,
             format_memory=format_bytes,
             remediation_by_classification=_GAP_REMEDIATION_BY_CLASSIFICATION,
+            phase_resolver=phase_resolver,
         )
 
     def analyze_cross_rank_timeline(
-        self, events: List[TelemetryEventV2]
+        self,
+        events: List[TelemetryEventV2],
+        *,
+        phase_resolver: PhaseTimelineResolver | None = None,
     ) -> Dict[str, Any]:
         """Merge rank timelines and detect the earliest cluster-wide spike cause."""
 
-        return summarize_cross_rank_analysis(events)
+        return summarize_cross_rank_analysis(events, phase_resolver=phase_resolver)
 
     def analyze_collective_attribution(
-        self, events: List[TelemetryEventV2]
+        self,
+        events: List[TelemetryEventV2],
+        *,
+        phase_resolver: PhaseTimelineResolver | None = None,
     ) -> List[CollectiveAttributionResult]:
         """Attribute hidden-memory spikes to collective communication phases."""
         return attribute_collective_memory(
             events=events,
             config=self.collective_attribution_config,
+            phase_resolver=phase_resolver,
         )
 
     def generate_optimization_report(
@@ -791,14 +805,24 @@ class MemoryAnalyzer:
 
         # Hidden-memory gap analysis (only when telemetry events are supplied).
         if events is not None:
-            gap_findings = self.analyze_memory_gaps(events)
-            collective_attribution = self.analyze_collective_attribution(events)
+            phase_resolver = PhaseTimelineResolver.from_events(events)
+            gap_findings = self.analyze_memory_gaps(
+                events,
+                phase_resolver=phase_resolver,
+            )
+            collective_attribution = self.analyze_collective_attribution(
+                events,
+                phase_resolver=phase_resolver,
+            )
             report["gap_analysis"] = [asdict(f) for f in gap_findings]
             report["collective_attribution"] = [
                 asdict(result) for result in collective_attribution
             ]
             if len({event.rank for event in events}) > 1:
-                report["cross_rank_analysis"] = self.analyze_cross_rank_timeline(events)
+                report["cross_rank_analysis"] = self.analyze_cross_rank_timeline(
+                    events,
+                    phase_resolver=phase_resolver,
+                )
 
         return report
 

--- a/stormlog/cli.py
+++ b/stormlog/cli.py
@@ -13,6 +13,7 @@ from typing import Any, Optional, Union, cast
 
 import psutil
 
+from .phases import summarize_phase_resolution
 from .telemetry_sink import TelemetrySinkConfig
 from .utils import (
     _detect_gpu_hardware,
@@ -879,15 +880,19 @@ def _input_artifact_size_bytes(path: Path) -> int:
 def _phase_summary_from_payload(payload: Any) -> str | None:
     if not isinstance(payload, dict):
         return None
-    resolution = payload.get("phase_resolution")
     phase_path = payload.get("phase_path")
     phase_paths = payload.get("phase_paths")
-    if resolution == "unique" and isinstance(phase_path, str) and phase_path:
-        return phase_path
-    if resolution == "ambiguous" and isinstance(phase_paths, list):
-        labels = [str(path) for path in phase_paths if str(path)]
-        return " | ".join(labels) if labels else None
-    return None
+    normalized_phase_path = phase_path if isinstance(phase_path, str) else None
+    normalized_phase_paths = (
+        [str(path) for path in phase_paths if str(path)]
+        if isinstance(phase_paths, list)
+        else None
+    )
+    return summarize_phase_resolution(
+        phase_resolution=payload.get("phase_resolution"),
+        phase_path=normalized_phase_path,
+        phase_paths=normalized_phase_paths,
+    )
 
 
 def _build_analyze_summary(

--- a/stormlog/cli.py
+++ b/stormlog/cli.py
@@ -876,6 +876,20 @@ def _input_artifact_size_bytes(path: Path) -> int:
     return 0
 
 
+def _phase_summary_from_payload(payload: Any) -> str | None:
+    if not isinstance(payload, dict):
+        return None
+    resolution = payload.get("phase_resolution")
+    phase_path = payload.get("phase_path")
+    phase_paths = payload.get("phase_paths")
+    if resolution == "unique" and isinstance(phase_path, str) and phase_path:
+        return phase_path
+    if resolution == "ambiguous" and isinstance(phase_paths, list):
+        labels = [str(path) for path in phase_paths if str(path)]
+        return " | ".join(labels) if labels else None
+    return None
+
+
 def _build_analyze_summary(
     input_file: str, file_size_bytes: int, report: dict[str, Any]
 ) -> str:
@@ -891,6 +905,18 @@ def _build_analyze_summary(
 
     if "gap_analysis" in report:
         lines.append(f"Gap findings: {len(report['gap_analysis'])}")
+        if report["gap_analysis"]:
+            top_gap_phase = next(
+                (
+                    _phase_summary_from_payload(item.get("phase_attribution"))
+                    for item in report["gap_analysis"]
+                    if isinstance(item, dict)
+                    and _phase_summary_from_payload(item.get("phase_attribution"))
+                ),
+                None,
+            )
+            if top_gap_phase:
+                lines.append(f"Top gap phase: {top_gap_phase}")
 
     cross_rank_analysis = report.get("cross_rank_analysis")
     if isinstance(cross_rank_analysis, dict):
@@ -925,6 +951,11 @@ def _build_analyze_summary(
                     f"delta={format_bytes(int(top_suspect['peak_delta_bytes']))}",
                 ]
             )
+            top_suspect_phase = _phase_summary_from_payload(
+                top_suspect.get("phase_attribution")
+            )
+            if top_suspect_phase:
+                lines.append(f"Suspect phase: {top_suspect_phase}")
         else:
             lines.append("No qualifying first-cause suspect identified.")
 

--- a/stormlog/collective_attribution.py
+++ b/stormlog/collective_attribution.py
@@ -7,6 +7,7 @@ from typing import Any, Iterable, Mapping, Sequence
 
 import numpy as np
 
+from .phases import PhaseAttribution, PhaseTimelineResolver, merge_phase_attributions
 from .telemetry import TelemetryEventV2
 
 _COLLECTIVE_TOKENS = (
@@ -64,12 +65,14 @@ class CollectiveAttributionResult:
     confidence: float
     reason_codes: list[str] = field(default_factory=list)
     evidence: CollectiveAttributionEvidence | None = None
+    phase_attribution: PhaseAttribution | None = None
 
 
 @dataclass(frozen=True)
 class _RankSpike:
     key: tuple[int, int, int]
     rank: int
+    session_id: str | None
     timestamp_ns: int
     peak_gap_bytes: int
     peak_gap_ratio: float | None
@@ -155,6 +158,7 @@ def attribute_collective_memory(
     config: CollectiveAttributionConfig | None = None,
     preset: str = "medium",
     overrides: Mapping[str, Any] | None = None,
+    phase_resolver: PhaseTimelineResolver | None = None,
 ) -> list[CollectiveAttributionResult]:
     """Attribute hidden-memory spikes to communication phases using hybrid signals."""
 
@@ -198,6 +202,7 @@ def attribute_collective_memory(
                 expected_world_size=expected_world_size,
                 trace_start_ns=trace_start_ns,
                 config=resolved,
+                phase_resolver=phase_resolver,
             )
             if scored is not None and scored.confidence >= resolved.min_confidence:
                 results.append(scored)
@@ -291,6 +296,7 @@ def _detect_rank_spikes(
             _RankSpike(
                 key=(rank, event.timestamp_ns, sample_index),
                 rank=rank,
+                session_id=getattr(event, "session_id", None),
                 timestamp_ns=event.timestamp_ns,
                 peak_gap_bytes=int(gap_bytes),
                 peak_gap_ratio=gap_ratio,
@@ -379,6 +385,7 @@ def _score_spike(
     expected_world_size: int,
     trace_start_ns: int,
     config: CollectiveAttributionConfig,
+    phase_resolver: PhaseTimelineResolver | None,
 ) -> CollectiveAttributionResult | None:
     marker_overlap = bool(spike.marker_times)
     synchronized_count = max(len(synchronized_ranks), 1)
@@ -460,6 +467,14 @@ def _score_spike(
     else:
         classification = "collective_suspect"
 
+    phase_attribution = None
+    if phase_resolver is not None and spike.session_id is not None:
+        phase_attribution = phase_resolver.resolve(
+            timestamp_ns=spike.timestamp_ns,
+            session_id=spike.session_id,
+            rank=spike.rank,
+        )
+
     return CollectiveAttributionResult(
         rank=spike.rank,
         interval_start_ns=interval_start,
@@ -468,6 +483,7 @@ def _score_spike(
         confidence=round(float(confidence), 3),
         reason_codes=sorted(set(reason_codes)),
         evidence=evidence,
+        phase_attribution=phase_attribution,
     )
 
 
@@ -530,6 +546,10 @@ def _merge_rank_intervals(
             confidence=max(prev.confidence, result.confidence),
             reason_codes=sorted(set(prev.reason_codes + result.reason_codes)),
             evidence=merged_evidence,
+            phase_attribution=merge_phase_attributions(
+                prev.phase_attribution,
+                result.phase_attribution,
+            ),
         )
 
     return merged

--- a/stormlog/cpu_profiler.py
+++ b/stormlog/cpu_profiler.py
@@ -10,12 +10,14 @@ import socket
 import threading
 import time
 from collections import deque
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 import psutil
 
+from stormlog.phases import PhaseHandle, TrackerPhaseState
 from stormlog.session import (
     SESSION_STATUS_COMPLETED,
     SESSION_STATUS_INCOMPLETE,
@@ -267,6 +269,7 @@ class CPUMemoryTracker:
         self._session_summary: Optional[SessionSummary] = None
         self._history_dropped_events = 0
         self._last_sink_diagnostics: Dict[str, int] = self._empty_sink_diagnostics()
+        self._phase_state = TrackerPhaseState()
 
         self.stats: Dict[str, Any] = {
             "tracking_start_time": None,
@@ -321,6 +324,7 @@ class CPUMemoryTracker:
         if self.is_tracking:
             return
         self._session_summary = None
+        self._phase_state.reset()
         self._ensure_telemetry_sink()
         self._stop_event.clear()
         with self._events_lock:
@@ -353,6 +357,7 @@ class CPUMemoryTracker:
                 self._session_summary,
                 ended_at_ns=now_ns(),
             )
+        self._phase_state.reset()
 
     def _tracking_loop(self) -> None:
         last_rss = self._current_rss()
@@ -395,7 +400,13 @@ class CPUMemoryTracker:
             last_rss = current_rss
             self._flush_telemetry_sink()
 
-    def _add_event(self, event_type: str, memory_change: int, context: str) -> None:
+    def _add_event(
+        self,
+        event_type: str,
+        memory_change: int,
+        context: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
         rss = self._current_rss()
         event = TrackingEvent(
             timestamp=time.time(),
@@ -414,12 +425,67 @@ class CPUMemoryTracker:
             rank=self.distributed_identity["rank"],
             local_rank=self.distributed_identity["local_rank"],
             world_size=self.distributed_identity["world_size"],
+            metadata=dict(metadata or {}),
         )
         with self._events_lock:
             if len(self.events) == self.max_events:
                 self._history_dropped_events += 1
             self.events.append(event)
         self._append_to_telemetry_sink(event)
+
+    def enter_phase(
+        self, name: str, *, metadata: Optional[Dict[str, Any]] = None
+    ) -> PhaseHandle:
+        """Enter one structured CPU tracking phase."""
+        if not self.is_tracking:
+            raise RuntimeError("Tracking must be active before entering a phase.")
+        session = self._open_session()
+        boundary = self._phase_state.enter_phase(
+            session_id=session.session_id,
+            rank=self.distributed_identity["rank"],
+            name=name,
+            metadata=metadata,
+        )
+        self._add_event(
+            boundary.event_type,
+            0,
+            boundary.context,
+            metadata=boundary.metadata,
+        )
+        return PhaseHandle(
+            scope_id=boundary.scope_id,
+            name=name,
+            path=boundary.path,
+            close_callback=lambda: self._emit_phase_exit(boundary.scope_id),
+        )
+
+    @contextmanager
+    def phase(self, name: str, *, metadata: Optional[Dict[str, Any]] = None) -> Any:
+        """Context manager that emits structured CPU phase telemetry."""
+        handle = self.enter_phase(name, metadata=metadata)
+        try:
+            yield handle
+        finally:
+            handle.close()
+
+    def _emit_phase_exit(self, scope_id: str) -> None:
+        session = self._session_summary
+        if session is None:
+            return
+        boundary = self._phase_state.exit_phase(
+            session_id=session.session_id,
+            rank=self.distributed_identity["rank"],
+            scope_id=scope_id,
+            thread_id=int(threading.current_thread().ident or 0),
+        )
+        if boundary is None:
+            return
+        self._add_event(
+            boundary.event_type,
+            0,
+            boundary.context,
+            metadata=boundary.metadata,
+        )
 
     def _telemetry_record_from_event(self, event: TrackingEvent) -> Dict[str, Any]:
         host = socket.gethostname()
@@ -445,6 +511,7 @@ class CPUMemoryTracker:
                     "rank": event.rank,
                     "local_rank": event.local_rank,
                     "world_size": event.world_size,
+                    "metadata": dict(event.metadata or {}),
                     "collector": "stormlog.cpu_tracker",
                     "sampling_interval_ms": sampling_interval_ms,
                     "pid": pid,

--- a/stormlog/distributed_analysis.py
+++ b/stormlog/distributed_analysis.py
@@ -7,6 +7,7 @@ from dataclasses import asdict, dataclass, field
 from statistics import median
 from typing import Any, Sequence
 
+from .phases import PhaseAttribution, PhaseTimelineResolver
 from .telemetry import TelemetryEventV2
 
 _SPIKE_MIN_BYTES = 64 * 1024**2
@@ -52,6 +53,7 @@ class FirstCauseSuspect:
     lead_over_cluster_onset_ns: int
     confidence: str
     evidence: dict[str, int | str]
+    phase_attribution: PhaseAttribution | None = None
 
 
 @dataclass
@@ -66,6 +68,7 @@ class FirstCauseAnalysisResult:
 @dataclass
 class _RankSpikeCandidate:
     rank: int
+    session_id: str | None
     first_spike_timestamp_ns: int
     aligned_first_spike_timestamp_ns: int
     peak_delta_bytes: int
@@ -286,6 +289,7 @@ def _find_rank_spike_candidate(
         spike_event = rank_events[index]
         return _RankSpikeCandidate(
             rank=spike_event.rank,
+            session_id=getattr(spike_event, "session_id", None),
             first_spike_timestamp_ns=spike_event.timestamp_ns,
             aligned_first_spike_timestamp_ns=spike_event.timestamp_ns - offset_ns,
             peak_delta_bytes=cumulative_delta,
@@ -298,6 +302,7 @@ def _find_rank_spike_candidate(
 def _detect_first_cause_spikes(
     grouped: dict[int, list[TelemetryEventV2]],
     merge_result: CrossRankMergeResult,
+    phase_resolver: PhaseTimelineResolver | None = None,
 ) -> FirstCauseAnalysisResult:
     if not grouped:
         return FirstCauseAnalysisResult(
@@ -417,6 +422,15 @@ def _detect_first_cause_spikes(
                     "device_used_delta_bytes": candidate.peak_delta_bytes,
                     "supporting_ranks_at_or_before_onset": support_count,
                 },
+                phase_attribution=(
+                    phase_resolver.resolve(
+                        timestamp_ns=candidate.first_spike_timestamp_ns,
+                        session_id=candidate.session_id,
+                        rank=candidate.rank,
+                    )
+                    if phase_resolver is not None and candidate.session_id is not None
+                    else None
+                ),
             )
         )
 
@@ -429,6 +443,8 @@ def _detect_first_cause_spikes(
 
 def analyze_cross_rank_events(
     events: Sequence[TelemetryEventV2],
+    *,
+    phase_resolver: PhaseTimelineResolver | None = None,
 ) -> tuple[CrossRankMergeResult, FirstCauseAnalysisResult]:
     """Analyze distributed telemetry for merged timelines and first-cause spikes."""
 
@@ -441,14 +457,25 @@ def analyze_cross_rank_events(
             notes=selection_notes or list(merge_result.notes),
         )
     grouped = _group_events_by_rank(analysis_events)
-    first_cause_result = _detect_first_cause_spikes(grouped, merge_result)
+    first_cause_result = _detect_first_cause_spikes(
+        grouped,
+        merge_result,
+        phase_resolver=phase_resolver,
+    )
     return merge_result, first_cause_result
 
 
-def summarize_cross_rank_analysis(events: Sequence[TelemetryEventV2]) -> dict[str, Any]:
+def summarize_cross_rank_analysis(
+    events: Sequence[TelemetryEventV2],
+    *,
+    phase_resolver: PhaseTimelineResolver | None = None,
+) -> dict[str, Any]:
     """Return a JSON-serializable cross-rank analysis summary."""
 
-    merge_result, first_cause_result = analyze_cross_rank_events(events)
+    merge_result, first_cause_result = analyze_cross_rank_events(
+        events,
+        phase_resolver=phase_resolver,
+    )
     notes = list(dict.fromkeys([*merge_result.notes, *first_cause_result.notes]))
     return {
         "job_id": merge_result.job_id,

--- a/stormlog/gap_analysis.py
+++ b/stormlog/gap_analysis.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, List, Mapping, Sequence
 import numpy as np
 from scipy import stats
 
+from .phases import PhaseAttribution, PhaseTimelineResolver
 from .telemetry import TelemetryEventV2
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,6 +23,8 @@ class GapFinding:
     evidence: dict[str, Any]
     description: str
     remediation: List[str]
+    evidence_timestamp_ns: int | None = None
+    phase_attribution: PhaseAttribution | None = None
 
 
 def analyze_hidden_memory_gaps(
@@ -29,6 +32,7 @@ def analyze_hidden_memory_gaps(
     thresholds: Mapping[str, float],
     format_memory: Callable[[int], str],
     remediation_by_classification: Mapping[str, List[str]],
+    phase_resolver: PhaseTimelineResolver | None = None,
 ) -> List[GapFinding]:
     """Classify allocator-vs-device hidden memory gaps over time."""
     gaps: List[float] = []
@@ -37,6 +41,8 @@ def analyze_hidden_memory_gaps(
     usable_events: List[TelemetryEventV2] = []
 
     for event in events:
+        if str(event.event_type).strip().lower() != "sample":
+            continue
         if event.device_total_bytes is None or event.device_total_bytes <= 0:
             continue
         gap = event.device_used_bytes - event.allocator_reserved_bytes
@@ -59,18 +65,22 @@ def analyze_hidden_memory_gaps(
     findings: List[GapFinding] = []
     findings.extend(
         _detect_gap_transient_spikes(
+            events=usable_events,
             gaps=gaps,
             z_threshold=thresholds["gap_spike_zscore"],
             remediation=remediation_by_classification.get("transient_spike", []),
+            phase_resolver=phase_resolver,
         )
     )
     findings.extend(
         _detect_gap_persistent_drift(
+            events=usable_events,
             gaps=gaps,
             timestamps_ns=timestamps_ns,
             drift_r_squared_threshold=thresholds["gap_drift_r_squared"],
             format_memory=format_memory,
             remediation=remediation_by_classification.get("persistent_drift", []),
+            phase_resolver=phase_resolver,
         )
     )
     findings.extend(
@@ -79,6 +89,7 @@ def analyze_hidden_memory_gaps(
             gaps=gaps,
             fragmentation_threshold=thresholds["gap_fragmentation_ratio"],
             remediation=remediation_by_classification.get("fragmentation_like", []),
+            phase_resolver=phase_resolver,
         )
     )
 
@@ -95,9 +106,11 @@ def analyze_hidden_memory_gaps(
 
 
 def _detect_gap_transient_spikes(
+    events: Sequence[TelemetryEventV2],
     gaps: List[float],
     z_threshold: float,
     remediation: List[str],
+    phase_resolver: PhaseTimelineResolver | None,
 ) -> List[GapFinding]:
     """Detect transient spikes in the gap series using z-score."""
     arr = np.asarray(gaps, dtype=float)
@@ -117,6 +130,7 @@ def _detect_gap_transient_spikes(
     max_idx = int(np.argmax(arr))
     max_gap = float(arr[max_idx])
     max_z = (max_gap - mean) / std
+    phase_event = events[max_idx]
 
     severity = "critical" if max_z > 2 * z_threshold else "warning"
     confidence = min(1.0, max_z / (3 * z_threshold))
@@ -138,16 +152,20 @@ def _detect_gap_transient_spikes(
                 f"device-vs-allocator gap (max z-score {max_z:.1f})."
             ),
             remediation=list(remediation),
+            evidence_timestamp_ns=phase_event.timestamp_ns,
+            phase_attribution=_resolve_phase_attribution(phase_resolver, phase_event),
         )
     ]
 
 
 def _detect_gap_persistent_drift(
+    events: Sequence[TelemetryEventV2],
     gaps: List[float],
     timestamps_ns: List[int],
     drift_r_squared_threshold: float,
     format_memory: Callable[[int], str],
     remediation: List[str],
+    phase_resolver: PhaseTimelineResolver | None,
 ) -> List[GapFinding]:
     """Detect persistent upward drift in the gap via linear regression."""
     if len(gaps) < 5:
@@ -166,6 +184,7 @@ def _detect_gap_persistent_drift(
     severity = "critical" if r_squared > 0.85 else "warning"
     confidence = round(min(1.0, r_squared), 3)
     slope_bytes_per_sec = slope * 1e9
+    phase_event = events[-1]
 
     return [
         GapFinding(
@@ -185,6 +204,8 @@ def _detect_gap_persistent_drift(
                 f"(R²={r_squared:.2f})."
             ),
             remediation=list(remediation),
+            evidence_timestamp_ns=phase_event.timestamp_ns,
+            phase_attribution=_resolve_phase_attribution(phase_resolver, phase_event),
         )
     ]
 
@@ -194,14 +215,17 @@ def _detect_gap_fragmentation_pattern(
     gaps: List[float],
     fragmentation_threshold: float,
     remediation: List[str],
+    phase_resolver: PhaseTimelineResolver | None,
 ) -> List[GapFinding]:
     """Detect fragmentation-like behaviour: high reserved-allocated ratio."""
     frag_ratios: List[float] = []
+    frag_events: List[TelemetryEventV2] = []
     for event in events:
         reserved = event.allocator_reserved_bytes
         allocated = event.allocator_allocated_bytes
         if reserved > 0:
             frag_ratios.append((reserved - allocated) / reserved)
+            frag_events.append(event)
 
     if not frag_ratios:
         return []
@@ -213,6 +237,7 @@ def _detect_gap_fragmentation_pattern(
 
     severity = "critical" if avg_frag > 0.5 else "warning"
     confidence = round(min(1.0, avg_frag / 0.6), 3)
+    phase_event = frag_events[int(np.argmax(frag_ratios))]
 
     return [
         GapFinding(
@@ -230,5 +255,16 @@ def _detect_gap_fragmentation_pattern(
                 f"reserved-but-unused memory is inflating the device footprint."
             ),
             remediation=list(remediation),
+            evidence_timestamp_ns=phase_event.timestamp_ns,
+            phase_attribution=_resolve_phase_attribution(phase_resolver, phase_event),
         )
     ]
+
+
+def _resolve_phase_attribution(
+    phase_resolver: PhaseTimelineResolver | None,
+    event: TelemetryEventV2,
+) -> PhaseAttribution | None:
+    if phase_resolver is None:
+        return None
+    return phase_resolver.resolve_for_event(event)

--- a/stormlog/phases.py
+++ b/stormlog/phases.py
@@ -1,0 +1,536 @@
+"""Structured phase telemetry helpers for long-running trackers and analysis."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping, Sequence
+
+PHASE_ENTER_EVENT = "phase_enter"
+PHASE_EXIT_EVENT = "phase_exit"
+PHASE_SCOPE_METADATA_KEY = "phase_scope"
+PHASE_SCOPE_ATTRIBUTES_KEY = "attributes"
+
+
+def format_phase_path(path: Sequence[str]) -> str:
+    """Return a human-readable phase path label."""
+    return " / ".join(part for part in path if part)
+
+
+def is_phase_boundary_event(event: Any) -> bool:
+    """Return ``True`` when the event is a structured phase boundary."""
+    event_type = _event_field(event, "event_type", "")
+    if event_type not in {PHASE_ENTER_EVENT, PHASE_EXIT_EVENT}:
+        return False
+    return extract_phase_scope(event) is not None
+
+
+@dataclass(frozen=True)
+class PhaseAttribution:
+    """Resolved workload phase attribution for an anomaly or report item."""
+
+    phase_resolution: str
+    phase_path: str | None = None
+    phase_paths: list[str] = field(default_factory=list)
+    scope_id: str | None = None
+    thread_id: int | None = None
+    thread_name: str | None = None
+
+
+class PhaseHandle:
+    """A closeable tracker phase handle returned by ``enter_phase()``."""
+
+    def __init__(
+        self,
+        *,
+        scope_id: str,
+        name: str,
+        path: tuple[str, ...],
+        close_callback: Callable[[], None],
+    ) -> None:
+        self.scope_id = scope_id
+        self.name = name
+        self.path = path
+        self._close_callback = close_callback
+        self._closed = False
+
+    @property
+    def phase_path(self) -> str:
+        """Return the formatted phase path."""
+        return format_phase_path(self.path)
+
+    @property
+    def closed(self) -> bool:
+        """Return ``True`` once the handle has been closed."""
+        return self._closed
+
+    def close(self) -> Any:
+        """Close the phase handle once."""
+        if self._closed:
+            return None
+        result = self._close_callback()
+        self._closed = True
+        return result
+
+    def __enter__(self) -> "PhaseHandle":
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.close()
+
+
+@dataclass(frozen=True)
+class _PhaseBoundary:
+    event_type: str
+    context: str
+    metadata: dict[str, Any]
+    scope_id: str
+    path: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _ActivePhase:
+    session_id: str
+    rank: int
+    thread_id: int
+    thread_name: str
+    scope_id: str
+    parent_scope_id: str | None
+    name: str
+    path: tuple[str, ...]
+    sequence: int
+    attributes: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class _PhaseInterval:
+    session_id: str
+    rank: int
+    thread_id: int
+    thread_name: str
+    scope_id: str
+    path: tuple[str, ...]
+    start_ns: int
+    end_ns: int
+    sequence: int
+    synthetic_end: bool = False
+
+    @property
+    def depth(self) -> int:
+        return len(self.path)
+
+
+class TrackerPhaseState:
+    """Per-tracker phase nesting state and boundary payload generation."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._sequence = 0
+        self._active_by_thread: dict[tuple[str, int, int], list[_ActivePhase]] = {}
+
+    def reset(self) -> None:
+        """Drop all active phase scopes for a new tracker session."""
+        with self._lock:
+            self._sequence = 0
+            self._active_by_thread.clear()
+
+    def enter_phase(
+        self,
+        *,
+        session_id: str,
+        rank: int,
+        name: str,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> _PhaseBoundary:
+        """Register one nested phase enter transition."""
+        normalized_name = _normalize_phase_name(name)
+        thread = threading.current_thread()
+        thread_id = int(thread.ident or 0)
+        thread_name = thread.name or f"thread-{thread_id}"
+        attributes = dict(metadata or {})
+
+        with self._lock:
+            key = (session_id, rank, thread_id)
+            stack = self._active_by_thread.setdefault(key, [])
+            parent = stack[-1] if stack else None
+            self._sequence += 1
+            scope_id = f"{session_id}:{self._sequence}"
+            path = (
+                (*parent.path, normalized_name)
+                if parent is not None
+                else (normalized_name,)
+            )
+            active = _ActivePhase(
+                session_id=session_id,
+                rank=rank,
+                thread_id=thread_id,
+                thread_name=thread_name,
+                scope_id=scope_id,
+                parent_scope_id=parent.scope_id if parent is not None else None,
+                name=normalized_name,
+                path=path,
+                sequence=self._sequence,
+                attributes=attributes,
+            )
+            stack.append(active)
+
+        boundary = _PhaseBoundary(
+            event_type=PHASE_ENTER_EVENT,
+            context=f"Phase entered: {format_phase_path(path)}",
+            metadata={
+                PHASE_SCOPE_METADATA_KEY: _phase_scope_payload(active, action="enter")
+            },
+            scope_id=scope_id,
+            path=path,
+        )
+        return boundary
+
+    def exit_phase(
+        self,
+        *,
+        session_id: str,
+        rank: int,
+        scope_id: str,
+        thread_id: int,
+    ) -> _PhaseBoundary | None:
+        """Register one nested phase exit transition."""
+        with self._lock:
+            key = (session_id, rank, thread_id)
+            stack = self._active_by_thread.get(key)
+            if not stack:
+                return None
+
+            active = stack[-1]
+            if active.scope_id != scope_id:
+                raise RuntimeError(
+                    "Phase handles must be closed in strict LIFO order per thread."
+                )
+
+            stack.pop()
+            if not stack:
+                self._active_by_thread.pop(key, None)
+            self._sequence += 1
+            closed = _ActivePhase(
+                session_id=active.session_id,
+                rank=active.rank,
+                thread_id=active.thread_id,
+                thread_name=active.thread_name,
+                scope_id=active.scope_id,
+                parent_scope_id=active.parent_scope_id,
+                name=active.name,
+                path=active.path,
+                sequence=self._sequence,
+                attributes=active.attributes,
+            )
+
+        return _PhaseBoundary(
+            event_type=PHASE_EXIT_EVENT,
+            context=f"Phase exited: {format_phase_path(closed.path)}",
+            metadata={
+                PHASE_SCOPE_METADATA_KEY: _phase_scope_payload(closed, action="exit")
+            },
+            scope_id=closed.scope_id,
+            path=closed.path,
+        )
+
+
+class PhaseTimelineResolver:
+    """Replay phase boundaries and resolve the active phase path at a timestamp."""
+
+    def __init__(
+        self, intervals_by_group: Mapping[tuple[str, int], Sequence[_PhaseInterval]]
+    ) -> None:
+        self._intervals_by_group = {
+            key: tuple(sorted(intervals, key=lambda item: (item.start_ns, item.end_ns)))
+            for key, intervals in intervals_by_group.items()
+        }
+
+    @classmethod
+    def from_events(cls, events: Sequence[Any]) -> "PhaseTimelineResolver":
+        """Build a replay index from telemetry events."""
+        session_end_by_group: dict[tuple[str, int], int] = {}
+        boundaries: list[tuple[int, int, str, int, _NormalizedPhaseScope]] = []
+        for event in events:
+            session_id = _event_field(event, "session_id")
+            timestamp_ns = _event_field(event, "timestamp_ns")
+            if not isinstance(session_id, str) or not isinstance(timestamp_ns, int):
+                continue
+            rank = int(_event_field(event, "rank", 0))
+            group_key = (session_id, rank)
+            previous_end = session_end_by_group.get(group_key)
+            if previous_end is None or timestamp_ns > previous_end:
+                session_end_by_group[group_key] = timestamp_ns
+
+            scope = extract_phase_scope(event)
+            if scope is None:
+                continue
+            boundaries.append(
+                (
+                    timestamp_ns,
+                    scope.sequence,
+                    scope.scope_id,
+                    rank,
+                    scope,
+                )
+            )
+
+        boundaries.sort(
+            key=lambda item: (item[4].session_id, item[3], item[0], item[1], item[2])
+        )
+
+        active_by_thread: dict[tuple[str, int, int], list[_NormalizedPhaseScope]] = {}
+        intervals_by_group: dict[tuple[str, int], list[_PhaseInterval]] = {}
+        for timestamp_ns, _, _, rank, scope in boundaries:
+            thread_key = (scope.session_id, rank, scope.thread_id)
+            stack = active_by_thread.setdefault(thread_key, [])
+            if scope.action == "enter":
+                stack.append(scope)
+                continue
+            if not stack or stack[-1].scope_id != scope.scope_id:
+                continue
+            opened = stack.pop()
+            if not stack:
+                active_by_thread.pop(thread_key, None)
+            intervals_by_group.setdefault((scope.session_id, rank), []).append(
+                _PhaseInterval(
+                    session_id=scope.session_id,
+                    rank=rank,
+                    thread_id=scope.thread_id,
+                    thread_name=scope.thread_name,
+                    scope_id=scope.scope_id,
+                    path=opened.path,
+                    start_ns=opened.timestamp_ns,
+                    end_ns=timestamp_ns,
+                    sequence=opened.sequence,
+                )
+            )
+
+        for (session_id, rank, _thread_id), stack in active_by_thread.items():
+            session_end_ns = session_end_by_group.get((session_id, rank))
+            if session_end_ns is None:
+                continue
+            for scope in stack:
+                intervals_by_group.setdefault((session_id, rank), []).append(
+                    _PhaseInterval(
+                        session_id=session_id,
+                        rank=rank,
+                        thread_id=scope.thread_id,
+                        thread_name=scope.thread_name,
+                        scope_id=scope.scope_id,
+                        path=scope.path,
+                        start_ns=scope.timestamp_ns,
+                        end_ns=session_end_ns,
+                        sequence=scope.sequence,
+                        synthetic_end=True,
+                    )
+                )
+
+        return cls(intervals_by_group)
+
+    def resolve(
+        self,
+        *,
+        timestamp_ns: int,
+        session_id: str | None,
+        rank: int | None = None,
+    ) -> PhaseAttribution | None:
+        """Resolve the active phase path at one timestamp."""
+        thread_matches: list[_PhaseInterval] = []
+        ambiguous_labels: set[str] = set()
+
+        for (
+            group_session_id,
+            group_rank,
+        ), intervals in self._intervals_by_group.items():
+            if session_id is not None and group_session_id != session_id:
+                continue
+            if rank is not None and group_rank != rank:
+                continue
+
+            deepest_by_thread: dict[int, list[_PhaseInterval]] = {}
+            for interval in intervals:
+                if interval.start_ns <= timestamp_ns <= interval.end_ns:
+                    deepest_by_thread.setdefault(interval.thread_id, []).append(
+                        interval
+                    )
+
+            for thread_intervals in deepest_by_thread.values():
+                max_depth = max(item.depth for item in thread_intervals)
+                deepest = [item for item in thread_intervals if item.depth == max_depth]
+                labels = {format_phase_path(item.path) for item in deepest}
+                if len(labels) != 1:
+                    ambiguous_labels.update(labels)
+                    continue
+                thread_matches.append(
+                    max(deepest, key=lambda item: (item.sequence, item.scope_id))
+                )
+
+        if not thread_matches and not ambiguous_labels:
+            return None
+
+        if ambiguous_labels or len(thread_matches) != 1:
+            phase_paths = sorted(
+                ambiguous_labels
+                | {format_phase_path(interval.path) for interval in thread_matches}
+            )
+            return PhaseAttribution(
+                phase_resolution="ambiguous",
+                phase_paths=phase_paths,
+            )
+
+        match = thread_matches[0]
+        phase_path = format_phase_path(match.path)
+        return PhaseAttribution(
+            phase_resolution="unique",
+            phase_path=phase_path,
+            phase_paths=[phase_path],
+            scope_id=match.scope_id,
+            thread_id=match.thread_id,
+            thread_name=match.thread_name,
+        )
+
+    def resolve_for_event(self, event: Any) -> PhaseAttribution | None:
+        """Resolve phase attribution for one telemetry event-like object."""
+        timestamp_ns = _event_field(event, "timestamp_ns")
+        session_id = _event_field(event, "session_id")
+        if not isinstance(timestamp_ns, int) or not isinstance(session_id, str):
+            return None
+        return self.resolve(
+            timestamp_ns=timestamp_ns,
+            session_id=session_id,
+            rank=int(_event_field(event, "rank", 0)),
+        )
+
+
+@dataclass(frozen=True)
+class _NormalizedPhaseScope:
+    action: str
+    name: str
+    path: tuple[str, ...]
+    depth: int
+    scope_id: str
+    parent_scope_id: str | None
+    thread_id: int
+    thread_name: str
+    sequence: int
+    session_id: str
+    timestamp_ns: int
+    attributes: dict[str, Any]
+
+
+def extract_phase_scope(event: Any) -> _NormalizedPhaseScope | None:
+    """Extract one normalized phase payload from an event-like object."""
+    metadata = _event_field(event, "metadata", {})
+    if not isinstance(metadata, Mapping):
+        return None
+    raw_scope = metadata.get(PHASE_SCOPE_METADATA_KEY)
+    if not isinstance(raw_scope, Mapping):
+        return None
+    session_id = _event_field(event, "session_id")
+    timestamp_ns = _event_field(event, "timestamp_ns")
+    if not isinstance(session_id, str) or not isinstance(timestamp_ns, int):
+        return None
+    action = raw_scope.get("action")
+    name = raw_scope.get("name")
+    scope_id = raw_scope.get("scope_id")
+    path = raw_scope.get("path")
+    thread_name = raw_scope.get("thread_name")
+    if (
+        not isinstance(action, str)
+        or action not in {"enter", "exit"}
+        or not isinstance(name, str)
+        or not name.strip()
+        or not isinstance(scope_id, str)
+        or not isinstance(thread_name, str)
+        or not isinstance(path, list)
+    ):
+        return None
+    normalized_path = tuple(
+        str(part) for part in path if isinstance(part, str) and part
+    )
+    if not normalized_path:
+        return None
+    depth_value = raw_scope.get("depth")
+    sequence_value = raw_scope.get("sequence")
+    thread_id_value = raw_scope.get("thread_id")
+    parent_scope_id_value = raw_scope.get("parent_scope_id")
+    if not isinstance(depth_value, int) or depth_value != len(normalized_path):
+        depth_value = len(normalized_path)
+    if not isinstance(sequence_value, int):
+        return None
+    if not isinstance(thread_id_value, int):
+        return None
+    if parent_scope_id_value is not None and not isinstance(parent_scope_id_value, str):
+        return None
+    raw_attributes = raw_scope.get(PHASE_SCOPE_ATTRIBUTES_KEY, {})
+    attributes = dict(raw_attributes) if isinstance(raw_attributes, Mapping) else {}
+    return _NormalizedPhaseScope(
+        action=action,
+        name=name.strip(),
+        path=normalized_path,
+        depth=depth_value,
+        scope_id=scope_id,
+        parent_scope_id=parent_scope_id_value,
+        thread_id=thread_id_value,
+        thread_name=thread_name,
+        sequence=sequence_value,
+        session_id=session_id,
+        timestamp_ns=timestamp_ns,
+        attributes=attributes,
+    )
+
+
+def summarize_phase_attribution(attribution: PhaseAttribution | None) -> str | None:
+    """Return a user-facing summary string for one phase attribution."""
+    if attribution is None:
+        return None
+    if attribution.phase_resolution == "unique" and attribution.phase_path:
+        return attribution.phase_path
+    if attribution.phase_resolution == "ambiguous" and attribution.phase_paths:
+        return " | ".join(attribution.phase_paths)
+    return None
+
+
+def _normalize_phase_name(name: str) -> str:
+    normalized = str(name).strip()
+    if not normalized:
+        raise ValueError("phase name must be a non-empty string")
+    return normalized
+
+
+def _phase_scope_payload(active: _ActivePhase, *, action: str) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "action": action,
+        "name": active.name,
+        "path": list(active.path),
+        "depth": len(active.path),
+        "scope_id": active.scope_id,
+        "parent_scope_id": active.parent_scope_id,
+        "thread_id": active.thread_id,
+        "thread_name": active.thread_name,
+        "sequence": active.sequence,
+    }
+    if active.attributes:
+        payload[PHASE_SCOPE_ATTRIBUTES_KEY] = dict(active.attributes)
+    return payload
+
+
+def _event_field(event: Any, field_name: str, default: Any = None) -> Any:
+    if isinstance(event, Mapping):
+        return event.get(field_name, default)
+    return getattr(event, field_name, default)
+
+
+__all__ = [
+    "PHASE_ENTER_EVENT",
+    "PHASE_EXIT_EVENT",
+    "PHASE_SCOPE_METADATA_KEY",
+    "PhaseAttribution",
+    "PhaseHandle",
+    "PhaseTimelineResolver",
+    "TrackerPhaseState",
+    "extract_phase_scope",
+    "format_phase_path",
+    "is_phase_boundary_event",
+    "summarize_phase_attribution",
+]

--- a/stormlog/phases.py
+++ b/stormlog/phases.py
@@ -491,11 +491,59 @@ def summarize_phase_attribution(attribution: PhaseAttribution | None) -> str | N
     return None
 
 
+def merge_phase_attributions(
+    first: PhaseAttribution | None,
+    second: PhaseAttribution | None,
+) -> PhaseAttribution | None:
+    """Merge two attribution candidates without inventing a false unique path."""
+    if first is None:
+        return second
+    if second is None:
+        return first
+
+    first_paths = _phase_paths(first)
+    second_paths = _phase_paths(second)
+    if not first_paths:
+        return second
+    if not second_paths:
+        return first
+
+    merged_paths = sorted(set(first_paths) | set(second_paths))
+    if len(merged_paths) == 1:
+        phase_path = merged_paths[0]
+        if (
+            first.phase_resolution == "unique"
+            and second.phase_resolution == "unique"
+            and first.phase_path == second.phase_path
+            and first.scope_id == second.scope_id
+            and first.thread_id == second.thread_id
+        ):
+            return first
+        return PhaseAttribution(
+            phase_resolution="unique",
+            phase_path=phase_path,
+            phase_paths=[phase_path],
+        )
+
+    return PhaseAttribution(
+        phase_resolution="ambiguous",
+        phase_paths=merged_paths,
+    )
+
+
 def _normalize_phase_name(name: str) -> str:
     normalized = str(name).strip()
     if not normalized:
         raise ValueError("phase name must be a non-empty string")
     return normalized
+
+
+def _phase_paths(attribution: PhaseAttribution) -> list[str]:
+    if attribution.phase_paths:
+        return [path for path in attribution.phase_paths if path]
+    if attribution.phase_path:
+        return [attribution.phase_path]
+    return []
 
 
 def _phase_scope_payload(active: _ActivePhase, *, action: str) -> dict[str, Any]:
@@ -532,5 +580,6 @@ __all__ = [
     "extract_phase_scope",
     "format_phase_path",
     "is_phase_boundary_event",
+    "merge_phase_attributions",
     "summarize_phase_attribution",
 ]

--- a/stormlog/phases.py
+++ b/stormlog/phases.py
@@ -484,10 +484,29 @@ def summarize_phase_attribution(attribution: PhaseAttribution | None) -> str | N
     """Return a user-facing summary string for one phase attribution."""
     if attribution is None:
         return None
-    if attribution.phase_resolution == "unique" and attribution.phase_path:
-        return attribution.phase_path
-    if attribution.phase_resolution == "ambiguous" and attribution.phase_paths:
-        return " | ".join(attribution.phase_paths)
+    return summarize_phase_resolution(
+        phase_resolution=attribution.phase_resolution,
+        phase_path=attribution.phase_path,
+        phase_paths=attribution.phase_paths,
+    )
+
+
+def summarize_phase_resolution(
+    *,
+    phase_resolution: str | None,
+    phase_path: str | None = None,
+    phase_paths: Sequence[str] | None = None,
+) -> str | None:
+    """Render one phase resolution without hiding ambiguity semantics."""
+    labels = [path for path in (phase_paths or ()) if path]
+    if phase_resolution == "unique":
+        if phase_path:
+            return phase_path
+        if len(labels) == 1:
+            return labels[0]
+        return None
+    if phase_resolution == "ambiguous" and labels:
+        return f"(ambiguous) {' | '.join(labels)}"
     return None
 
 
@@ -520,8 +539,7 @@ def merge_phase_attributions(
         ):
             return first
         return PhaseAttribution(
-            phase_resolution="unique",
-            phase_path=phase_path,
+            phase_resolution="ambiguous",
             phase_paths=[phase_path],
         )
 
@@ -582,4 +600,5 @@ __all__ = [
     "is_phase_boundary_event",
     "merge_phase_attributions",
     "summarize_phase_attribution",
+    "summarize_phase_resolution",
 ]

--- a/stormlog/session.py
+++ b/stormlog/session.py
@@ -53,7 +53,7 @@ class _HasSummary(Protocol):
     summary: SessionSummary
 
 
-_SessionLikeT = TypeVar("_SessionLikeT", SessionSummary, _HasSummary)
+_SessionLikeT = TypeVar("_SessionLikeT", bound=SessionSummary | _HasSummary)
 
 
 def now_ns() -> int:

--- a/stormlog/tensorflow/analyzer.py
+++ b/stormlog/tensorflow/analyzer.py
@@ -14,6 +14,7 @@ from stormlog.collective_attribution import (
     resolve_collective_attribution_config,
 )
 from stormlog.gap_analysis import GapFinding, analyze_hidden_memory_gaps
+from stormlog.phases import PhaseTimelineResolver
 from stormlog.telemetry import TelemetryEventV2
 
 from .utils import format_memory
@@ -346,7 +347,12 @@ class MemoryAnalyzer:
     # Hidden-memory gap analysis (operates on TelemetryEventV2 series)
     # ------------------------------------------------------------------
 
-    def analyze_memory_gaps(self, events: List[TelemetryEventV2]) -> List[GapFinding]:
+    def analyze_memory_gaps(
+        self,
+        events: List[TelemetryEventV2],
+        *,
+        phase_resolver: PhaseTimelineResolver | None = None,
+    ) -> List[GapFinding]:
         """Classify allocator-vs-device hidden memory gaps over time.
 
         Args:
@@ -360,15 +366,20 @@ class MemoryAnalyzer:
             thresholds=self.thresholds,
             format_memory=format_memory,
             remediation_by_classification=_GAP_REMEDIATION_BY_CLASSIFICATION,
+            phase_resolver=phase_resolver,
         )
 
     def analyze_collective_attribution(
-        self, events: List[TelemetryEventV2]
+        self,
+        events: List[TelemetryEventV2],
+        *,
+        phase_resolver: PhaseTimelineResolver | None = None,
     ) -> List[CollectiveAttributionResult]:
         """Attribute hidden-memory spikes to collective communication phases."""
         return attribute_collective_memory(
             events=events,
             config=self.collective_attribution_config,
+            phase_resolver=phase_resolver,
         )
 
     def score_optimization(
@@ -442,8 +453,15 @@ class MemoryAnalyzer:
 
         # Hidden-memory gap analysis (only when telemetry events are supplied).
         if events is not None:
-            gap_findings = self.analyze_memory_gaps(events)
-            collective_attribution = self.analyze_collective_attribution(events)
+            phase_resolver = PhaseTimelineResolver.from_events(events)
+            gap_findings = self.analyze_memory_gaps(
+                events,
+                phase_resolver=phase_resolver,
+            )
+            collective_attribution = self.analyze_collective_attribution(
+                events,
+                phase_resolver=phase_resolver,
+            )
             optimization_score["gap_analysis"] = [asdict(f) for f in gap_findings]
             optimization_score["collective_attribution"] = [
                 asdict(result) for result in collective_attribution

--- a/stormlog/tensorflow/tracker.py
+++ b/stormlog/tensorflow/tracker.py
@@ -11,6 +11,7 @@ import socket
 import threading
 import time
 from collections import deque
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
 
@@ -32,6 +33,7 @@ from stormlog.collector_health import (
     CollectorHealthState,
     collector_retry_delay_seconds,
 )
+from stormlog.phases import PhaseHandle, TrackerPhaseState
 from stormlog.session import (
     SESSION_STATUS_COMPLETED,
     SESSION_STATUS_INCOMPLETE,
@@ -168,6 +170,7 @@ class MemoryTracker:
         self._min_memory_mb = float("inf")
         self._sum_memory_mb = 0.0
         self._last_sink_diagnostics: Dict[str, int] = self._empty_sink_diagnostics()
+        self._phase_state = TrackerPhaseState()
 
         # Thread synchronization
         self._lock = threading.Lock()
@@ -555,6 +558,7 @@ class MemoryTracker:
         self._session_start_time = time.time()
         self._session_end_time = None
         self._session_summary = None
+        self._phase_state.reset()
         self._ensure_telemetry_sink()
         self._stop_event.clear()
 
@@ -612,6 +616,7 @@ class MemoryTracker:
                 self._session_summary,
                 ended_at_ns=now_ns(),
             )
+        self._phase_state.reset()
         # Create result
         result = self._create_tracking_result()
 
@@ -834,6 +839,62 @@ class MemoryTracker:
             sink.close(session_status=status)
         except TypeError:
             sink.close()
+
+    def enter_phase(
+        self, name: str, *, metadata: Optional[Dict[str, Any]] = None
+    ) -> PhaseHandle:
+        """Enter one structured TensorFlow tracking phase."""
+        if not self.tracking:
+            raise RuntimeError("Tracking must be active before entering a phase.")
+        session = self._ensure_session_summary()
+        boundary = self._phase_state.enter_phase(
+            session_id=session.session_id,
+            rank=self.distributed_identity["rank"],
+            name=name,
+            metadata=metadata,
+        )
+        self._append_event(
+            timestamp=time.time(),
+            memory_mb=self._status_memory_value(),
+            event_type=boundary.event_type,
+            context=boundary.context,
+            metadata=boundary.metadata,
+        )
+        return PhaseHandle(
+            scope_id=boundary.scope_id,
+            name=name,
+            path=boundary.path,
+            close_callback=lambda: self._emit_phase_exit(boundary.scope_id),
+        )
+
+    @contextmanager
+    def phase(self, name: str, *, metadata: Optional[Dict[str, Any]] = None) -> Any:
+        """Context manager that emits structured TensorFlow phase telemetry."""
+        handle = self.enter_phase(name, metadata=metadata)
+        try:
+            yield handle
+        finally:
+            handle.close()
+
+    def _emit_phase_exit(self, scope_id: str) -> None:
+        session = self._session_summary
+        if session is None:
+            return
+        boundary = self._phase_state.exit_phase(
+            session_id=session.session_id,
+            rank=self.distributed_identity["rank"],
+            scope_id=scope_id,
+            thread_id=int(threading.current_thread().ident or 0),
+        )
+        if boundary is None:
+            return
+        self._append_event(
+            timestamp=time.time(),
+            memory_mb=self._status_memory_value(),
+            event_type=boundary.event_type,
+            context=boundary.context,
+            metadata=boundary.metadata,
+        )
 
     def set_alert_threshold(self, threshold_mb: float) -> None:
         """Update alert threshold."""

--- a/stormlog/tracker.py
+++ b/stormlog/tracker.py
@@ -40,6 +40,7 @@ from .oom_flight_recorder import (
     OOMFlightRecorderConfig,
     classify_oom_exception,
 )
+from .phases import PHASE_EXIT_EVENT, PhaseHandle, TrackerPhaseState
 from .session import (
     SESSION_STATUS_COMPLETED,
     SESSION_STATUS_INCOMPLETE,
@@ -182,6 +183,7 @@ class MemoryTracker:
         self._collector_retry_backoff_initial_s = 1.0
         self._collector_retry_backoff_factor = 2.0
         self._collector_retry_backoff_cap_s = 30.0
+        self._phase_state = TrackerPhaseState()
 
         # Memory thresholds for alerts
         self.thresholds: Dict[str, float] = {
@@ -570,6 +572,7 @@ class MemoryTracker:
         self._reset_collector_session_state()
         self._reset_tracking_state_for_new_session()
         self._session_summary = None
+        self._phase_state.reset()
         self._ensure_telemetry_sink()
         self._stop_event.clear()
         self.stats["tracking_start_time"] = time.time()
@@ -602,6 +605,7 @@ class MemoryTracker:
                 self._session_summary,
                 ended_at_ns=now_ns(),
             )
+        self._phase_state.reset()
 
     def _tracking_loop(self) -> None:
         """Main tracking loop running in background thread."""
@@ -671,6 +675,63 @@ class MemoryTracker:
                     callback(event)
                 except Exception as exc:
                     logger.debug("Alert callback error (suppressed): %s", exc)
+
+    def enter_phase(
+        self, name: str, *, metadata: Optional[Dict[str, Any]] = None
+    ) -> PhaseHandle:
+        """Enter one structured workload phase while tracking is active."""
+        if not self.is_tracking:
+            raise RuntimeError("Tracking must be active before entering a phase.")
+        session = self._open_session()
+        boundary = self._phase_state.enter_phase(
+            session_id=session.session_id,
+            rank=self.distributed_identity["rank"],
+            name=name,
+            metadata=metadata,
+        )
+        self._add_event(
+            boundary.event_type,
+            0,
+            boundary.context,
+            metadata=boundary.metadata,
+        )
+        return PhaseHandle(
+            scope_id=boundary.scope_id,
+            name=name,
+            path=boundary.path,
+            close_callback=lambda: self._emit_phase_exit(boundary.scope_id),
+        )
+
+    @contextmanager
+    def phase(self, name: str, *, metadata: Optional[Dict[str, Any]] = None) -> Any:
+        """Context manager that emits structured phase enter and exit records."""
+        handle = self.enter_phase(name, metadata=metadata)
+        try:
+            yield handle
+        finally:
+            self._close_phase_handle(handle)
+
+    def _close_phase_handle(self, handle: PhaseHandle) -> None:
+        handle.close()
+
+    def _emit_phase_exit(self, scope_id: str) -> None:
+        session = self._session_summary
+        if session is None:
+            return
+        boundary = self._phase_state.exit_phase(
+            session_id=session.session_id,
+            rank=self.distributed_identity["rank"],
+            scope_id=scope_id,
+            thread_id=int(threading.current_thread().ident or 0),
+        )
+        if boundary is None:
+            return
+        self._add_event(
+            PHASE_EXIT_EVENT,
+            0,
+            boundary.context,
+            metadata=boundary.metadata,
+        )
 
     def _check_alerts(
         self,

--- a/stormlog/tui/distributed_diagnostics.py
+++ b/stormlog/tui/distributed_diagnostics.py
@@ -17,6 +17,7 @@ from stormlog.collective_attribution import (
     resolve_collective_attribution_config,
 )
 from stormlog.gap_analysis import analyze_hidden_memory_gaps
+from stormlog.phases import PhaseTimelineResolver, summarize_phase_attribution
 from stormlog.session import (
     SESSION_STATUS_COMPLETED,
     SESSION_STATUS_INCOMPLETE,
@@ -117,6 +118,7 @@ class RankDiagnosticsRow:
     has_anomaly: bool
     first_anomaly_timestamp_ns: int | None = None
     first_anomaly_signal: str | None = None
+    first_anomaly_phase_path: str | None = None
 
 
 @dataclass
@@ -131,6 +133,7 @@ class AnomalyIndicator:
     details: str
     confidence: float | None = None
     reason_codes: list[str] = field(default_factory=list)
+    phase_path: str | None = None
 
 
 @dataclass
@@ -155,6 +158,7 @@ class _AnomalyCandidate:
     details: str
     confidence: float | None = None
     reason_codes: list[str] = field(default_factory=list)
+    phase_path: str | None = None
 
 
 @dataclass(frozen=True)
@@ -671,9 +675,13 @@ def build_distributed_model(
         )
 
     grouped: dict[int, list[TelemetryCompatibleEvent]] = {}
+    sample_grouped: dict[int, list[TelemetryCompatibleEvent]] = {}
     world_sizes: set[int] = set()
+    phase_resolver = PhaseTimelineResolver.from_events(events)
     for event in sorted(events, key=lambda item: item.timestamp_ns):
         grouped.setdefault(event.rank, []).append(event)
+        if _is_sample_event(event):
+            sample_grouped.setdefault(event.rank, []).append(event)
         if event.world_size > 0:
             world_sizes.add(event.world_size)
 
@@ -710,10 +718,14 @@ def build_distributed_model(
     rows: list[RankDiagnosticsRow] = []
     timelines: dict[int, dict[str, list[int]]] = {}
     candidates: list[_AnomalyCandidate] = []
-    collective_by_rank = _group_collective_attribution_by_rank(events)
+    collective_by_rank = _group_collective_attribution_by_rank(
+        events,
+        phase_resolver=phase_resolver,
+    )
 
     for rank in filtered_expected:
         rank_events = grouped.get(rank, [])
+        rank_samples = sample_grouped.get(rank, [])
         if not rank_events:
             rows.append(
                 RankDiagnosticsRow(
@@ -732,17 +744,19 @@ def build_distributed_model(
         row, rank_candidates = _build_rank_row(
             rank,
             rank_events,
+            rank_samples,
             collective_by_rank.get(rank, []),
+            phase_resolver=phase_resolver,
         )
         rows.append(row)
         candidates.extend(rank_candidates)
         timelines[rank] = {
-            "timestamps_ns": [event.timestamp_ns for event in rank_events],
-            "allocated": [event.allocator_allocated_bytes for event in rank_events],
-            "reserved": [event.allocator_reserved_bytes for event in rank_events],
+            "timestamps_ns": [event.timestamp_ns for event in rank_samples],
+            "allocated": [event.allocator_allocated_bytes for event in rank_samples],
+            "reserved": [event.allocator_reserved_bytes for event in rank_samples],
             "gap": [
                 event.device_used_bytes - event.allocator_reserved_bytes
-                for event in rank_events
+                for event in rank_samples
             ],
         }
 
@@ -760,20 +774,27 @@ def build_distributed_model(
 def _build_rank_row(
     rank: int,
     rank_events: Sequence[TelemetryCompatibleEvent],
+    rank_samples: Sequence[TelemetryCompatibleEvent],
     collective_attribution: list[CollectiveAttributionResult],
+    *,
+    phase_resolver: PhaseTimelineResolver,
 ) -> tuple[RankDiagnosticsRow, list[_AnomalyCandidate]]:
-    first_event = rank_events[0]
-    last_event = rank_events[-1]
+    first_event = rank_samples[0] if rank_samples else None
+    last_event = rank_samples[-1] if rank_samples else None
 
     allocated_delta = (
         last_event.allocator_allocated_bytes - first_event.allocator_allocated_bytes
+        if first_event is not None and last_event is not None
+        else 0
     )
     reserved_delta = (
         last_event.allocator_reserved_bytes - first_event.allocator_reserved_bytes
+        if first_event is not None and last_event is not None
+        else 0
     )
     gaps = [
         event.device_used_bytes - event.allocator_reserved_bytes
-        for event in rank_events
+        for event in rank_samples
     ]
     gap_latest = gaps[-1] if gaps else 0
     gap_peak_abs = max((abs(value) for value in gaps), default=0)
@@ -781,7 +802,9 @@ def _build_rank_row(
     candidates = _derive_rank_anomaly_candidates(
         rank,
         rank_events,
+        rank_samples,
         collective_attribution,
+        phase_resolver=phase_resolver,
     )
     earliest = (
         min(candidates, key=lambda candidate: candidate.timestamp_ns)
@@ -791,7 +814,7 @@ def _build_rank_row(
     row = RankDiagnosticsRow(
         rank=rank,
         availability="present",
-        samples=len(rank_events),
+        samples=len(rank_samples),
         allocated_delta_bytes=allocated_delta,
         reserved_delta_bytes=reserved_delta,
         hidden_gap_latest_bytes=gap_latest,
@@ -799,6 +822,7 @@ def _build_rank_row(
         has_anomaly=bool(candidates),
         first_anomaly_timestamp_ns=earliest.timestamp_ns if earliest else None,
         first_anomaly_signal=earliest.signal if earliest else None,
+        first_anomaly_phase_path=earliest.phase_path if earliest else None,
     )
     return row, candidates
 
@@ -806,13 +830,19 @@ def _build_rank_row(
 def _derive_rank_anomaly_candidates(
     rank: int,
     rank_events: Sequence[TelemetryCompatibleEvent],
+    rank_samples: Sequence[TelemetryCompatibleEvent],
     collective_attribution: list[CollectiveAttributionResult],
+    *,
+    phase_resolver: PhaseTimelineResolver,
 ) -> list[_AnomalyCandidate]:
     candidates: list[_AnomalyCandidate] = []
     first_gap_breach_ts: int | None = None
 
     for event in rank_events:
         if event.event_type in _ALERT_TYPES:
+            phase_path = summarize_phase_attribution(
+                phase_resolver.resolve_for_event(event)
+            )
             severity = _ALERT_SEVERITY.get(event.event_type, "warning")
             candidates.append(
                 _AnomalyCandidate(
@@ -821,15 +851,20 @@ def _derive_rank_anomaly_candidates(
                     timestamp_ns=event.timestamp_ns,
                     signal=f"alert:{event.event_type}",
                     details=event.context or "Alert event",
+                    phase_path=phase_path,
                 )
             )
 
+    for event in rank_samples:
         if event.device_total_bytes and event.device_total_bytes > 0:
             gap_value = event.device_used_bytes - event.allocator_reserved_bytes
             gap_ratio = abs(gap_value) / event.device_total_bytes
             if gap_ratio >= GAP_RATIO_THRESHOLD:
                 if first_gap_breach_ts is None:
                     first_gap_breach_ts = event.timestamp_ns
+                phase_path = summarize_phase_attribution(
+                    phase_resolver.resolve_for_event(event)
+                )
                 candidates.append(
                     _AnomalyCandidate(
                         rank=rank,
@@ -837,6 +872,7 @@ def _derive_rank_anomaly_candidates(
                         timestamp_ns=event.timestamp_ns,
                         signal="gap_ratio_breach",
                         details=f"gap ratio {gap_ratio:.1%} exceeded threshold",
+                        phase_path=phase_path,
                     )
                 )
 
@@ -845,16 +881,23 @@ def _derive_rank_anomaly_candidates(
         thresholds=_GAP_THRESHOLDS,
         format_memory=format_bytes,
         remediation_by_classification=_EMPTY_REMEDIATION,
+        phase_resolver=phase_resolver,
     )
     for finding in gap_findings:
-        fallback_ts = first_gap_breach_ts or rank_events[0].timestamp_ns
+        fallback_ts = first_gap_breach_ts or (
+            rank_samples[0].timestamp_ns
+            if rank_samples
+            else rank_events[0].timestamp_ns
+        )
+        phase_path = summarize_phase_attribution(finding.phase_attribution)
         candidates.append(
             _AnomalyCandidate(
                 rank=rank,
                 severity=finding.severity,
-                timestamp_ns=fallback_ts,
+                timestamp_ns=finding.evidence_timestamp_ns or fallback_ts,
                 signal=f"gap:{finding.classification}",
                 details=finding.description,
+                phase_path=phase_path,
             )
         )
 
@@ -862,7 +905,15 @@ def _derive_rank_anomaly_candidates(
         confidence = round(float(attribution.confidence), 3)
         reason_codes = sorted(set(attribution.reason_codes))
         reason_summary = ", ".join(reason_codes) if reason_codes else "no reason codes"
-        attribution_ts = max(attribution.interval_start_ns, rank_events[0].timestamp_ns)
+        attribution_ts = max(
+            attribution.interval_start_ns,
+            (
+                rank_samples[0].timestamp_ns
+                if rank_samples
+                else rank_events[0].timestamp_ns
+            ),
+        )
+        phase_path = summarize_phase_attribution(attribution.phase_attribution)
         candidates.append(
             _AnomalyCandidate(
                 rank=rank,
@@ -875,19 +926,27 @@ def _derive_rank_anomaly_candidates(
                 ),
                 confidence=confidence,
                 reason_codes=reason_codes,
+                phase_path=phase_path,
             )
         )
 
     return candidates
 
 
+def _is_sample_event(event: TelemetryCompatibleEvent) -> bool:
+    return str(event.event_type).strip().lower() == "sample"
+
+
 def _group_collective_attribution_by_rank(
     events: Sequence[TelemetryCompatibleEvent],
+    *,
+    phase_resolver: PhaseTimelineResolver,
 ) -> dict[int, list[CollectiveAttributionResult]]:
     grouped: dict[int, list[CollectiveAttributionResult]] = {}
     attributions = attribute_collective_memory(
         events=cast(Sequence[TelemetryEventV2], events),
         config=_COLLECTIVE_ATTRIBUTION_CONFIG,
+        phase_resolver=phase_resolver,
     )
     for attribution in attributions:
         grouped.setdefault(attribution.rank, []).append(attribution)
@@ -924,9 +983,10 @@ def _build_first_cause_indicators(
             severity=earliest.severity,
             timestamp_ns=earliest.timestamp_ns,
             signal=earliest.signal,
-            details=earliest.details,
+            details=_format_indicator_details(earliest),
             confidence=earliest.confidence,
             reason_codes=list(earliest.reason_codes),
+            phase_path=earliest.phase_path,
         ),
         AnomalyIndicator(
             kind="most_severe",
@@ -934,11 +994,18 @@ def _build_first_cause_indicators(
             severity=most_severe.severity,
             timestamp_ns=most_severe.timestamp_ns,
             signal=most_severe.signal,
-            details=most_severe.details,
+            details=_format_indicator_details(most_severe),
             confidence=most_severe.confidence,
             reason_codes=list(most_severe.reason_codes),
+            phase_path=most_severe.phase_path,
         ),
     ]
+
+
+def _format_indicator_details(candidate: _AnomalyCandidate) -> str:
+    if not candidate.phase_path:
+        return candidate.details
+    return f"{candidate.details} Phase: {candidate.phase_path}."
 
 
 def _load_artifact_file(

--- a/tests/test_attributed_viz.py
+++ b/tests/test_attributed_viz.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
 import json
+from typing import Any, cast
 
 import stormlog.attributed_viz as attributed_viz
 import stormlog.cuda_native_debug as native_debug
 
 
-def _extract_embedded_payload(html: str) -> dict[str, object]:
+def _extract_embedded_payload(html: str) -> dict[str, Any]:
     prefix = "const DATA = "
     start = html.index(prefix) + len(prefix)
     end = html.index(";\n\n// === UTILS ===", start)
-    return json.loads(html[start:end].replace("<\\/", "</"))
+    return cast(dict[str, Any], json.loads(html[start:end].replace("<\\/", "</")))
 
 
 def test_render_attributed_html_is_self_contained() -> None:

--- a/tests/test_cli_analyze.py
+++ b/tests/test_cli_analyze.py
@@ -178,6 +178,63 @@ def _build_single_rank_gap_events_with_phase() -> list:
     return events
 
 
+def _build_single_rank_gap_events_with_ambiguous_phase() -> list:
+    session_id = "session-cli-gap-ambiguous"
+    phase_events = []
+    for thread_id, sequence, scope_id in (
+        (1, 1, "phase-gap-a"),
+        (2, 2, "phase-gap-b"),
+    ):
+        phase_events.append(
+            telemetry_event_from_record(
+                {
+                    "schema_version": 3,
+                    "session_id": session_id,
+                    "timestamp_ns": BASE_NS - 1_000_000 + sequence,
+                    "event_type": "phase_enter",
+                    "collector": "stormlog.cuda_tracker",
+                    "sampling_interval_ms": 100,
+                    "pid": 1,
+                    "host": "host-0",
+                    "job_id": "cli-gap-job",
+                    "rank": 0,
+                    "local_rank": 0,
+                    "world_size": 1,
+                    "device_id": 0,
+                    "allocator_allocated_bytes": 2_000_000_000,
+                    "allocator_reserved_bytes": 2_500_000_000,
+                    "allocator_active_bytes": None,
+                    "allocator_inactive_bytes": None,
+                    "allocator_change_bytes": 0,
+                    "device_used_bytes": 2_500_000_000,
+                    "device_free_bytes": 13 * _GB,
+                    "device_total_bytes": 16 * _GB,
+                    "context": "Phase entered: train / forward",
+                    "metadata": {
+                        "phase_scope": {
+                            "action": "enter",
+                            "name": "forward",
+                            "path": ["train", "forward"],
+                            "depth": 2,
+                            "scope_id": scope_id,
+                            "parent_scope_id": "phase-train",
+                            "thread_id": thread_id,
+                            "thread_name": f"thread-{thread_id}",
+                            "sequence": sequence,
+                        }
+                    },
+                }
+            )
+        )
+    sample_events = []
+    for event in _build_single_rank_gap_events_with_phase()[1:]:
+        record = telemetry_event_to_dict(event)
+        record["schema_version"] = 3
+        record["session_id"] = session_id
+        sample_events.append(telemetry_event_from_record(record))
+    return [*phase_events, *sample_events]
+
+
 def test_cmd_analyze_reports_cross_rank_findings_and_writes_artifacts(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -268,6 +325,35 @@ def test_cmd_analyze_surfaces_gap_phase_summary_when_present(
     assert exit_code == 0
     stdout = capsys.readouterr().out
     assert "Top gap phase: train / forward" in stdout
+
+
+def test_cmd_analyze_marks_ambiguous_gap_phase_summary(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    input_path = tmp_path / "telemetry-gap-ambiguous.json"
+    input_path.write_text(
+        json.dumps(
+            [
+                telemetry_event_to_dict(event)
+                for event in _build_single_rank_gap_events_with_ambiguous_phase()
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = cmd_analyze(
+        argparse.Namespace(
+            input_file=str(input_path),
+            output=None,
+            format="json",
+            visualization=False,
+            plot_dir=str(tmp_path / "plots"),
+        )
+    )
+
+    assert exit_code == 0
+    stdout = capsys.readouterr().out
+    assert "Top gap phase: (ambiguous) train / forward" in stdout
 
 
 def test_cmd_analyze_non_telemetry_falls_back_gracefully(

--- a/tests/test_cli_analyze.py
+++ b/tests/test_cli_analyze.py
@@ -12,7 +12,7 @@ import pytest
 
 import stormlog.cli as gpumemprof_cli
 from stormlog.cli import cmd_analyze
-from stormlog.telemetry import telemetry_event_to_dict
+from stormlog.telemetry import telemetry_event_from_record, telemetry_event_to_dict
 from stormlog.telemetry_sink import AppendOnlyTelemetrySink, TelemetrySinkConfig
 from tests.gap_test_helpers import BASE_NS, INTERVAL_NS, build_gap_event
 
@@ -49,6 +49,135 @@ def _build_cross_rank_events() -> list:
     return events
 
 
+def _build_cross_rank_events_with_phases() -> list:
+    session_id = "session-cli-phase"
+    events = []
+    for rank in range(3):
+        events.append(
+            telemetry_event_from_record(
+                {
+                    "schema_version": 3,
+                    "session_id": session_id,
+                    "timestamp_ns": BASE_NS - 1_000_000 + rank * 100_000,
+                    "event_type": "phase_enter",
+                    "collector": "stormlog.cuda_tracker",
+                    "sampling_interval_ms": 100,
+                    "pid": 1,
+                    "host": f"host-{rank}",
+                    "job_id": "cli-job",
+                    "rank": rank,
+                    "local_rank": rank,
+                    "world_size": 3,
+                    "device_id": 0,
+                    "allocator_allocated_bytes": 1 * _GB,
+                    "allocator_reserved_bytes": 1 * _GB,
+                    "allocator_active_bytes": None,
+                    "allocator_inactive_bytes": None,
+                    "allocator_change_bytes": 0,
+                    "device_used_bytes": 1 * _GB,
+                    "device_free_bytes": 15 * _GB,
+                    "device_total_bytes": 16 * _GB,
+                    "context": "Phase entered: train / forward",
+                    "metadata": {
+                        "phase_scope": {
+                            "action": "enter",
+                            "name": "forward",
+                            "path": ["train", "forward"],
+                            "depth": 2,
+                            "scope_id": f"phase-{rank}",
+                            "parent_scope_id": "phase-train",
+                            "thread_id": 1,
+                            "thread_name": "MainThread",
+                            "sequence": rank + 1,
+                        }
+                    },
+                }
+            )
+        )
+    for event in _build_cross_rank_events():
+        record = telemetry_event_to_dict(event)
+        record["schema_version"] = 3
+        record["session_id"] = session_id
+        events.append(telemetry_event_from_record(record))
+    return events
+
+
+def _build_single_rank_gap_events_with_phase() -> list:
+    session_id = "session-cli-gap-phase"
+    events = [
+        telemetry_event_from_record(
+            {
+                "schema_version": 3,
+                "session_id": session_id,
+                "timestamp_ns": BASE_NS - 1_000_000,
+                "event_type": "phase_enter",
+                "collector": "stormlog.cuda_tracker",
+                "sampling_interval_ms": 100,
+                "pid": 1,
+                "host": "host-0",
+                "job_id": "cli-gap-job",
+                "rank": 0,
+                "local_rank": 0,
+                "world_size": 1,
+                "device_id": 0,
+                "allocator_allocated_bytes": 2_000_000_000,
+                "allocator_reserved_bytes": 2_500_000_000,
+                "allocator_active_bytes": None,
+                "allocator_inactive_bytes": None,
+                "allocator_change_bytes": 0,
+                "device_used_bytes": 2_500_000_000,
+                "device_free_bytes": 13 * _GB,
+                "device_total_bytes": 16 * _GB,
+                "context": "Phase entered: train / forward",
+                "metadata": {
+                    "phase_scope": {
+                        "action": "enter",
+                        "name": "forward",
+                        "path": ["train", "forward"],
+                        "depth": 2,
+                        "scope_id": "phase-gap",
+                        "parent_scope_id": "phase-train",
+                        "thread_id": 1,
+                        "thread_name": "MainThread",
+                        "sequence": 1,
+                    }
+                },
+            }
+        )
+    ]
+    for index in range(12):
+        events.append(
+            telemetry_event_from_record(
+                {
+                    "schema_version": 3,
+                    "session_id": session_id,
+                    "timestamp_ns": BASE_NS + index * INTERVAL_NS,
+                    "event_type": "sample",
+                    "collector": "stormlog.cuda_tracker",
+                    "sampling_interval_ms": 100,
+                    "pid": 1,
+                    "host": "host-0",
+                    "job_id": "cli-gap-job",
+                    "rank": 0,
+                    "local_rank": 0,
+                    "world_size": 1,
+                    "device_id": 0,
+                    "allocator_allocated_bytes": 2_000_000_000,
+                    "allocator_reserved_bytes": 2_500_000_000,
+                    "allocator_active_bytes": None,
+                    "allocator_inactive_bytes": None,
+                    "allocator_change_bytes": 0,
+                    "device_used_bytes": 3_000_000_000 + index * 150_000_000,
+                    "device_free_bytes": None,
+                    "device_total_bytes": 16 * _GB,
+                    "context": "sample",
+                    "metadata": {},
+                }
+            )
+        )
+    return events
+
+
 def test_cmd_analyze_reports_cross_rank_findings_and_writes_artifacts(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -81,6 +210,64 @@ def test_cmd_analyze_reports_cross_rank_findings_and_writes_artifacts(
 
     report = json.loads(report_path.read_text(encoding="utf-8"))
     assert report["cross_rank_analysis"]["first_cause_suspects"][0]["rank"] == 2
+
+
+def test_cmd_analyze_surfaces_phase_summaries_when_present(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    input_path = tmp_path / "telemetry.json"
+    input_path.write_text(
+        json.dumps(
+            [
+                telemetry_event_to_dict(event)
+                for event in _build_cross_rank_events_with_phases()
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = cmd_analyze(
+        argparse.Namespace(
+            input_file=str(input_path),
+            output=None,
+            format="json",
+            visualization=False,
+            plot_dir=str(tmp_path / "plots"),
+        )
+    )
+
+    assert exit_code == 0
+    stdout = capsys.readouterr().out
+    assert "Suspect phase: train / forward" in stdout
+
+
+def test_cmd_analyze_surfaces_gap_phase_summary_when_present(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    input_path = tmp_path / "telemetry-gap.json"
+    input_path.write_text(
+        json.dumps(
+            [
+                telemetry_event_to_dict(event)
+                for event in _build_single_rank_gap_events_with_phase()
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = cmd_analyze(
+        argparse.Namespace(
+            input_file=str(input_path),
+            output=None,
+            format="json",
+            visualization=False,
+            plot_dir=str(tmp_path / "plots"),
+        )
+    )
+
+    assert exit_code == 0
+    stdout = capsys.readouterr().out
+    assert "Top gap phase: train / forward" in stdout
 
 
 def test_cmd_analyze_non_telemetry_falls_back_gracefully(

--- a/tests/test_collective_attribution.py
+++ b/tests/test_collective_attribution.py
@@ -2,13 +2,20 @@
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 import pytest
 
 from stormlog.collective_attribution import (
     attribute_collective_memory,
     resolve_collective_attribution_config,
 )
-from stormlog.telemetry import SCHEMA_VERSION_V2, TelemetryEventV2
+from stormlog.phases import PhaseTimelineResolver
+from stormlog.telemetry import (
+    SCHEMA_VERSION_V2,
+    TelemetryEventV2,
+    telemetry_event_from_record,
+)
 
 BASE_NS = 1_700_000_000_000_000_000
 STEP_NS = 100_000_000
@@ -101,6 +108,57 @@ def _build_sync_spike_events(
                 )
 
     return events
+
+
+def _make_phase_boundary_event(
+    *,
+    session_id: str,
+    timestamp_ns: int,
+    rank: int,
+    world_size: int,
+    action: str,
+    sequence: int,
+    scope_id: str,
+) -> object:
+    return telemetry_event_from_record(
+        {
+            "schema_version": 3,
+            "session_id": session_id,
+            "timestamp_ns": timestamp_ns,
+            "event_type": f"phase_{action}",
+            "collector": "stormlog.cuda_tracker",
+            "sampling_interval_ms": 100,
+            "pid": 1,
+            "host": "test",
+            "device_id": 0,
+            "allocator_allocated_bytes": 2_000_000_000,
+            "allocator_reserved_bytes": 2_000_000_000,
+            "allocator_active_bytes": None,
+            "allocator_inactive_bytes": None,
+            "allocator_change_bytes": 0,
+            "device_used_bytes": 2_000_000_000,
+            "device_free_bytes": DEVICE_TOTAL_BYTES - 2_000_000_000,
+            "device_total_bytes": DEVICE_TOTAL_BYTES,
+            "context": f"Phase {action}ed: communication",
+            "job_id": "phase-job",
+            "rank": rank,
+            "local_rank": rank,
+            "world_size": world_size,
+            "metadata": {
+                "phase_scope": {
+                    "action": action,
+                    "name": "communication",
+                    "path": ["train", "communication"],
+                    "depth": 2,
+                    "scope_id": scope_id,
+                    "parent_scope_id": "parent-train",
+                    "thread_id": 1,
+                    "thread_name": "MainThread",
+                    "sequence": sequence,
+                }
+            },
+        }
+    )
 
 
 def test_resolve_collective_config_supports_preset_and_overrides() -> None:
@@ -228,6 +286,65 @@ def test_collective_attribution_keeps_marker_evidence_rank_local() -> None:
     assert "marker_collective_token" in rank0.reason_codes
     assert "marker_collective_token" not in rank1.reason_codes
     assert "weak_marker_signal" in rank1.reason_codes
+
+
+def test_collective_attribution_includes_phase_attribution_when_available() -> None:
+    session_id = "session-collective-phase"
+    events: list[Any] = []
+    for rank in (0, 1):
+        events.append(
+            _make_phase_boundary_event(
+                session_id=session_id,
+                timestamp_ns=BASE_NS - 1_000_000 + rank * 100_000,
+                rank=rank,
+                world_size=2,
+                action="enter",
+                sequence=rank + 1,
+                scope_id=f"phase-{rank}",
+            )
+        )
+    events.extend(_build_sync_spike_events(world_size=2, with_markers=True))
+    canonical_events: list[Any] = []
+    for event in events:
+        if isinstance(event, TelemetryEventV2):
+            canonical_events.append(
+                telemetry_event_from_record(
+                    {
+                        **event.__dict__,
+                        "schema_version": 3,
+                        "session_id": session_id,
+                    }
+                )
+            )
+        else:
+            canonical_events.append(event)
+    for rank in (0, 1):
+        events.append(
+            _make_phase_boundary_event(
+                session_id=session_id,
+                timestamp_ns=BASE_NS + 12 * STEP_NS + rank * 100_000,
+                rank=rank,
+                world_size=2,
+                action="exit",
+                sequence=rank + 3,
+                scope_id=f"phase-{rank}",
+            )
+        )
+    canonical_events.extend(events[-2:])
+
+    resolver = PhaseTimelineResolver.from_events(canonical_events)
+    results = attribute_collective_memory(
+        cast(list[TelemetryEventV2], canonical_events),
+        phase_resolver=resolver,
+    )
+
+    assert results
+    assert all(result.phase_attribution is not None for result in results)
+    assert all(
+        result.phase_attribution
+        and result.phase_attribution.phase_path == "train / communication"
+        for result in results
+    )
 
 
 def test_collective_attribution_accepts_uppercase_sample_event_type() -> None:

--- a/tests/test_cpu_profiler.py
+++ b/tests/test_cpu_profiler.py
@@ -20,6 +20,7 @@ from stormlog.cpu_profiler import (
     CPUMemoryTracker,
     CPUProfileResult,
 )
+from stormlog.phases import extract_phase_scope
 from stormlog.telemetry_sink import TelemetrySinkConfig
 
 # ---------------------------------------------------------------------------
@@ -613,10 +614,58 @@ class TestCPUMemoryTracker:
             assert tracker._telemetry_sink is None
 
             tracker.start_tracking()
-            second_sink = tracker._telemetry_sink
+            second_sink = cast(Any, tracker._telemetry_sink)
 
         assert second_sink is not None
         assert second_sink is not first_sink
+
+    @patch("stormlog.cpu_profiler.psutil.Process")
+    def test_tracker_emits_structured_phase_boundaries(self, mock_cls: Any) -> None:
+        mock_cls.return_value = _make_mock_process(rss=2048)
+        tracker = CPUMemoryTracker(sampling_interval=0.05)
+
+        class _NoOpThread:
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                _ = args, kwargs
+
+            def start(self) -> None:
+                return None
+
+            def is_alive(self) -> bool:
+                return False
+
+            def join(self, timeout: float | None = None) -> None:
+                _ = timeout
+
+        with patch("stormlog.cpu_profiler.threading.Thread", _NoOpThread):
+            tracker.start_tracking()
+            with tracker.phase("train_step", metadata={"epoch": 1}) as handle:
+                assert handle.phase_path == "train_step"
+            tracker.stop_tracking()
+
+        phase_events = [
+            event
+            for event in tracker.get_events()
+            if event.event_type.startswith("phase_")
+        ]
+        assert [event.event_type for event in phase_events] == [
+            "phase_enter",
+            "phase_exit",
+        ]
+
+        enter_scope = extract_phase_scope(
+            tracker._telemetry_record_from_event(phase_events[0])
+        )
+        exit_scope = extract_phase_scope(
+            tracker._telemetry_record_from_event(phase_events[1])
+        )
+        assert enter_scope is not None
+        assert exit_scope is not None
+        assert enter_scope.path == ("train_step",)
+        assert enter_scope.depth == 1
+        assert enter_scope.attributes == {"epoch": 1}
+        assert exit_scope.scope_id == enter_scope.scope_id
+        assert exit_scope.path == enter_scope.path
 
     @patch("stormlog.cpu_profiler.psutil.Process")
     def test_tracker_disables_sink_after_append_failure(self, mock_cls: Any) -> None:

--- a/tests/test_distributed_analysis.py
+++ b/tests/test_distributed_analysis.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from typing import Any, cast
 
 from stormlog.analyzer import MemoryAnalyzer
 from stormlog.distributed_analysis import (
     analyze_cross_rank_events,
     merge_cross_rank_timelines,
 )
+from stormlog.phases import PhaseTimelineResolver
+from stormlog.telemetry import telemetry_event_from_record, telemetry_event_to_dict
 from tests.gap_test_helpers import BASE_NS, INTERVAL_NS, build_gap_event
 
 _GB = 1024**3
@@ -79,6 +82,101 @@ def _build_cross_rank_fixture(world_size: int = 4) -> list:
         )
     )
     return events
+
+
+def _canonicalize_phase_events(events: list[Any], *, session_id: str) -> list[Any]:
+    canonical_events: list[Any] = []
+    observed_ranks = sorted({event.rank for event in events})
+    for offset, rank in enumerate(observed_ranks, start=1):
+        canonical_events.append(
+            telemetry_event_from_record(
+                {
+                    "schema_version": 3,
+                    "session_id": session_id,
+                    "timestamp_ns": BASE_NS - 1_000_000 + rank * 100_000,
+                    "event_type": "phase_enter",
+                    "collector": "stormlog.cuda_tracker",
+                    "sampling_interval_ms": 100,
+                    "pid": 1,
+                    "host": f"host-{rank // 2}",
+                    "job_id": "job-28",
+                    "rank": rank,
+                    "local_rank": rank % 2,
+                    "world_size": len(observed_ranks),
+                    "device_id": 0,
+                    "allocator_allocated_bytes": 1 * _GB,
+                    "allocator_reserved_bytes": 1 * _GB,
+                    "allocator_active_bytes": None,
+                    "allocator_inactive_bytes": None,
+                    "allocator_change_bytes": 0,
+                    "device_used_bytes": 1 * _GB,
+                    "device_free_bytes": 15 * _GB,
+                    "device_total_bytes": 16 * _GB,
+                    "context": "Phase entered: train / forward",
+                    "metadata": {
+                        "phase_scope": {
+                            "action": "enter",
+                            "name": "forward",
+                            "path": ["train", "forward"],
+                            "depth": 2,
+                            "scope_id": f"phase-{rank}",
+                            "parent_scope_id": "phase-train",
+                            "thread_id": 1,
+                            "thread_name": "MainThread",
+                            "sequence": offset,
+                        }
+                    },
+                }
+            )
+        )
+    for event in events:
+        record = telemetry_event_to_dict(event)
+        record["schema_version"] = 3
+        record["session_id"] = session_id
+        canonical_events.append(telemetry_event_from_record(record))
+    for offset, rank in enumerate(observed_ranks, start=len(observed_ranks) + 1):
+        canonical_events.append(
+            telemetry_event_from_record(
+                {
+                    "schema_version": 3,
+                    "session_id": session_id,
+                    "timestamp_ns": BASE_NS + 5 * INTERVAL_NS + rank * 100_000,
+                    "event_type": "phase_exit",
+                    "collector": "stormlog.cuda_tracker",
+                    "sampling_interval_ms": 100,
+                    "pid": 1,
+                    "host": f"host-{rank // 2}",
+                    "job_id": "job-28",
+                    "rank": rank,
+                    "local_rank": rank % 2,
+                    "world_size": len(observed_ranks),
+                    "device_id": 0,
+                    "allocator_allocated_bytes": 1 * _GB,
+                    "allocator_reserved_bytes": 1 * _GB,
+                    "allocator_active_bytes": None,
+                    "allocator_inactive_bytes": None,
+                    "allocator_change_bytes": 0,
+                    "device_used_bytes": 1 * _GB,
+                    "device_free_bytes": 15 * _GB,
+                    "device_total_bytes": 16 * _GB,
+                    "context": "Phase exited: train / forward",
+                    "metadata": {
+                        "phase_scope": {
+                            "action": "exit",
+                            "name": "forward",
+                            "path": ["train", "forward"],
+                            "depth": 2,
+                            "scope_id": f"phase-{rank}",
+                            "parent_scope_id": "phase-train",
+                            "thread_id": 1,
+                            "thread_name": "MainThread",
+                            "sequence": offset,
+                        }
+                    },
+                }
+            )
+        )
+    return canonical_events
 
 
 class TestCrossRankMerge:
@@ -330,6 +428,25 @@ class TestCrossRankMerge:
         _, first_cause = analyze_cross_rank_events(events)
 
         assert first_cause.suspects[0].rank == 1
+
+    def test_first_cause_suspects_include_phase_attribution_when_available(
+        self,
+    ) -> None:
+        events = _canonicalize_phase_events(
+            _build_cross_rank_fixture(),
+            session_id="session-cross-rank-phase",
+        )
+
+        _, first_cause = analyze_cross_rank_events(
+            cast(Any, events),
+            phase_resolver=PhaseTimelineResolver.from_events(events),
+        )
+
+        assert first_cause.suspects
+        assert first_cause.suspects[0].phase_attribution is not None
+        assert first_cause.suspects[0].phase_attribution.phase_path == (
+            "train / forward"
+        )
 
 
 class TestAnalyzerIntegration:

--- a/tests/test_gap_analysis.py
+++ b/tests/test_gap_analysis.py
@@ -2,8 +2,15 @@
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 from stormlog.analyzer import MemoryAnalyzer
-from stormlog.telemetry import SCHEMA_VERSION_V2, TelemetryEventV2
+from stormlog.phases import PhaseTimelineResolver
+from stormlog.telemetry import (
+    SCHEMA_VERSION_V2,
+    TelemetryEventV2,
+    telemetry_event_from_record,
+)
 from tests.gap_test_helpers import build_gap_event
 
 # ---------------------------------------------------------------------------
@@ -63,6 +70,86 @@ def _make_collective_event(
         local_rank=rank,
         world_size=world_size,
         metadata=metadata or {},
+    )
+
+
+def _make_phase_sample_event(
+    *,
+    session_id: str,
+    timestamp_ns: int,
+    allocator_allocated: int,
+    allocator_reserved: int,
+    device_used: int,
+    rank: int = 0,
+    world_size: int = 1,
+    event_type: str = "sample",
+    context: str | None = None,
+    metadata: dict | None = None,
+) -> object:
+    total_bytes = 16 * 1024**3
+    return telemetry_event_from_record(
+        {
+            "schema_version": 3,
+            "session_id": session_id,
+            "timestamp_ns": timestamp_ns,
+            "event_type": event_type,
+            "collector": "stormlog.cuda_tracker",
+            "sampling_interval_ms": 100,
+            "pid": 1,
+            "host": "test",
+            "device_id": 0,
+            "allocator_allocated_bytes": allocator_allocated,
+            "allocator_reserved_bytes": allocator_reserved,
+            "allocator_active_bytes": None,
+            "allocator_inactive_bytes": None,
+            "allocator_change_bytes": 0,
+            "device_used_bytes": device_used,
+            "device_free_bytes": max(0, total_bytes - device_used),
+            "device_total_bytes": total_bytes,
+            "context": context,
+            "job_id": "job-phase",
+            "rank": rank,
+            "local_rank": rank,
+            "world_size": world_size,
+            "metadata": metadata or {},
+        }
+    )
+
+
+def _make_phase_boundary_event(
+    *,
+    session_id: str,
+    timestamp_ns: int,
+    rank: int,
+    world_size: int,
+    event_type: str,
+    action: str,
+    sequence: int,
+    scope_id: str,
+) -> object:
+    return _make_phase_sample_event(
+        session_id=session_id,
+        timestamp_ns=timestamp_ns,
+        allocator_allocated=2_000_000_000,
+        allocator_reserved=2_500_000_000,
+        device_used=2_500_000_000,
+        rank=rank,
+        world_size=world_size,
+        event_type=event_type,
+        context=f"Phase {action}ed: train",
+        metadata={
+            "phase_scope": {
+                "action": action,
+                "name": "train",
+                "path": ["train"],
+                "depth": 1,
+                "scope_id": scope_id,
+                "parent_scope_id": None,
+                "thread_id": 1,
+                "thread_name": "MainThread",
+                "sequence": sequence,
+            }
+        },
     )
 
 
@@ -267,3 +354,57 @@ class TestEdgeCases:
             assert "confidence" in attribution
             assert "reason_codes" in attribution
             assert attribution["reason_codes"]
+
+    def test_gap_findings_include_phase_attribution_when_available(self) -> None:
+        session_id = "session-gap-phase"
+        base_ts = 1_700_000_000_000_000_000
+        events: list[Any] = [
+            _make_phase_boundary_event(
+                session_id=session_id,
+                timestamp_ns=base_ts,
+                rank=0,
+                world_size=1,
+                event_type="phase_enter",
+                action="enter",
+                sequence=1,
+                scope_id="phase-1",
+            )
+        ]
+        alloc = 2_000_000_000
+        reserved = 2_500_000_000
+        for index in range(12):
+            events.append(
+                _make_phase_sample_event(
+                    session_id=session_id,
+                    timestamp_ns=base_ts + (index + 1) * 100_000_000,
+                    allocator_allocated=alloc,
+                    allocator_reserved=reserved,
+                    device_used=reserved + 500_000_000 + index * 120_000_000,
+                )
+            )
+        events.append(
+            _make_phase_boundary_event(
+                session_id=session_id,
+                timestamp_ns=base_ts + 13 * 100_000_000,
+                rank=0,
+                world_size=1,
+                event_type="phase_exit",
+                action="exit",
+                sequence=2,
+                scope_id="phase-1",
+            )
+        )
+
+        analyzer = MemoryAnalyzer()
+        resolver = PhaseTimelineResolver.from_events(events)
+        findings = analyzer.analyze_memory_gaps(
+            cast(list[TelemetryEventV2], events),
+            phase_resolver=resolver,
+        )
+
+        drift_findings = [f for f in findings if f.classification == "persistent_drift"]
+        assert len(drift_findings) == 1
+        finding = drift_findings[0]
+        assert finding.evidence_timestamp_ns is not None
+        assert finding.phase_attribution is not None
+        assert finding.phase_attribution.phase_path == "train"

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -1,0 +1,209 @@
+"""Tests for structured phase replay and attribution."""
+
+from __future__ import annotations
+
+from stormlog.phases import (
+    PHASE_ENTER_EVENT,
+    PHASE_EXIT_EVENT,
+    PHASE_SCOPE_METADATA_KEY,
+    PhaseTimelineResolver,
+)
+from stormlog.telemetry import SCHEMA_VERSION_V3, telemetry_event_from_record
+
+
+def _make_event(
+    *,
+    timestamp_ns: int,
+    event_type: str = "sample",
+    session_id: str = "session-1",
+    rank: int = 0,
+    metadata: dict[str, object] | None = None,
+) -> object:
+    return telemetry_event_from_record(
+        {
+            "schema_version": SCHEMA_VERSION_V3,
+            "session_id": session_id,
+            "timestamp_ns": timestamp_ns,
+            "event_type": event_type,
+            "collector": "stormlog.cuda_tracker",
+            "sampling_interval_ms": 100,
+            "pid": 1234,
+            "host": "test-host",
+            "device_id": 0,
+            "allocator_allocated_bytes": 1,
+            "allocator_reserved_bytes": 1,
+            "allocator_active_bytes": 1,
+            "allocator_inactive_bytes": 0,
+            "allocator_change_bytes": 0,
+            "device_used_bytes": 1,
+            "device_free_bytes": 1,
+            "device_total_bytes": 2,
+            "context": event_type,
+            "job_id": "job-1",
+            "rank": rank,
+            "local_rank": rank,
+            "world_size": 2,
+            "metadata": metadata or {},
+        },
+        permissive_legacy=False,
+    )
+
+
+def _phase_scope(
+    *,
+    action: str,
+    name: str,
+    path: list[str],
+    scope_id: str,
+    sequence: int,
+    thread_id: int,
+) -> dict[str, object]:
+    return {
+        PHASE_SCOPE_METADATA_KEY: {
+            "action": action,
+            "name": name,
+            "path": path,
+            "depth": len(path),
+            "scope_id": scope_id,
+            "parent_scope_id": scope_id.rsplit(":", 1)[0] if len(path) > 1 else None,
+            "thread_id": thread_id,
+            "thread_name": f"thread-{thread_id}",
+            "sequence": sequence,
+        }
+    }
+
+
+def test_phase_timeline_resolver_prefers_deepest_nested_path() -> None:
+    events = [
+        _make_event(
+            timestamp_ns=100,
+            event_type=PHASE_ENTER_EVENT,
+            metadata=_phase_scope(
+                action="enter",
+                name="train",
+                path=["train"],
+                scope_id="session-1:1",
+                sequence=1,
+                thread_id=11,
+            ),
+        ),
+        _make_event(
+            timestamp_ns=120,
+            event_type=PHASE_ENTER_EVENT,
+            metadata=_phase_scope(
+                action="enter",
+                name="step",
+                path=["train", "step"],
+                scope_id="session-1:2",
+                sequence=2,
+                thread_id=11,
+            ),
+        ),
+        _make_event(timestamp_ns=140),
+    ]
+
+    resolver = PhaseTimelineResolver.from_events(events)
+    attribution = resolver.resolve_for_event(events[-1])
+
+    assert attribution is not None
+    assert attribution.phase_resolution == "unique"
+    assert attribution.phase_path == "train / step"
+
+
+def test_phase_timeline_resolver_treats_same_timestamp_exit_as_active() -> None:
+    events = [
+        _make_event(
+            timestamp_ns=100,
+            event_type=PHASE_ENTER_EVENT,
+            metadata=_phase_scope(
+                action="enter",
+                name="train",
+                path=["train"],
+                scope_id="session-1:1",
+                sequence=1,
+                thread_id=11,
+            ),
+        ),
+        _make_event(
+            timestamp_ns=100,
+            event_type=PHASE_EXIT_EVENT,
+            metadata=_phase_scope(
+                action="exit",
+                name="train",
+                path=["train"],
+                scope_id="session-1:1",
+                sequence=2,
+                thread_id=11,
+            ),
+        ),
+        _make_event(timestamp_ns=100),
+    ]
+
+    resolver = PhaseTimelineResolver.from_events(events)
+    attribution = resolver.resolve_for_event(events[-1])
+
+    assert attribution is not None
+    assert attribution.phase_resolution == "unique"
+    assert attribution.phase_path == "train"
+
+
+def test_phase_timeline_resolver_synthesizes_open_scope_until_session_end() -> None:
+    events = [
+        _make_event(
+            timestamp_ns=100,
+            event_type=PHASE_ENTER_EVENT,
+            metadata=_phase_scope(
+                action="enter",
+                name="evaluate",
+                path=["evaluate"],
+                scope_id="session-1:1",
+                sequence=1,
+                thread_id=11,
+            ),
+        ),
+        _make_event(timestamp_ns=200),
+    ]
+
+    resolver = PhaseTimelineResolver.from_events(events)
+    attribution = resolver.resolve_for_event(events[-1])
+
+    assert attribution is not None
+    assert attribution.phase_resolution == "unique"
+    assert attribution.phase_path == "evaluate"
+
+
+def test_phase_timeline_resolver_marks_multi_thread_overlap_ambiguous() -> None:
+    events = [
+        _make_event(
+            timestamp_ns=100,
+            event_type=PHASE_ENTER_EVENT,
+            metadata=_phase_scope(
+                action="enter",
+                name="train",
+                path=["train"],
+                scope_id="session-1:1",
+                sequence=1,
+                thread_id=11,
+            ),
+        ),
+        _make_event(
+            timestamp_ns=110,
+            event_type=PHASE_ENTER_EVENT,
+            metadata=_phase_scope(
+                action="enter",
+                name="evaluate",
+                path=["evaluate"],
+                scope_id="session-1:2",
+                sequence=2,
+                thread_id=12,
+            ),
+        ),
+        _make_event(timestamp_ns=120),
+    ]
+
+    resolver = PhaseTimelineResolver.from_events(events)
+    attribution = resolver.resolve_for_event(events[-1])
+
+    assert attribution is not None
+    assert attribution.phase_resolution == "ambiguous"
+    assert attribution.phase_paths == ["evaluate", "train"]

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -6,7 +6,10 @@ from stormlog.phases import (
     PHASE_ENTER_EVENT,
     PHASE_EXIT_EVENT,
     PHASE_SCOPE_METADATA_KEY,
+    PhaseAttribution,
     PhaseTimelineResolver,
+    merge_phase_attributions,
+    summarize_phase_attribution,
 )
 from stormlog.telemetry import SCHEMA_VERSION_V3, telemetry_event_from_record
 
@@ -207,3 +210,42 @@ def test_phase_timeline_resolver_marks_multi_thread_overlap_ambiguous() -> None:
     assert attribution is not None
     assert attribution.phase_resolution == "ambiguous"
     assert attribution.phase_paths == ["evaluate", "train"]
+
+
+def test_merge_phase_attributions_keeps_same_label_multi_thread_overlap_ambiguous() -> (
+    None
+):
+    merged = merge_phase_attributions(
+        PhaseAttribution(
+            phase_resolution="unique",
+            phase_path="train / step",
+            phase_paths=["train / step"],
+            scope_id="scope-1",
+            thread_id=11,
+            thread_name="thread-11",
+        ),
+        PhaseAttribution(
+            phase_resolution="unique",
+            phase_path="train / step",
+            phase_paths=["train / step"],
+            scope_id="scope-2",
+            thread_id=12,
+            thread_name="thread-12",
+        ),
+    )
+
+    assert merged is not None
+    assert merged.phase_resolution == "ambiguous"
+    assert merged.phase_paths == ["train / step"]
+    assert merged.phase_path is None
+
+
+def test_summarize_phase_attribution_marks_ambiguous_single_label() -> None:
+    summary = summarize_phase_attribution(
+        PhaseAttribution(
+            phase_resolution="ambiguous",
+            phase_paths=["train / step"],
+        )
+    )
+
+    assert summary == "(ambiguous) train / step"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -6,6 +6,7 @@ from stormlog.session import (
     SESSION_STATUS_COMPLETED,
     SESSION_STATUS_RUNNING,
     SessionSummary,
+    _HasSummary,
     create_session_summary,
     select_default_session,
     update_session_summary,
@@ -13,7 +14,7 @@ from stormlog.session import (
 
 
 @dataclass(frozen=True)
-class _LoadedSession:
+class _LoadedSession(_HasSummary):
     summary: SessionSummary
 
 

--- a/tests/test_telemetry_v2.py
+++ b/tests/test_telemetry_v2.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import csv
 import json
 from collections import UserDict
 from pathlib import Path
@@ -9,6 +10,7 @@ from pathlib import Path
 import jsonschema  # type: ignore[import-untyped, unused-ignore]
 import pytest
 
+from stormlog.phases import extract_phase_scope
 from stormlog.telemetry import (
     SCHEMA_VERSION_V2,
     SCHEMA_VERSION_V3,
@@ -23,6 +25,7 @@ from stormlog.telemetry import (
     validate_telemetry_record,
 )
 from stormlog.telemetry_sink import AppendOnlyTelemetrySink, TelemetrySinkConfig
+from stormlog.tui.distributed_diagnostics import load_distributed_artifacts
 
 
 def _schema(version: int) -> dict[str, object]:
@@ -206,6 +209,203 @@ def test_legacy_tf_record_converts_with_defaults() -> None:
     assert isinstance(record["session_id"], str)
     assert record["session_id"]
     jsonschema.validate(instance=record, schema=_schema(SCHEMA_VERSION_V3))
+
+
+def test_phase_boundary_record_round_trips_through_v3_schema() -> None:
+    event = telemetry_event_from_record(
+        {
+            "schema_version": SCHEMA_VERSION_V3,
+            "session_id": "session-phase",
+            "timestamp_ns": 1_700_000_000_000_000_100,
+            "event_type": "phase_enter",
+            "collector": "stormlog.cuda_tracker",
+            "sampling_interval_ms": 100,
+            "pid": 1234,
+            "host": "host-a",
+            "job_id": "job-123",
+            "rank": 1,
+            "local_rank": 1,
+            "world_size": 8,
+            "device_id": 0,
+            "allocator_allocated_bytes": 1024,
+            "allocator_reserved_bytes": 2048,
+            "allocator_active_bytes": 512,
+            "allocator_inactive_bytes": 1536,
+            "allocator_change_bytes": 0,
+            "device_used_bytes": 2048,
+            "device_free_bytes": 4096,
+            "device_total_bytes": 6144,
+            "context": "Phase entered: train / step",
+            "metadata": {
+                "phase_scope": {
+                    "action": "enter",
+                    "name": "step",
+                    "path": ["train", "step"],
+                    "depth": 2,
+                    "scope_id": "session-phase:2",
+                    "parent_scope_id": "session-phase:1",
+                    "thread_id": 88,
+                    "thread_name": "MainThread",
+                    "sequence": 2,
+                    "attributes": {"epoch": 3},
+                }
+            },
+        }
+    )
+
+    record = telemetry_event_to_dict(event)
+
+    validate_telemetry_record(record)
+    jsonschema.validate(instance=record, schema=_schema(SCHEMA_VERSION_V3))
+    scope = extract_phase_scope(record)
+    assert scope is not None
+    assert scope.path == ("train", "step")
+    assert scope.attributes == {"epoch": 3}
+
+
+def test_load_telemetry_sessions_preserves_phase_scope_metadata_across_formats(
+    tmp_path: Path,
+) -> None:
+    sample_record = telemetry_event_to_dict(
+        telemetry_event_from_record(
+            {
+                "schema_version": SCHEMA_VERSION_V3,
+                "session_id": "session-phase",
+                "timestamp_ns": 1_700_000_000_000_000_000,
+                "event_type": "sample",
+                "collector": "stormlog.cuda_tracker",
+                "sampling_interval_ms": 100,
+                "pid": 1234,
+                "host": "host-a",
+                "job_id": "job-123",
+                "rank": 1,
+                "local_rank": 1,
+                "world_size": 8,
+                "device_id": 0,
+                "allocator_allocated_bytes": 1024,
+                "allocator_reserved_bytes": 2048,
+                "allocator_active_bytes": 512,
+                "allocator_inactive_bytes": 1536,
+                "allocator_change_bytes": 0,
+                "device_used_bytes": 2048,
+                "device_free_bytes": 4096,
+                "device_total_bytes": 6144,
+                "context": "sample",
+                "metadata": {},
+            }
+        )
+    )
+    enter_record = dict(sample_record)
+    enter_record.update(
+        {
+            "timestamp_ns": sample_record["timestamp_ns"] + 10,
+            "event_type": "phase_enter",
+            "context": "Phase entered: train / step",
+            "metadata": {
+                "phase_scope": {
+                    "action": "enter",
+                    "name": "step",
+                    "path": ["train", "step"],
+                    "depth": 2,
+                    "scope_id": "session-phase:2",
+                    "parent_scope_id": "session-phase:1",
+                    "thread_id": 88,
+                    "thread_name": "MainThread",
+                    "sequence": 2,
+                    "attributes": {"epoch": 3},
+                }
+            },
+        }
+    )
+    exit_record = dict(enter_record)
+    exit_record.update(
+        {
+            "timestamp_ns": enter_record["timestamp_ns"] + 10,
+            "event_type": "phase_exit",
+            "context": "Phase exited: train / step",
+            "metadata": {
+                "phase_scope": {
+                    "action": "exit",
+                    "name": "step",
+                    "path": ["train", "step"],
+                    "depth": 2,
+                    "scope_id": "session-phase:2",
+                    "parent_scope_id": "session-phase:1",
+                    "thread_id": 88,
+                    "thread_name": "MainThread",
+                    "sequence": 3,
+                    "attributes": {"epoch": 3},
+                }
+            },
+        }
+    )
+    records = [sample_record, enter_record, exit_record]
+
+    json_path = tmp_path / "events.json"
+    json_path.write_text(json.dumps(records), encoding="utf-8")
+
+    csv_path = tmp_path / "events.csv"
+    with csv_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(sample_record.keys()))
+        writer.writeheader()
+        for record in records:
+            writer.writerow(
+                {
+                    key: (
+                        json.dumps(value)
+                        if isinstance(value, dict)
+                        else ("" if value is None else str(value))
+                    )
+                    for key, value in record.items()
+                }
+            )
+
+    sink = AppendOnlyTelemetrySink(
+        TelemetrySinkConfig(
+            root_dir=tmp_path / "sink",
+            flush_every_events=1,
+            flush_every_seconds=1.0,
+        )
+    )
+    for record in records:
+        sink.append(record)
+    sink.close()
+
+    for source in (json_path, tmp_path / "sink"):
+        loaded = load_telemetry_sessions(source, permissive_legacy=True)
+        assert len(loaded) == 1
+        phase_events = [
+            event for event in loaded[0].events if event.event_type.startswith("phase_")
+        ]
+        assert [event.event_type for event in phase_events] == [
+            "phase_enter",
+            "phase_exit",
+        ]
+        enter_scope = extract_phase_scope(phase_events[0])
+        exit_scope = extract_phase_scope(phase_events[1])
+        assert enter_scope is not None
+        assert exit_scope is not None
+        assert enter_scope.path == ("train", "step")
+        assert enter_scope.attributes == {"epoch": 3}
+        assert exit_scope.scope_id == enter_scope.scope_id
+
+    artifact_result = load_distributed_artifacts([csv_path])
+    csv_phase_events = [
+        event
+        for event in artifact_result.events
+        if event.event_type.startswith("phase_")
+    ]
+    assert [event.event_type for event in csv_phase_events] == [
+        "phase_enter",
+        "phase_exit",
+    ]
+    csv_enter_scope = extract_phase_scope(csv_phase_events[0])
+    csv_exit_scope = extract_phase_scope(csv_phase_events[1])
+    assert csv_enter_scope is not None
+    assert csv_exit_scope is not None
+    assert csv_enter_scope.path == ("train", "step")
+    assert csv_enter_scope.attributes == {"epoch": 3}
+    assert csv_exit_scope.scope_id == csv_enter_scope.scope_id
 
 
 def test_resolve_distributed_identity_uses_torchrun_env() -> None:

--- a/tests/test_tf_telemetry_export.py
+++ b/tests/test_tf_telemetry_export.py
@@ -13,6 +13,7 @@ import pytest
 import stormlog.tensorflow.cli as tf_cli
 import stormlog.tensorflow.tracker as tf_tracker
 from stormlog.collector_health import COLLECTOR_HEALTH_UNHEALTHY
+from stormlog.phases import extract_phase_scope
 from stormlog.telemetry import validate_telemetry_record
 from stormlog.telemetry_sink import TelemetrySinkConfig
 
@@ -603,7 +604,42 @@ def test_tf_tracker_recreates_sink_on_restart(
     assert tracker._telemetry_sink is None
 
     tracker.start_tracking()
-    second_sink = tracker._telemetry_sink
+    second_sink = cast(object, tracker._telemetry_sink)
 
     assert second_sink is not None
     assert second_sink is not first_sink
+
+
+def test_tf_tracker_emits_structured_phase_boundaries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(tf_tracker, "TF_AVAILABLE", True)
+    monkeypatch.setattr(tf_tracker.threading, "Thread", _NoOpThread)
+
+    tracker = tf_tracker.MemoryTracker(
+        sampling_interval=0.01,
+        device="/GPU:0",
+        enable_logging=False,
+    )
+
+    tracker.start_tracking()
+    with tracker.phase("train_step", metadata={"epoch": 2}) as handle:
+        assert handle.phase_path == "train_step"
+    result = tracker.stop_tracking()
+
+    phase_events = [
+        event for event in result.events if event["event_type"].startswith("phase_")
+    ]
+    assert [event["event_type"] for event in phase_events] == [
+        "phase_enter",
+        "phase_exit",
+    ]
+
+    enter_scope = extract_phase_scope(phase_events[0])
+    exit_scope = extract_phase_scope(phase_events[1])
+    assert enter_scope is not None
+    assert exit_scope is not None
+    assert enter_scope.path == ("train_step",)
+    assert enter_scope.attributes == {"epoch": 2}
+    assert exit_scope.scope_id == enter_scope.scope_id
+    assert exit_scope.path == enter_scope.path

--- a/tests/test_tracker_resilience.py
+++ b/tests/test_tracker_resilience.py
@@ -13,6 +13,7 @@ from stormlog.collector_health import (
     COLLECTOR_HEALTH_UNHEALTHY,
 )
 from stormlog.device_collectors import DeviceMemorySample, DeviceMemorySampleResult
+from stormlog.phases import extract_phase_scope
 from stormlog.telemetry_sink import TelemetrySinkConfig
 
 
@@ -537,7 +538,43 @@ def test_memory_tracker_recreates_sink_on_restart(
     assert tracker._telemetry_sink is None
 
     tracker.start_tracking()
-    second_sink = tracker._telemetry_sink
+    second_sink = cast(Any, tracker._telemetry_sink)
 
     assert second_sink is not None
     assert second_sink is not first_sink
+
+
+def test_memory_tracker_emits_structured_phase_boundaries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    collector = _SequencedCollector(
+        [DeviceMemorySampleResult(sample=_sample(allocated=128, reserved=256))]
+    )
+    tracker = _build_tracker(monkeypatch, collector)
+    monkeypatch.setattr(tracker_mod.threading, "Thread", _NoOpThread)
+
+    tracker.start_tracking()
+    with tracker.phase("forward", metadata={"microbatch": 4}) as handle:
+        assert handle.phase_path == "forward"
+    tracker.stop_tracking()
+
+    phase_events = [
+        event for event in tracker.get_events() if event.event_type.startswith("phase_")
+    ]
+    assert [event.event_type for event in phase_events] == [
+        "phase_enter",
+        "phase_exit",
+    ]
+
+    enter_scope = extract_phase_scope(
+        tracker._telemetry_record_from_event(phase_events[0])
+    )
+    exit_scope = extract_phase_scope(
+        tracker._telemetry_record_from_event(phase_events[1])
+    )
+    assert enter_scope is not None
+    assert exit_scope is not None
+    assert enter_scope.path == ("forward",)
+    assert enter_scope.attributes == {"microbatch": 4}
+    assert exit_scope.scope_id == enter_scope.scope_id
+    assert exit_scope.path == enter_scope.path

--- a/tests/tui/test_distributed_diagnostics.py
+++ b/tests/tui/test_distributed_diagnostics.py
@@ -26,6 +26,7 @@ def _make_event(
     timestamp: float,
     rank: int,
     world_size: int,
+    session_id: str | None = None,
     event_type: str = "sample",
     allocated: int = 0,
     reserved: int = 0,
@@ -34,8 +35,35 @@ def _make_event(
     context: str = "",
     metadata: dict[str, object] | None = None,
 ) -> TelemetryEvent:
-    return telemetry_event_from_record(
-        {
+    if session_id is not None:
+        used_bytes = used or reserved
+        record: dict[str, object] = {
+            "schema_version": 3,
+            "session_id": session_id,
+            "timestamp_ns": int(timestamp * 1_000_000_000),
+            "event_type": event_type,
+            "collector": "stormlog.cuda_tracker",
+            "sampling_interval_ms": 100,
+            "pid": 1234,
+            "host": "test-host",
+            "device_id": 0,
+            "allocator_allocated_bytes": allocated,
+            "allocator_reserved_bytes": reserved,
+            "allocator_active_bytes": None,
+            "allocator_inactive_bytes": None,
+            "allocator_change_bytes": 0,
+            "device_used_bytes": used_bytes,
+            "device_free_bytes": None if total is None else max(0, total - used_bytes),
+            "device_total_bytes": total,
+            "context": context,
+            "job_id": "job-1",
+            "rank": rank,
+            "local_rank": rank,
+            "world_size": world_size,
+            "metadata": metadata or {},
+        }
+    else:
+        record = {
             "timestamp": timestamp,
             "event_type": event_type,
             "memory_allocated": allocated,
@@ -54,7 +82,9 @@ def _make_event(
             "local_rank": rank,
             "world_size": world_size,
             "metadata": metadata or {},
-        },
+        }
+    return telemetry_event_from_record(
+        record,
         permissive_legacy=True,
         default_collector="stormlog.cuda_tracker",
         default_sampling_interval_ms=100,
@@ -241,6 +271,93 @@ def test_build_distributed_model_surfaces_collective_attribution_signals() -> No
         assert indicator.confidence is not None
         assert indicator.reason_codes
         assert "marker_collective_token" in indicator.reason_codes
+
+
+def test_build_distributed_model_surfaces_phase_paths_in_rows_and_indicators() -> None:
+    session_id = "session-diagnostics-phase"
+    events = [
+        _make_event(
+            timestamp=0.9,
+            session_id=session_id,
+            rank=0,
+            world_size=2,
+            event_type="phase_enter",
+            allocated=10,
+            reserved=10,
+            used=10,
+            total=100,
+            context="Phase entered: train / forward",
+            metadata={
+                "phase_scope": {
+                    "action": "enter",
+                    "name": "forward",
+                    "path": ["train", "forward"],
+                    "depth": 2,
+                    "scope_id": "phase-0",
+                    "parent_scope_id": "phase-train",
+                    "thread_id": 1,
+                    "thread_name": "MainThread",
+                    "sequence": 1,
+                }
+            },
+        ),
+        _make_event(
+            timestamp=1.0,
+            session_id=session_id,
+            rank=0,
+            world_size=2,
+            allocated=10,
+            reserved=15,
+            used=30,
+            total=100,
+            context="gap breach",
+        ),
+        _make_event(
+            timestamp=1.1,
+            session_id=session_id,
+            rank=1,
+            world_size=2,
+            allocated=12,
+            reserved=12,
+            used=12,
+            total=100,
+        ),
+        _make_event(
+            timestamp=1.2,
+            session_id=session_id,
+            rank=0,
+            world_size=2,
+            event_type="phase_exit",
+            allocated=10,
+            reserved=10,
+            used=10,
+            total=100,
+            context="Phase exited: train / forward",
+            metadata={
+                "phase_scope": {
+                    "action": "exit",
+                    "name": "forward",
+                    "path": ["train", "forward"],
+                    "depth": 2,
+                    "scope_id": "phase-0",
+                    "parent_scope_id": "phase-train",
+                    "thread_id": 1,
+                    "thread_name": "MainThread",
+                    "sequence": 2,
+                }
+            },
+        ),
+    ]
+
+    model = build_distributed_model(events)
+    row_rank_0 = next(row for row in model.rows if row.rank == 0)
+    earliest_indicator = next(
+        indicator for indicator in model.indicators if indicator.kind == "earliest"
+    )
+
+    assert row_rank_0.first_anomaly_phase_path == "train / forward"
+    assert earliest_indicator.phase_path == "train / forward"
+    assert "Phase: train / forward." in earliest_indicator.details
 
 
 def test_load_distributed_artifacts_merges_json_and_csv_inputs(


### PR DESCRIPTION
## Summary

This PR introduces structured workload phases for long-running monitor telemetry so anomalies can be explained in terms of workload scope, not only raw timestamps.

### What changed

- Added structured phase companion records under `metadata["phase_scope"]` without changing the raw telemetry schema version.
- Added tracker-owned phase instrumentation APIs:
  - `phase(name, metadata=None)`
  - `enter_phase(name, metadata=None)`
  - `PhaseHandle.close()`
- Added deterministic phase replay and attribution helpers in `stormlog/phases.py`.
- Extended analysis paths to attach optional phase attribution to:
  - gap findings
  - collective attribution results
  - cross-rank first-cause suspects
  - TUI distributed diagnostics indicators and rows
- Updated CLI and docs to surface phase-aware interpretation.
- Added a CPU-only phase demo and expanded regression coverage.

### Review follow-up fixes

- Preserved ambiguity when overlapping phases from different threads share the same visible path label.
- Marked ambiguous phase summaries explicitly in shared rendering and CLI output.
- Aligned Black across direct `.venv/bin/python -m black` usage and project configuration by pinning `24.3.0` and requiring that version in `pyproject.toml`.

## Why

Always-on telemetry is more useful when it can answer not just when memory changed, but what workload phase was active when it changed. This improves explainability for long-lived training and inference workloads while keeping phase instrumentation optional and bounded in overhead.

## Validation

- Focused telemetry/analysis/TUI suite: `93 passed`
- Non-TF suite: `405 passed, 17 skipped, 18 deselected`
- TF suite: `44 passed, 1 skipped`
- TUI pilot/snapshot suite: `17 passed, 25 deselected`
- PTY smoke: `1 passed`
- `isort --check --diff` passed
- `black --check` passed
- `flake8` passed
- `mypy stormlog/` passed
- `pre-commit run --all-files` passed
- `sphinx -W -b html docs docs/_build/html` passed
- `zizmor .github/workflows/*.yml` reported no findings

Closes #94 
