### PR TITLE
feat(telemetry): add derived_fields module for computed metrics (#117)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,6 +150,7 @@ Analyzers turn raw or normalized memory data into higher-level findings.
 - `stormlog.analyzer.MemoryAnalyzer`
 - `stormlog.tensorflow.analyzer.MemoryAnalyzer`
 - gap-analysis and collective-attribution helpers in `stormlog`
+- common metric formulas centralized in `stormlog.derived_fields`
 
 These modules power:
 

--- a/stormlog/derived_fields.py
+++ b/stormlog/derived_fields.py
@@ -19,7 +19,10 @@ Usage::
 
 from __future__ import annotations
 
+import dataclasses
 from typing import Any, Dict, Sequence, TypedDict
+
+from .collector_health import COLLECTOR_HEALTH_DEGRADED
 
 # ---------------------------------------------------------------------------
 # Public contract
@@ -38,8 +41,8 @@ class DerivedFields(TypedDict, total=False):
     utilization_ratio: None | float
     fragmentation_ratio: None | float
     is_degraded_collector: bool
-    is_session_interrupted: bool
-    health_score: float
+    # is_session_interrupted: bool   # TODO(#117): wire when session logic lands
+    # health_score: float            # TODO(#117): wire when scoring logic lands
 
 
 class SessionDerivedFields(TypedDict, total=False):  # type false for nullable fields
@@ -60,7 +63,7 @@ class SessionDerivedFields(TypedDict, total=False):  # type false for nullable f
 _DEGRADED_COLLECTOR_SUBSTRINGS: frozenset[str] = frozenset(
     {
         "fallback",
-        "degraded",
+        COLLECTOR_HEALTH_DEGRADED,  # canonical constant from collector_health.py
         "unavailable",
         "partial",
         "legacy.unknown",
@@ -85,8 +88,14 @@ def _compute_hidden_gap_bytes(
     allocator_allocated_bytes: int,
     allocator_reserved_bytes: int,
 ) -> int:
-    """Reserved memory that the allocator holds but has not actively allocated."""
-    return allocator_reserved_bytes - allocator_allocated_bytes
+    """Reserved memory that the allocator holds but has not actively allocated.
+
+    Clamped to zero — negative values indicate a stale or inconsistent snapshot
+    rather than a meaningful metric.
+    """
+    return max(
+        0, allocator_reserved_bytes - allocator_allocated_bytes
+    )  # TODO: review occasional negatives
 
 
 def _compute_utilization_ratio(
@@ -94,7 +103,7 @@ def _compute_utilization_ratio(
     device_total_bytes: None | int,
 ) -> None | float:
     """Fraction of device capacity currently allocated (0.0 – 1.0)."""
-    if not device_total_bytes:
+    if device_total_bytes is None or device_total_bytes <= 0:
         return None
     return allocator_allocated_bytes / device_total_bytes
 
@@ -112,6 +121,18 @@ def _compute_fragmentation_ratio(
         return None
     gap = allocator_reserved_bytes - allocator_allocated_bytes
     return gap / allocator_reserved_bytes
+
+
+# ---------------------------------------------------------------------------
+# Shared accessor
+# ---------------------------------------------------------------------------
+
+
+def _event_get(event: Any, key: str, default: Any = None) -> Any:
+    """Uniform attribute access — works for dataclasses and plain dicts alike."""
+    if isinstance(event, dict):
+        return event.get(key, default)
+    return getattr(event, key, default)
 
 
 # ---------------------------------------------------------------------------
@@ -135,17 +156,10 @@ def compute_event_fields(event: Any) -> DerivedFields:
     Returns:
         A :class:`DerivedFields` dict.
     """
-
-    # Uniform attribute access — works for dataclasses and plain dicts alike.
-    def _get(key: str, default: Any = None) -> Any:
-        if isinstance(event, dict):
-            return event.get(key, default)
-        return getattr(event, key, default)
-
-    allocated: int = int(_get("allocator_allocated_bytes", 0) or 0)
-    reserved: int = int(_get("allocator_reserved_bytes", 0) or 0)
-    device_total: None | int = _get("device_total_bytes")
-    collector: None | str = _get("collector")
+    allocated: int = int(_event_get(event, "allocator_allocated_bytes", 0) or 0)
+    reserved: int = int(_event_get(event, "allocator_reserved_bytes", 0) or 0)
+    device_total: None | int = _event_get(event, "device_total_bytes")
+    collector: None | str = _event_get(event, "collector")
 
     result: DerivedFields = {
         "hidden_gap_bytes": _compute_hidden_gap_bytes(allocated, reserved),
@@ -191,11 +205,7 @@ def compute_session_fields(events: Sequence[Any]) -> SessionDerivedFields:
 
     last_event_type: str = ""
     if events:
-        last = events[-1]
-        if isinstance(last, dict):
-            last_event_type = last.get("event_type", "")
-        else:
-            last_event_type = getattr(last, "event_type", "")
+        last_event_type = _event_get(events[-1], "event_type", "")
 
     is_interrupted = last_event_type != "stop"
 
@@ -220,14 +230,10 @@ def enrich_event(event: Any) -> Dict[str, Any]:
     """
     if isinstance(event, dict):
         raw: Dict[str, Any] = dict(event)
+    elif dataclasses.is_dataclass(event):
+        raw = dataclasses.asdict(event)
     else:
-        # Dataclass / object: pull via __dict__ if available, else vars()
-        try:
-            from dataclasses import asdict
-
-            raw = asdict(event)
-        except TypeError:
-            raw = dict(vars(event))
+        raw = dict(vars(event))
 
     raw["derived"] = dict(compute_event_fields(event))
     return raw

--- a/stormlog/derived_fields.py
+++ b/stormlog/derived_fields.py
@@ -10,11 +10,11 @@ Usage::
     from stormlog.derived_fields import compute_event_fields, enrich_event
 
     fields = compute_event_fields(event)
-    # fields["hidden_gap_bytes"] always present
+    # fields["allocator_gap_bytes"] always present
     # fields["utilization_ratio"] is None when device_total_bytes is unknown
 
     enriched = enrich_event(event)
-    # {"allocator_allocated_bytes": ..., ..., "hidden_gap_bytes": ..., ...}
+    # {"allocator_allocated_bytes": ..., ..., "allocator_gap_bytes": ..., ...}
 """
 
 from __future__ import annotations
@@ -32,17 +32,15 @@ from .collector_health import COLLECTOR_HEALTH_DEGRADED
 class DerivedFields(TypedDict, total=False):
     """Computed fields derived from a single telemetry event.
 
-    ``hidden_gap_bytes`` is always present.  All other fields are present only
+    ``allocator_gap_bytes`` is always present.  All other fields are present only
     when the underlying raw counters are available; their absence is encoded as
     ``None`` in the returned dict rather than a missing key.
     """
 
-    hidden_gap_bytes: int
+    allocator_gap_bytes: int
     utilization_ratio: None | float
     fragmentation_ratio: None | float
     is_degraded_collector: bool
-    # is_session_interrupted: bool   # TODO(#117): wire when session logic lands
-    # health_score: float            # TODO(#117): wire when scoring logic lands
 
 
 class SessionDerivedFields(TypedDict, total=False):  # type false for nullable fields
@@ -84,7 +82,7 @@ def _collector_is_degraded(collector: None | str) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _compute_hidden_gap_bytes(
+def _compute_allocator_gap_bytes(
     allocator_allocated_bytes: int,
     allocator_reserved_bytes: int,
 ) -> int:
@@ -93,9 +91,7 @@ def _compute_hidden_gap_bytes(
     Clamped to zero — negative values indicate a stale or inconsistent snapshot
     rather than a meaningful metric.
     """
-    return max(
-        0, allocator_reserved_bytes - allocator_allocated_bytes
-    )  # TODO: review occasional negatives
+    return max(0, allocator_reserved_bytes - allocator_allocated_bytes)
 
 
 def _compute_utilization_ratio(
@@ -119,7 +115,9 @@ def _compute_fragmentation_ratio(
     """
     if allocator_reserved_bytes == 0:
         return None
-    gap = allocator_reserved_bytes - allocator_allocated_bytes
+    gap = _compute_allocator_gap_bytes(
+        allocator_allocated_bytes, allocator_reserved_bytes
+    )
     return gap / allocator_reserved_bytes
 
 
@@ -146,7 +144,7 @@ def compute_event_fields(event: Any) -> DerivedFields:
     ``event`` may be a ``TelemetryEventV2``, ``TelemetryEventV3``, or any
     object / mapping that exposes the standard allocator counter attributes.
 
-    ``hidden_gap_bytes`` is always present in the returned dict.  Fields that
+    ``allocator_gap_bytes`` is always present in the returned dict.  Fields that
     require raw counters which may be absent (e.g. ``device_total_bytes``) are
     returned as ``None`` rather than being omitted.
 
@@ -162,7 +160,7 @@ def compute_event_fields(event: Any) -> DerivedFields:
     collector: None | str = _event_get(event, "collector")
 
     result: DerivedFields = {
-        "hidden_gap_bytes": _compute_hidden_gap_bytes(allocated, reserved),
+        "allocator_gap_bytes": _compute_allocator_gap_bytes(allocated, reserved),
         "utilization_ratio": _compute_utilization_ratio(allocated, device_total),
         "fragmentation_ratio": _compute_fragmentation_ratio(allocated, reserved),
         "is_degraded_collector": _collector_is_degraded(collector),
@@ -226,7 +224,7 @@ def enrich_event(event: Any) -> Dict[str, Any]:
         event: A telemetry event object or mapping.
 
     Returns:
-        ``{"schema_version": ..., ..., "derived": {"hidden_gap_bytes": ..., ...}}``
+        ``{"schema_version": ..., ..., "derived": {"allocator_gap_bytes": ..., ...}}``
     """
     if isinstance(event, dict):
         raw: Dict[str, Any] = dict(event)

--- a/stormlog/derived_fields.py
+++ b/stormlog/derived_fields.py
@@ -1,0 +1,242 @@
+"""Registry-driven derived-field layer for Stormlog telemetry.
+
+Centralises the common investigation formulas (allocator gap, utilisation %,
+fragmentation ratio, degraded-collector state) so that ``diagnose.py``,
+``gap_analysis.py``, and future TUI surfaces all use a single, tested source
+of truth instead of copy-pasting the same arithmetic.
+
+Usage::
+
+    from stormlog.derived_fields import compute_event_fields, enrich_event
+
+    fields = compute_event_fields(event)
+    # fields["hidden_gap_bytes"] always present
+    # fields["utilization_ratio"] is None when device_total_bytes is unknown
+
+    enriched = enrich_event(event)
+    # {"allocator_allocated_bytes": ..., ..., "hidden_gap_bytes": ..., ...}
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Sequence, TypedDict
+
+# ---------------------------------------------------------------------------
+# Public contract
+# ---------------------------------------------------------------------------
+
+
+class DerivedFields(TypedDict, total=False):
+    """Computed fields derived from a single telemetry event.
+
+    ``hidden_gap_bytes`` is always present.  All other fields are present only
+    when the underlying raw counters are available; their absence is encoded as
+    ``None`` in the returned dict rather than a missing key.
+    """
+
+    hidden_gap_bytes: int
+    utilization_ratio: None | float
+    fragmentation_ratio: None | float
+    is_degraded_collector: bool
+    is_session_interrupted: bool
+    health_score: float
+
+
+class SessionDerivedFields(TypedDict, total=False):  # type false for nullable fields
+    """Session-scoped rollups computed across a sequence of events."""
+
+    peak_utilization_ratio: None | float
+    avg_fragmentation_ratio: None | float
+    is_session_interrupted: bool
+
+
+# ---------------------------------------------------------------------------
+# Degraded-collector registry
+# ---------------------------------------------------------------------------
+
+# Collector strings that indicate the collector is operating in a degraded /
+# fallback mode.  Cross-referenced against ``collector_health.py`` status
+# constants and the known collector name fragments used in ``telemetry.py``.
+_DEGRADED_COLLECTOR_SUBSTRINGS: frozenset[str] = frozenset(
+    {
+        "fallback",
+        "degraded",
+        "unavailable",
+        "partial",
+        "legacy.unknown",
+    }
+)
+
+
+def _collector_is_degraded(collector: None | str) -> bool:
+    """Return True when the collector name signals a degraded / fallback mode."""
+    if not collector:
+        return False
+    lower = collector.lower()
+    return any(fragment in lower for fragment in _DEGRADED_COLLECTOR_SUBSTRINGS)
+
+
+# ---------------------------------------------------------------------------
+# Per-field compute helpers (the "registry")
+# ---------------------------------------------------------------------------
+
+
+def _compute_hidden_gap_bytes(
+    allocator_allocated_bytes: int,
+    allocator_reserved_bytes: int,
+) -> int:
+    """Reserved memory that the allocator holds but has not actively allocated."""
+    return allocator_reserved_bytes - allocator_allocated_bytes
+
+
+def _compute_utilization_ratio(
+    allocator_allocated_bytes: int,
+    device_total_bytes: None | int,
+) -> None | float:
+    """Fraction of device capacity currently allocated (0.0 – 1.0)."""
+    if not device_total_bytes:
+        return None
+    return allocator_allocated_bytes / device_total_bytes
+
+
+def _compute_fragmentation_ratio(
+    allocator_allocated_bytes: int,
+    allocator_reserved_bytes: int,
+) -> None | float:
+    """Fraction of reserved memory that is fragmented (unused gap / reserved).
+
+    Returns ``None`` when ``allocator_reserved_bytes`` is zero to avoid
+    division-by-zero.
+    """
+    if allocator_reserved_bytes == 0:
+        return None
+    gap = allocator_reserved_bytes - allocator_allocated_bytes
+    return gap / allocator_reserved_bytes
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def compute_event_fields(event: Any) -> DerivedFields:
+    """Compute row-scoped derived fields from a single telemetry event.
+
+    ``event`` may be a ``TelemetryEventV2``, ``TelemetryEventV3``, or any
+    object / mapping that exposes the standard allocator counter attributes.
+
+    ``hidden_gap_bytes`` is always present in the returned dict.  Fields that
+    require raw counters which may be absent (e.g. ``device_total_bytes``) are
+    returned as ``None`` rather than being omitted.
+
+    Args:
+        event: A telemetry event object or mapping.
+
+    Returns:
+        A :class:`DerivedFields` dict.
+    """
+
+    # Uniform attribute access — works for dataclasses and plain dicts alike.
+    def _get(key: str, default: Any = None) -> Any:
+        if isinstance(event, dict):
+            return event.get(key, default)
+        return getattr(event, key, default)
+
+    allocated: int = int(_get("allocator_allocated_bytes", 0) or 0)
+    reserved: int = int(_get("allocator_reserved_bytes", 0) or 0)
+    device_total: None | int = _get("device_total_bytes")
+    collector: None | str = _get("collector")
+
+    result: DerivedFields = {
+        "hidden_gap_bytes": _compute_hidden_gap_bytes(allocated, reserved),
+        "utilization_ratio": _compute_utilization_ratio(allocated, device_total),
+        "fragmentation_ratio": _compute_fragmentation_ratio(allocated, reserved),
+        "is_degraded_collector": _collector_is_degraded(collector),
+    }
+    return result
+
+
+def compute_session_fields(events: Sequence[Any]) -> SessionDerivedFields:
+    """Compute session-scoped rollups across an ordered sequence of events.
+
+    Args:
+        events: Ordered sequence of telemetry event objects or mappings.
+
+    Returns:
+        A :class:`SessionDerivedFields` dict with:
+
+        * ``peak_utilization_ratio`` — highest per-event utilization seen; or
+          ``None`` if ``device_total_bytes`` was unavailable in every event.
+        * ``avg_fragmentation_ratio`` — mean fragmentation ratio across events
+          where ``allocator_reserved_bytes > 0``; ``None`` if none qualify.
+        * ``is_session_interrupted`` — ``True`` when the last event is not a
+          ``"stop"`` event.
+    """
+    util_values: list[float] = []
+    frag_values: list[float] = []
+
+    for event in events:
+        per_event = compute_event_fields(event)
+        u = per_event.get("utilization_ratio")
+        if u is not None:
+            util_values.append(u)
+        f = per_event.get("fragmentation_ratio")
+        if f is not None:
+            frag_values.append(f)
+
+    peak_utilization: None | float = max(util_values) if util_values else None
+    avg_fragmentation: None | float = (
+        sum(frag_values) / len(frag_values) if frag_values else None
+    )
+
+    last_event_type: str = ""
+    if events:
+        last = events[-1]
+        if isinstance(last, dict):
+            last_event_type = last.get("event_type", "")
+        else:
+            last_event_type = getattr(last, "event_type", "")
+
+    is_interrupted = last_event_type != "stop"
+
+    return {
+        "peak_utilization_ratio": peak_utilization,
+        "avg_fragmentation_ratio": avg_fragmentation,
+        "is_session_interrupted": is_interrupted,
+    }
+
+
+def enrich_event(event: Any) -> Dict[str, Any]:
+    """Return a flat dict merging raw event fields with derived fields.
+
+    Derived fields are nested under a ``"derived"`` key so that raw and
+    computed fields never collide.
+
+    Args:
+        event: A telemetry event object or mapping.
+
+    Returns:
+        ``{"schema_version": ..., ..., "derived": {"hidden_gap_bytes": ..., ...}}``
+    """
+    if isinstance(event, dict):
+        raw: Dict[str, Any] = dict(event)
+    else:
+        # Dataclass / object: pull via __dict__ if available, else vars()
+        try:
+            from dataclasses import asdict
+
+            raw = asdict(event)
+        except TypeError:
+            raw = dict(vars(event))
+
+    raw["derived"] = dict(compute_event_fields(event))
+    return raw
+
+
+__all__ = [
+    "DerivedFields",
+    "SessionDerivedFields",
+    "compute_event_fields",
+    "compute_session_fields",
+    "enrich_event",
+]

--- a/stormlog/diagnose.py
+++ b/stormlog/diagnose.py
@@ -238,7 +238,7 @@ def build_diagnostic_summary(
     }
     _derived = compute_event_fields(_synthetic_event)
     utilization_ratio = _derived["utilization_ratio"] or 0.0
-    hidden_gap_bytes: int = _derived["hidden_gap_bytes"]
+    allocator_gap_bytes: int = _derived["allocator_gap_bytes"]
     # fragmentation_ratio comes from check_memory_fragmentation(), which uses
     # torch.cuda.memory_stats() — a richer source than the simple
     # (reserved - allocated) / reserved approximation in compute_event_fields.
@@ -271,7 +271,7 @@ def build_diagnostic_summary(
         "reserved_bytes": reserved,
         "peak_bytes": peak,
         "total_bytes": total,
-        "hidden_gap_bytes": hidden_gap_bytes,
+        "allocator_gap_bytes": allocator_gap_bytes,
         "utilization_ratio": utilization_ratio,
         "fragmentation_ratio": fragmentation_ratio,
         "num_ooms": num_ooms,

--- a/stormlog/diagnose.py
+++ b/stormlog/diagnose.py
@@ -13,6 +13,7 @@ from .cuda_native_debug import (
     cuda_memory_history,
     cuda_memory_history_supported,
 )
+from .derived_fields import compute_event_fields
 from .device_collectors import (
     build_device_memory_collector,
     detect_torch_runtime_backend,
@@ -229,7 +230,18 @@ def build_diagnostic_summary(
             total = sample.total_bytes or 0
             peak = max(allocated, reserved)
 
-    utilization_ratio = float(allocated / total) if total else 0.0
+    _synthetic_event = {
+        "allocator_allocated_bytes": allocated,
+        "allocator_reserved_bytes": reserved,
+        "device_total_bytes": total if total else None,
+        "collector": None,
+    }
+    _derived = compute_event_fields(_synthetic_event)
+    utilization_ratio = _derived["utilization_ratio"] or 0.0
+    hidden_gap_bytes: int = _derived["hidden_gap_bytes"]
+    # fragmentation_ratio comes from check_memory_fragmentation(), which uses
+    # torch.cuda.memory_stats() — a richer source than the simple
+    # (reserved - allocated) / reserved approximation in compute_event_fields.
     fragmentation_ratio = float(frag_info.get("fragmentation_ratio", 0))
     num_ooms = 0
     if (
@@ -259,6 +271,7 @@ def build_diagnostic_summary(
         "reserved_bytes": reserved,
         "peak_bytes": peak,
         "total_bytes": total,
+        "hidden_gap_bytes": hidden_gap_bytes,
         "utilization_ratio": utilization_ratio,
         "fragmentation_ratio": fragmentation_ratio,
         "num_ooms": num_ooms,

--- a/stormlog/gap_analysis.py
+++ b/stormlog/gap_analysis.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, List, Mapping, Sequence
 import numpy as np
 from scipy import stats
 
+from .derived_fields import compute_event_fields
 from .telemetry import TelemetryEventV2
 
 _LOGGER = logging.getLogger(__name__)
@@ -198,10 +199,10 @@ def _detect_gap_fragmentation_pattern(
     """Detect fragmentation-like behaviour: high reserved-allocated ratio."""
     frag_ratios: List[float] = []
     for event in events:
-        reserved = event.allocator_reserved_bytes
-        allocated = event.allocator_allocated_bytes
-        if reserved > 0:
-            frag_ratios.append((reserved - allocated) / reserved)
+        derived = compute_event_fields(event)
+        frag = derived.get("fragmentation_ratio")
+        if frag is not None:
+            frag_ratios.append(frag)
 
     if not frag_ratios:
         return []

--- a/stormlog/gap_analysis.py
+++ b/stormlog/gap_analysis.py
@@ -8,6 +8,7 @@ import numpy as np
 from scipy import stats
 
 from .derived_fields import compute_event_fields
+
 try:
     from .phases import PhaseAttribution, PhaseReplayIndex
 except ImportError:  # pragma: no cover - phase package may land in another slice
@@ -230,10 +231,6 @@ def _detect_gap_fragmentation_pattern(
         frag = derived.get("fragmentation_ratio")
         if frag is not None:
             frag_ratios.append(frag)
-        reserved = event.allocator_reserved_bytes
-        allocated = event.allocator_allocated_bytes
-        if reserved > 0:
-            frag_ratios.append((reserved - allocated) / reserved)
             frag_events.append(event)
 
     if not frag_ratios:

--- a/stormlog/tensorflow/diagnose.py
+++ b/stormlog/tensorflow/diagnose.py
@@ -219,7 +219,7 @@ def build_diagnostic_summary(
     #
     # compute_event_fields gives us utilization_ratio and allocator_gap_bytes;
     # allocator_gap_bytes is always 0 for TF (reserved == allocated).
-    # fragmentation_ratio is always None here (TF does not expose it).
+    # fragmentation_ratio remains 0.0 here (TF does not expose fragmentation).
     _synthetic_event = {
         "allocator_allocated_bytes": allocated,
         "allocator_reserved_bytes": allocated,

--- a/stormlog/tensorflow/diagnose.py
+++ b/stormlog/tensorflow/diagnose.py
@@ -209,8 +209,16 @@ def build_diagnostic_summary(
         peak = 0
         total_bytes = 0
 
-    # TensorFlow aliases reserved == allocated (no separate reserved counter).
-    # compute_event_fields gives us utilization_ratio and hidden_gap_bytes;
+    # TensorFlow's Python API (get_gpu_info) reports current_memory_mb and
+    # peak_memory_mb — both track *allocated* memory. There is no separate
+    # "reserved but unallocated" counter like PyTorch's
+    # torch.cuda.memory_reserved(). We intentionally alias reserved_bytes to
+    # allocated_bytes for schema compatibility across backend diagnostic
+    # summaries. Downstream consumers MUST NOT interpret reserved_bytes from
+    # a TF diagnostic summary as a real reservation signal.
+    #
+    # compute_event_fields gives us utilization_ratio and allocator_gap_bytes;
+    # allocator_gap_bytes is always 0 for TF (reserved == allocated).
     # fragmentation_ratio is always None here (TF does not expose it).
     _synthetic_event = {
         "allocator_allocated_bytes": allocated,
@@ -220,7 +228,7 @@ def build_diagnostic_summary(
     }
     _derived = compute_event_fields(_synthetic_event)
     utilization_ratio = _derived["utilization_ratio"] or 0.0
-    hidden_gap_bytes: int = _derived["hidden_gap_bytes"]  # always 0 for TF
+    allocator_gap_bytes: int = _derived["allocator_gap_bytes"]  # always 0 for TF
 
     # Risk flags (no OOM/fragmentation from TF API)
     oom_occurred = num_ooms > 0
@@ -233,10 +241,10 @@ def build_diagnostic_summary(
     summary: Dict[str, Any] = {
         "backend": backend,
         "allocated_bytes": allocated,
-        "reserved_bytes": allocated,  # TF: no separate reserved counter
+        "reserved_bytes": allocated,  # TF has no separate reserved counter; intentional alias for schema compatibility
         "peak_bytes": peak,
         "total_bytes": total_bytes,
-        "hidden_gap_bytes": hidden_gap_bytes,
+        "allocator_gap_bytes": allocator_gap_bytes,
         "utilization_ratio": utilization_ratio,
         "fragmentation_ratio": fragmentation_ratio,
         "num_ooms": num_ooms,

--- a/stormlog/tensorflow/diagnose.py
+++ b/stormlog/tensorflow/diagnose.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from stormlog.derived_fields import compute_event_fields
 from stormlog.session import (
     SESSION_STATUS_COMPLETED,
     SESSION_STATUS_INCOMPLETE,
@@ -201,15 +202,25 @@ def build_diagnostic_summary(
         total_memory_mb = d.get("total_memory_mb")
         if isinstance(total_memory_mb, (int, float)) and total_memory_mb > 0:
             total_bytes = int(total_memory_mb * 1024 * 1024)
-            utilization_ratio = float(current_mb / total_memory_mb)
         else:
             total_bytes = 0
-            utilization_ratio = 0.0
     else:
         allocated = 0
         peak = 0
         total_bytes = 0
-        utilization_ratio = 0.0
+
+    # TensorFlow aliases reserved == allocated (no separate reserved counter).
+    # compute_event_fields gives us utilization_ratio and hidden_gap_bytes;
+    # fragmentation_ratio is always None here (TF does not expose it).
+    _synthetic_event = {
+        "allocator_allocated_bytes": allocated,
+        "allocator_reserved_bytes": allocated,
+        "device_total_bytes": total_bytes if total_bytes else None,
+        "collector": None,
+    }
+    _derived = compute_event_fields(_synthetic_event)
+    utilization_ratio = _derived["utilization_ratio"] or 0.0
+    hidden_gap_bytes: int = _derived["hidden_gap_bytes"]  # always 0 for TF
 
     # Risk flags (no OOM/fragmentation from TF API)
     oom_occurred = num_ooms > 0
@@ -222,9 +233,10 @@ def build_diagnostic_summary(
     summary: Dict[str, Any] = {
         "backend": backend,
         "allocated_bytes": allocated,
-        "reserved_bytes": allocated,
+        "reserved_bytes": allocated,  # TF: no separate reserved counter
         "peak_bytes": peak,
         "total_bytes": total_bytes,
+        "hidden_gap_bytes": hidden_gap_bytes,
         "utilization_ratio": utilization_ratio,
         "fragmentation_ratio": fragmentation_ratio,
         "num_ooms": num_ooms,

--- a/tests/test_derived_fields.py
+++ b/tests/test_derived_fields.py
@@ -77,6 +77,13 @@ def test_hidden_gap_bytes_always_present_even_with_no_total() -> None:
     assert fields["hidden_gap_bytes"] == 1024
 
 
+def test_hidden_gap_bytes_clamped_to_zero_when_allocated_exceeds_reserved() -> None:
+    """Negative gaps indicate stale data; clamp to zero."""
+    event = _make_event(allocated=8 * 1024**3, reserved=4 * 1024**3)
+    fields = compute_event_fields(event)
+    assert fields["hidden_gap_bytes"] == 0
+
+
 # ---------------------------------------------------------------------------
 # compute_event_fields — utilization_ratio
 # ---------------------------------------------------------------------------
@@ -98,7 +105,7 @@ def test_utilization_ratio_is_none_when_device_total_is_none() -> None:
 
 def test_utilization_ratio_is_none_when_device_total_is_zero() -> None:
     # device_total_bytes of 0 is treated as unknown (guard against div-by-zero)
-    event = _make_event(device_total=None)
+    event = _make_event(allocated=0, reserved=0, device_total=0)
     fields = compute_event_fields(event)
     assert fields["utilization_ratio"] is None
 
@@ -305,3 +312,27 @@ def test_enrich_event_accepts_plain_dict() -> None:
     assert enriched["allocator_allocated_bytes"] == 512
     assert "derived" in enriched
     assert enriched["derived"]["hidden_gap_bytes"] == 512
+
+
+def test_enrich_event_accepts_plain_object() -> None:
+    """Exercise the vars() fallback for non-dataclass, non-dict objects."""
+    from types import SimpleNamespace
+
+    event = SimpleNamespace(
+        allocator_allocated_bytes=256,
+        allocator_reserved_bytes=512,
+        device_total_bytes=2048,
+        collector="stormlog.cpu_tracker",
+    )
+    enriched = enrich_event(event)
+    assert enriched["allocator_allocated_bytes"] == 256
+    assert "derived" in enriched
+    assert enriched["derived"]["hidden_gap_bytes"] == 256
+
+
+def test_degraded_substrings_include_canonical_health_constant() -> None:
+    """Guard against drift between derived_fields and collector_health."""
+    from stormlog.collector_health import COLLECTOR_HEALTH_DEGRADED
+    from stormlog.derived_fields import _DEGRADED_COLLECTOR_SUBSTRINGS
+
+    assert COLLECTOR_HEALTH_DEGRADED in _DEGRADED_COLLECTOR_SUBSTRINGS

--- a/tests/test_derived_fields.py
+++ b/tests/test_derived_fields.py
@@ -1,0 +1,307 @@
+"""Tests for stormlog/derived_fields.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from stormlog.derived_fields import (
+    compute_event_fields,
+    compute_session_fields,
+    enrich_event,
+)
+from stormlog.telemetry import SCHEMA_VERSION_V2, TelemetryEventV2
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_BASE_NS = 1_700_000_000_000_000_000
+_DEVICE_TOTAL = 16 * 1024**3  # 16 GiB
+
+
+def _make_event(
+    *,
+    allocated: int = 4 * 1024**3,
+    reserved: int = 6 * 1024**3,
+    device_total: int | None = _DEVICE_TOTAL,
+    collector: str = "stormlog.cuda_tracker",
+    event_type: str = "sample",
+    index: int = 0,
+) -> TelemetryEventV2:
+    """Build a minimal valid TelemetryEventV2 for derived-field tests."""
+    ts = _BASE_NS + index * 100_000_000
+    device_used = allocated
+    device_free = (device_total - device_used) if device_total is not None else None
+    return TelemetryEventV2(
+        schema_version=SCHEMA_VERSION_V2,
+        timestamp_ns=ts,
+        event_type=event_type,
+        collector=collector,
+        sampling_interval_ms=100,
+        pid=1,
+        host="test-host",
+        device_id=0,
+        allocator_allocated_bytes=allocated,
+        allocator_reserved_bytes=reserved,
+        allocator_active_bytes=None,
+        allocator_inactive_bytes=None,
+        allocator_change_bytes=0,
+        device_used_bytes=device_used,
+        device_free_bytes=device_free,
+        device_total_bytes=device_total,
+        context=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# compute_event_fields — hidden_gap_bytes
+# ---------------------------------------------------------------------------
+
+
+def test_hidden_gap_bytes_is_reserved_minus_allocated() -> None:
+    event = _make_event(allocated=4 * 1024**3, reserved=6 * 1024**3)
+    fields = compute_event_fields(event)
+    assert fields["hidden_gap_bytes"] == 2 * 1024**3
+
+
+def test_hidden_gap_bytes_is_zero_when_equal() -> None:
+    event = _make_event(allocated=4 * 1024**3, reserved=4 * 1024**3)
+    fields = compute_event_fields(event)
+    assert fields["hidden_gap_bytes"] == 0
+
+
+def test_hidden_gap_bytes_always_present_even_with_no_total() -> None:
+    event = _make_event(allocated=1024, reserved=2048, device_total=None)
+    fields = compute_event_fields(event)
+    assert "hidden_gap_bytes" in fields
+    assert fields["hidden_gap_bytes"] == 1024
+
+
+# ---------------------------------------------------------------------------
+# compute_event_fields — utilization_ratio
+# ---------------------------------------------------------------------------
+
+
+def test_utilization_ratio_when_device_total_is_known() -> None:
+    allocated = 4 * 1024**3
+    event = _make_event(allocated=allocated, device_total=_DEVICE_TOTAL)
+    fields = compute_event_fields(event)
+    expected = allocated / _DEVICE_TOTAL
+    assert fields["utilization_ratio"] == pytest.approx(expected)
+
+
+def test_utilization_ratio_is_none_when_device_total_is_none() -> None:
+    event = _make_event(device_total=None)
+    fields = compute_event_fields(event)
+    assert fields["utilization_ratio"] is None
+
+
+def test_utilization_ratio_is_none_when_device_total_is_zero() -> None:
+    # device_total_bytes of 0 is treated as unknown (guard against div-by-zero)
+    event = _make_event(device_total=None)
+    fields = compute_event_fields(event)
+    assert fields["utilization_ratio"] is None
+
+
+# ---------------------------------------------------------------------------
+# compute_event_fields — fragmentation_ratio (div-by-zero guard)
+# ---------------------------------------------------------------------------
+
+
+def test_fragmentation_ratio_normal_case() -> None:
+    allocated = 2 * 1024**3
+    reserved = 4 * 1024**3
+    event = _make_event(allocated=allocated, reserved=reserved)
+    fields = compute_event_fields(event)
+    # gap = 2 GiB, reserved = 4 GiB → ratio = 0.5
+    assert fields["fragmentation_ratio"] == pytest.approx(0.5)
+
+
+def test_fragmentation_ratio_is_none_when_reserved_is_zero() -> None:
+    """Must not divide by zero."""
+    event = _make_event(allocated=0, reserved=0)
+    fields = compute_event_fields(event)
+    assert fields["fragmentation_ratio"] is None
+
+
+def test_fragmentation_ratio_is_zero_when_fully_allocated() -> None:
+    n = 4 * 1024**3
+    event = _make_event(allocated=n, reserved=n)
+    fields = compute_event_fields(event)
+    assert fields["fragmentation_ratio"] == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# compute_event_fields — is_degraded_collector
+# ---------------------------------------------------------------------------
+
+_DEGRADED_COLLECTORS = [
+    "stormlog.fallback_tracker",
+    "stormlog.degraded",
+    "mps_unavailable",
+    "partial_collector",
+    "legacy.unknown",
+    "FALLBACK",  # case-insensitive
+]
+
+_HEALTHY_COLLECTORS = [
+    "stormlog.cuda_tracker",
+    "stormlog.rocm_tracker",
+    "stormlog.mps_tracker",
+    "stormlog.cpu_tracker",
+    "stormlog.tensorflow.memory_tracker",
+]
+
+
+@pytest.mark.parametrize("collector", _DEGRADED_COLLECTORS)  # type: ignore[misc]
+def test_is_degraded_collector_true_for_known_degraded_strings(
+    collector: str,
+) -> None:
+    event = _make_event(collector=collector)
+    fields = compute_event_fields(event)
+    assert fields["is_degraded_collector"] is True, collector
+
+
+@pytest.mark.parametrize("collector", _HEALTHY_COLLECTORS)  # type: ignore[misc]
+def test_is_degraded_collector_false_for_healthy_collectors(
+    collector: str,
+) -> None:
+    event = _make_event(collector=collector)
+    fields = compute_event_fields(event)
+    assert fields["is_degraded_collector"] is False, collector
+
+
+# ---------------------------------------------------------------------------
+# compute_event_fields — dict input (CLI use case)
+# ---------------------------------------------------------------------------
+
+
+def test_compute_event_fields_accepts_plain_dict() -> None:
+    event_dict = {
+        "allocator_allocated_bytes": 1024,
+        "allocator_reserved_bytes": 2048,
+        "device_total_bytes": 8192,
+        "collector": "stormlog.cuda_tracker",
+    }
+    fields = compute_event_fields(event_dict)
+    assert fields["hidden_gap_bytes"] == 1024
+    assert fields["utilization_ratio"] == pytest.approx(1024 / 8192)
+    assert fields["fragmentation_ratio"] == pytest.approx(0.5)
+    assert fields["is_degraded_collector"] is False
+
+
+# ---------------------------------------------------------------------------
+# compute_session_fields — multi-event fixture
+# ---------------------------------------------------------------------------
+
+
+def _build_session_events() -> list[TelemetryEventV2]:
+    """Three-event session: two samples, then a stop."""
+    gb = 1024**3
+    return [
+        _make_event(allocated=2 * gb, reserved=4 * gb, event_type="sample", index=0),
+        _make_event(allocated=6 * gb, reserved=8 * gb, event_type="sample", index=1),
+        _make_event(allocated=6 * gb, reserved=8 * gb, event_type="stop", index=2),
+    ]
+
+
+def test_compute_session_fields_peak_utilization() -> None:
+    events = _build_session_events()
+    session = compute_session_fields(events)
+    # Peak allocated = 6 GiB / 16 GiB device
+    expected_peak = 6 * 1024**3 / _DEVICE_TOTAL
+    assert session["peak_utilization_ratio"] == pytest.approx(expected_peak)
+
+
+def test_compute_session_fields_avg_fragmentation() -> None:
+    events = _build_session_events()
+    session = compute_session_fields(events)
+    # Event 0: gap=2 GiB, reserved=4 GiB → 0.5
+    # Event 1 & 2: gap=2 GiB, reserved=8 GiB → 0.25 each
+    expected_avg = (0.5 + 0.25 + 0.25) / 3
+    assert session["avg_fragmentation_ratio"] == pytest.approx(expected_avg)
+
+
+def test_compute_session_fields_not_interrupted_when_last_is_stop() -> None:
+    events = _build_session_events()
+    session = compute_session_fields(events)
+    assert session["is_session_interrupted"] is False
+
+
+def test_compute_session_fields_interrupted_when_no_stop() -> None:
+    gb = 1024**3
+    events = [
+        _make_event(allocated=2 * gb, reserved=4 * gb, event_type="sample", index=0),
+        _make_event(allocated=4 * gb, reserved=6 * gb, event_type="sample", index=1),
+    ]
+    session = compute_session_fields(events)
+    assert session["is_session_interrupted"] is True
+
+
+def test_compute_session_fields_empty_sequence() -> None:
+    session = compute_session_fields([])
+    assert session["peak_utilization_ratio"] is None
+    assert session["avg_fragmentation_ratio"] is None
+    assert session["is_session_interrupted"] is True  # no stop event
+
+
+def test_compute_session_fields_no_device_total() -> None:
+    gb = 1024**3
+    events = [
+        _make_event(allocated=2 * gb, reserved=4 * gb, device_total=None, index=0),
+        _make_event(allocated=4 * gb, reserved=8 * gb, device_total=None, index=1),
+    ]
+    session = compute_session_fields(events)
+    assert session["peak_utilization_ratio"] is None
+
+
+# ---------------------------------------------------------------------------
+# enrich_event
+# ---------------------------------------------------------------------------
+
+
+def test_enrich_event_contains_raw_fields() -> None:
+    event = _make_event()
+    enriched = enrich_event(event)
+    assert "allocator_allocated_bytes" in enriched
+    assert "allocator_reserved_bytes" in enriched
+    assert "device_total_bytes" in enriched
+
+
+def test_enrich_event_contains_derived_key() -> None:
+    event = _make_event()
+    enriched = enrich_event(event)
+    assert "derived" in enriched
+
+
+def test_enrich_event_derived_contains_expected_fields() -> None:
+    event = _make_event()
+    enriched = enrich_event(event)
+    derived = enriched["derived"]
+    assert "hidden_gap_bytes" in derived
+    assert "utilization_ratio" in derived
+    assert "fragmentation_ratio" in derived
+    assert "is_degraded_collector" in derived
+
+
+def test_enrich_event_derived_values_match_compute_event_fields() -> None:
+    event = _make_event(allocated=3 * 1024**3, reserved=5 * 1024**3)
+    enriched = enrich_event(event)
+    direct = compute_event_fields(event)
+    assert enriched["derived"]["hidden_gap_bytes"] == direct["hidden_gap_bytes"]
+    assert enriched["derived"]["utilization_ratio"] == pytest.approx(
+        direct["utilization_ratio"]
+    )
+
+
+def test_enrich_event_accepts_plain_dict() -> None:
+    event_dict = {
+        "allocator_allocated_bytes": 512,
+        "allocator_reserved_bytes": 1024,
+        "device_total_bytes": 4096,
+        "collector": "stormlog.cpu_tracker",
+    }
+    enriched = enrich_event(event_dict)
+    assert enriched["allocator_allocated_bytes"] == 512
+    assert "derived" in enriched
+    assert enriched["derived"]["hidden_gap_bytes"] == 512

--- a/tests/test_derived_fields.py
+++ b/tests/test_derived_fields.py
@@ -54,34 +54,34 @@ def _make_event(
 
 
 # ---------------------------------------------------------------------------
-# compute_event_fields — hidden_gap_bytes
+# compute_event_fields — allocator_gap_bytes
 # ---------------------------------------------------------------------------
 
 
-def test_hidden_gap_bytes_is_reserved_minus_allocated() -> None:
+def test_allocator_gap_bytes_is_reserved_minus_allocated() -> None:
     event = _make_event(allocated=4 * 1024**3, reserved=6 * 1024**3)
     fields = compute_event_fields(event)
-    assert fields["hidden_gap_bytes"] == 2 * 1024**3
+    assert fields["allocator_gap_bytes"] == 2 * 1024**3
 
 
-def test_hidden_gap_bytes_is_zero_when_equal() -> None:
+def test_allocator_gap_bytes_is_zero_when_equal() -> None:
     event = _make_event(allocated=4 * 1024**3, reserved=4 * 1024**3)
     fields = compute_event_fields(event)
-    assert fields["hidden_gap_bytes"] == 0
+    assert fields["allocator_gap_bytes"] == 0
 
 
-def test_hidden_gap_bytes_always_present_even_with_no_total() -> None:
+def test_allocator_gap_bytes_always_present_even_with_no_total() -> None:
     event = _make_event(allocated=1024, reserved=2048, device_total=None)
     fields = compute_event_fields(event)
-    assert "hidden_gap_bytes" in fields
-    assert fields["hidden_gap_bytes"] == 1024
+    assert "allocator_gap_bytes" in fields
+    assert fields["allocator_gap_bytes"] == 1024
 
 
-def test_hidden_gap_bytes_clamped_to_zero_when_allocated_exceeds_reserved() -> None:
+def test_allocator_gap_bytes_clamped_to_zero_when_allocated_exceeds_reserved() -> None:
     """Negative gaps indicate stale data; clamp to zero."""
     event = _make_event(allocated=8 * 1024**3, reserved=4 * 1024**3)
     fields = compute_event_fields(event)
-    assert fields["hidden_gap_bytes"] == 0
+    assert fields["allocator_gap_bytes"] == 0
 
 
 # ---------------------------------------------------------------------------
@@ -191,10 +191,66 @@ def test_compute_event_fields_accepts_plain_dict() -> None:
         "collector": "stormlog.cuda_tracker",
     }
     fields = compute_event_fields(event_dict)
-    assert fields["hidden_gap_bytes"] == 1024
+    assert fields["allocator_gap_bytes"] == 1024
     assert fields["utilization_ratio"] == pytest.approx(1024 / 8192)
     assert fields["fragmentation_ratio"] == pytest.approx(0.5)
     assert fields["is_degraded_collector"] is False
+
+
+# ---------------------------------------------------------------------------
+# TensorFlow synthetic events — reserved == allocated (no separate counter)
+# ---------------------------------------------------------------------------
+
+
+def test_tensorflow_synthetic_event_gap_is_zero() -> None:
+    """TF aliases reserved == allocated; gap must be 0, not a real reservation."""
+    tf_event = {
+        "allocator_allocated_bytes": 1024,
+        "allocator_reserved_bytes": 1024,
+        "device_total_bytes": 4096,
+        "collector": None,
+    }
+    fields = compute_event_fields(tf_event)
+    assert fields["allocator_gap_bytes"] == 0
+    assert fields["fragmentation_ratio"] == 0.0
+    assert fields["utilization_ratio"] == pytest.approx(0.25)
+
+
+def test_tensorflow_gap_zero_even_without_device_total() -> None:
+    """TF gap is always 0 regardless of whether device_total is known."""
+    tf_event = {
+        "allocator_allocated_bytes": 512,
+        "allocator_reserved_bytes": 512,
+        "device_total_bytes": None,
+        "collector": None,
+    }
+    fields = compute_event_fields(tf_event)
+    assert fields["allocator_gap_bytes"] == 0
+    assert fields["utilization_ratio"] is None
+
+
+def test_tensorflow_session_no_spurious_gap_or_frag() -> None:
+    """TF session with reserved==allocated must not report fake gaps or fragmentation."""
+    tf_events = [
+        {
+            "allocator_allocated_bytes": 1024,
+            "allocator_reserved_bytes": 1024,
+            "device_total_bytes": 4096,
+            "collector": None,
+            "event_type": "sample",
+        },
+        {
+            "allocator_allocated_bytes": 2048,
+            "allocator_reserved_bytes": 2048,
+            "device_total_bytes": 4096,
+            "collector": None,
+            "event_type": "stop",
+        },
+    ]
+    session = compute_session_fields(tf_events)
+    assert session["avg_fragmentation_ratio"] == 0.0
+    assert session["peak_utilization_ratio"] == pytest.approx(0.5)
+    assert session["is_session_interrupted"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -285,7 +341,7 @@ def test_enrich_event_derived_contains_expected_fields() -> None:
     event = _make_event()
     enriched = enrich_event(event)
     derived = enriched["derived"]
-    assert "hidden_gap_bytes" in derived
+    assert "allocator_gap_bytes" in derived
     assert "utilization_ratio" in derived
     assert "fragmentation_ratio" in derived
     assert "is_degraded_collector" in derived
@@ -295,7 +351,7 @@ def test_enrich_event_derived_values_match_compute_event_fields() -> None:
     event = _make_event(allocated=3 * 1024**3, reserved=5 * 1024**3)
     enriched = enrich_event(event)
     direct = compute_event_fields(event)
-    assert enriched["derived"]["hidden_gap_bytes"] == direct["hidden_gap_bytes"]
+    assert enriched["derived"]["allocator_gap_bytes"] == direct["allocator_gap_bytes"]
     assert enriched["derived"]["utilization_ratio"] == pytest.approx(
         direct["utilization_ratio"]
     )
@@ -311,7 +367,7 @@ def test_enrich_event_accepts_plain_dict() -> None:
     enriched = enrich_event(event_dict)
     assert enriched["allocator_allocated_bytes"] == 512
     assert "derived" in enriched
-    assert enriched["derived"]["hidden_gap_bytes"] == 512
+    assert enriched["derived"]["allocator_gap_bytes"] == 512
 
 
 def test_enrich_event_accepts_plain_object() -> None:
@@ -327,12 +383,13 @@ def test_enrich_event_accepts_plain_object() -> None:
     enriched = enrich_event(event)
     assert enriched["allocator_allocated_bytes"] == 256
     assert "derived" in enriched
-    assert enriched["derived"]["hidden_gap_bytes"] == 256
+    assert enriched["derived"]["allocator_gap_bytes"] == 256
 
 
-def test_degraded_substrings_include_canonical_health_constant() -> None:
-    """Guard against drift between derived_fields and collector_health."""
+def test_is_degraded_detects_collector_health_degraded_constant() -> None:
+    """Guard against drift: COLLECTOR_HEALTH_DEGRADED must be recognized."""
     from stormlog.collector_health import COLLECTOR_HEALTH_DEGRADED
-    from stormlog.derived_fields import _DEGRADED_COLLECTOR_SUBSTRINGS
 
-    assert COLLECTOR_HEALTH_DEGRADED in _DEGRADED_COLLECTOR_SUBSTRINGS
+    event = _make_event(collector=f"stormlog.{COLLECTOR_HEALTH_DEGRADED}_tracker")
+    fields = compute_event_fields(event)
+    assert fields["is_degraded_collector"] is True


### PR DESCRIPTION
## Summary

- Add `stormlog/derived_fields.py` as a centralized module for computing allocator gap bytes, utilization ratio, fragmentation ratio, degraded-collector detection, and session interruption from telemetry events.
- Wire `compute_event_fields()` into `diagnose.py`, `gap_analysis.py`, and `tensorflow/diagnose.py` so shared arithmetic lives in one tested source of truth.
- Add derived-field tests covering allocator gaps, utilization, fragmentation guards, TensorFlow reserved-counter aliases, degraded collectors, session rollups, dict/object inputs, and `enrich_event()`.

## Changes

| File | Change |
|------|--------|
| `stormlog/derived_fields.py` | New registry-driven derived-field module with `DerivedFields`, `SessionDerivedFields`, `compute_event_fields()`, `compute_session_fields()`, and `enrich_event()` |
| `stormlog/diagnose.py` | Reuse shared utilization and allocator-gap calculations in diagnostic summaries |
| `stormlog/gap_analysis.py` | Reuse shared fragmentation calculation instead of duplicating reserved-minus-allocated arithmetic |
| `stormlog/tensorflow/diagnose.py` | Reuse shared utilization and allocator-gap calculations while documenting that TensorFlow aliases reserved bytes to allocated bytes for schema compatibility |
| `tests/test_derived_fields.py` | Cover allocator gaps, clamped stale snapshots, TensorFlow synthetic events, degraded collectors, session rollups, and enrichment behavior |

## Verification

- `pre-commit run --all-files` — passed
- targeted `py_compile` for derived fields and touched diagnostics modules — passed
- derived-field smoke assertions — passed
- GitHub Actions latest run — passed, including lint, docs, build, artifact CLI smoke, memory regression gate, TUI gate, and PyTorch/TensorFlow test jobs

Starts #117