### PR TITLE
Issue 106/investigate canonical telemetry first event model

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -30,6 +30,7 @@ Core modules documented in generated pages:
 - `stormlog.profiler`
 - `stormlog.tracker`
 - `stormlog.telemetry`
+- `stormlog.telemetry_model`
 - `stormlog.cpu_profiler`
 
 Primary exported symbols:
@@ -40,6 +41,12 @@ Primary exported symbols:
 - `CPUMemoryTracker`
 - `MemoryVisualizer`
 - `TelemetryEventV2`
+
+Telemetry model symbols exported from `stormlog.telemetry`:
+
+- `CanonicalTelemetryRecord`
+- `canonical_record_from_telemetry_event`
+- `canonical_records_from_telemetry_events`
 
 ### `stormlog.tensorflow` (TensorFlow workflows)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -44,9 +44,9 @@ Primary exported symbols:
 
 Telemetry model symbols exported from `stormlog.telemetry`:
 
-- `CanonicalTelemetryRecord`
-- `canonical_record_from_telemetry_event`
-- `canonical_records_from_telemetry_events`
+- `ProjectedTelemetryRecord`
+- `project_telemetry_event`
+- `project_telemetry_events`
 
 ### `stormlog.tensorflow` (TensorFlow workflows)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ cpu_compatibility
 compatibility_matrix
 benchmark_harness
 telemetry_schema
-telemetry_first_internal_model
+telemetry_projection
 pytorch_testing_guide
 tensorflow_testing_guide
 article

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ cpu_compatibility
 compatibility_matrix
 benchmark_harness
 telemetry_schema
+telemetry_first_internal_model
 pytorch_testing_guide
 tensorflow_testing_guide
 article

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -6,3 +6,13 @@ Generated API Modules
    :recursive:
 
    stormlog
+   stormlog.profiler
+   stormlog.tracker
+   stormlog.telemetry
+   stormlog.telemetry_model
+   stormlog.timeline_markers
+   stormlog.cpu_profiler
+   stormlog.tensorflow
+   stormlog.tensorflow.profiler
+   stormlog.tensorflow.tracker
+   stormlog.tensorflow.context_profiler

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -9,6 +9,7 @@ Generated API Modules
    stormlog.profiler
    stormlog.tracker
    stormlog.telemetry
+   stormlog.telemetry_model
    stormlog.timeline_markers
    stormlog.cpu_profiler
    stormlog.tensorflow

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -6,13 +6,3 @@ Generated API Modules
    :recursive:
 
    stormlog
-   stormlog.profiler
-   stormlog.tracker
-   stormlog.telemetry
-   stormlog.telemetry_model
-   stormlog.timeline_markers
-   stormlog.cpu_profiler
-   stormlog.tensorflow
-   stormlog.tensorflow.profiler
-   stormlog.tensorflow.tracker
-   stormlog.tensorflow.context_profiler

--- a/docs/telemetry_first_internal_model.md
+++ b/docs/telemetry_first_internal_model.md
@@ -1,0 +1,247 @@
+[← Back to main docs](index.md)
+
+# Stormlog Telemetry-First Internal Model
+
+## Status
+
+This document records the target direction for consolidating Stormlog around one primary telemetry event model across
+runtime capture, append-only sink persistence, artifact loading, live display,
+and offline analysis. It does not change the current runtime API,
+`TelemetryEvent v3` schema, sink format, loader behavior, or TUI behavior.
+
+## Decision
+
+Stormlog should move toward one telemetry-first internal model for runtime
+capture, append-only sink persistence, artifact loading, live display, and
+offline analysis.
+
+The preferred architecture is:
+
+1. Trackers capture compact runtime events with only cheap local fields.
+2. A shared adapter normalizes those events into canonical telemetry records as
+   early as possible outside the hottest capture path.
+3. Sinks persist canonical records only.
+4. Loaders convert every supported artifact version into canonical records.
+5. The TUI and analysis layers consume one session abstraction for live and
+   loaded data.
+
+This keeps tracker capture inexpensive while giving downstream code a stable
+record shape for queryability, aggregation, integrations, and schema evolution.
+
+## Current State
+
+Stormlog already has several pieces of this architecture:
+
+- `stormlog.telemetry.TelemetryEventV3` is the current canonical event used by
+  tracker exports, append-only sink segments, synthesized diagnose timelines,
+  and loader output.
+- `stormlog.telemetry.TelemetryEventV2` and permissive legacy loading preserve
+  older artifact compatibility.
+- PyTorch and CPU trackers keep lightweight `TrackingEvent` instances, then
+  convert them through `_telemetry_record_from_event(...)`.
+- The TensorFlow tracker builds normalized records in
+  `_build_telemetry_event_record(...)`.
+- `AppendOnlyTelemetrySink` writes newline-delimited JSON records and tracks
+  session summaries through its manifest.
+- `load_telemetry_sessions(...)` loads JSON, JSONL, and sink directories into
+  `LoadedTelemetrySession` objects grouped by `session_id`.
+- `stormlog.tui.monitor.TrackerSession` adapts live tracker output into TUI
+  view models and can expose normalized telemetry events.
+
+The gap is that the current V3 shape is still memory-metric oriented. It works
+well for today's CPU, CUDA, ROCm, MPS, and TensorFlow memory capture paths, but
+future queryability and backend-neutral integrations need a smaller canonical
+envelope with extensible attributes.
+
+## Target Record Contract
+
+The next canonical record should be small, immutable, versioned, and
+backend-neutral. Required fields should cover identity, time, classification,
+source context, and extensibility without hard-coding one runtime's memory
+model.
+
+Recommended fields:
+
+- `schema_version`: canonical envelope version.
+- `record_id`: stable unique identifier for the record.
+- `timestamp_ns`: event time from the source, in nanoseconds.
+- `observed_timestamp_ns`: time Stormlog observed or normalized the event.
+- `session_id`: capture/session identity.
+- `source_kind`: backend family such as `cpu`, `cuda`, `rocm`, `mps`,
+  `tensorflow`, `tpu`, or `other`.
+- `event_type`: generic event classification such as `sample`, `start`,
+  `stop`, `phase_enter`, `phase_exit`, `warning`, `critical`, or `error`.
+- `stage`: optional lifecycle or workload stage.
+- `severity`: optional normalized severity value.
+- `body`: primary message or payload for the event.
+- `resource`: runtime identity such as host, process, job, worker, backend,
+  device, framework, and version.
+- `attributes`: extensible metadata for backend-specific values such as memory
+  counters, stream identifiers, tensor shapes, batch sizes, driver versions, or
+  collector health.
+- `correlation`: run, trace, span, phase, rank, or parent identifiers used to
+  connect records.
+
+Memory-specific fields from `TelemetryEvent v3`, such as allocator counters,
+device counters, and collector health, should become named attributes or
+resource fields in the future envelope rather than top-level requirements.
+
+## Compatibility Policy
+
+Compatibility must stay explicit and boundary-local:
+
+- Existing V2, V3, and legacy artifacts remain loadable.
+- The V3 schema remains the current write format until a separate migration
+  changes runtime behavior.
+- Future new writes should use the new canonical envelope only after sink,
+  loader, exporter, and TUI compatibility paths are ready.
+- Legacy input adapters convert old tracker shapes or artifact versions into
+  canonical records.
+- Legacy output adapters project canonical records back into old export shapes
+  only when callers explicitly request compatibility.
+- Compatibility shims should live outside the core model and include removal
+  criteria once supported artifact windows are old enough to retire.
+
+Older artifacts should be handled with versioned loaders:
+
+1. Detect artifact or sink schema version.
+2. Parse records with the version-specific reader.
+3. Upcast into canonical records.
+4. Preserve source warnings when fields are missing or lossy.
+5. Build indexes after loading unless streaming UX requires incremental
+   indexing.
+
+## Performance Policy
+
+Always-on capture must protect application liveness first. The capture path
+should avoid blocking I/O, reflection-heavy shaping, and heap-heavy
+serialization.
+
+The hot path should do only:
+
+- field capture,
+- timestamping,
+- correlation/session lookup,
+- bounded queue or history append,
+- optional fixed-cost normalization when it is proven cheap.
+
+Sink persistence should remain batched and asynchronous. Under pressure,
+Stormlog should prefer explicit sampling or low-priority event shedding over
+blocking the application being measured.
+
+Benchmark acceptance should be based on:
+
+- per-event capture latency,
+- allocations per event,
+- bytes allocated per second,
+- queue or bounded-history depth under bursts,
+- sink flush throughput,
+- p95 and p99 capture impact,
+- TUI update latency in live mode,
+- artifact load time for large sessions.
+
+The benchmark suite should compare the current split model against the future
+canonical-envelope implementation before any runtime migration is accepted.
+
+## Shared Session Interface
+
+Live sessions and loaded artifacts should expose the same model to TUI and
+analysis code. The backing source may differ, but consumers should see the same
+query surface.
+
+Target interface capabilities:
+
+- `events()` returns canonical records.
+- `resources()` returns observed resources and backend identities.
+- `summary()` returns session lifecycle and high-level capture metadata.
+- `filter(query)` returns records matching event, resource, attribute, or time
+  predicates.
+- `timeline(range)` returns ordered records and derived markers.
+- `correlate(id)` returns related records for a run, phase, trace, rank, or
+  span-like identifier.
+
+Live implementations can be backed by a bounded async stream. Loaded
+implementations can be backed by indexed artifact readers. Both should feed the
+same TUI tables, timelines, summaries, and analysis code.
+
+## Migration Plan
+
+### Phase 1: Canonical Envelope
+
+- Define the next canonical record type and schema version.
+- Keep V3 as the current public artifact format until migration is ready.
+- Add conversion helpers from V2, V3, and legacy records into the new envelope.
+- Add deterministic serialization tests for the new envelope.
+
+### Phase 2: Tracker Adapters
+
+- Keep tracker-local runtime events compact.
+- Move PyTorch, CPU, and TensorFlow normalization into shared adapter helpers.
+- Centralize timestamp rules, session identity, severity mapping, backend tags,
+  collector health, and distributed correlation.
+- Add capture and enqueue counters for benchmark visibility.
+
+### Phase 3: Sink Migration
+
+- Add a sink schema version that persists canonical envelope records.
+- Keep append-only JSONL semantics and deterministic serialization.
+- Batch writes and preserve existing rollover, pruning, recovery, and manifest
+  behavior.
+- Keep old sink loading paths for existing artifacts.
+
+### Phase 4: Loader Migration
+
+- Dispatch by artifact and sink schema version.
+- Parse V2, V3, legacy JSON, JSONL, and canonical envelope records into the same
+  internal stream.
+- Keep compatibility transforms separate from primary parsing.
+- Preserve old fixtures through loader adapters instead of rewriting user data.
+
+### Phase 5: TUI and Session Unification
+
+- Introduce the shared session abstraction for live and loaded data.
+- Render TUI monitoring and diagnostics from canonical records or derived view
+  models built from canonical records.
+- Keep TUI-specific formatting outside the core telemetry model.
+- Reuse the same query and marker logic for live and offline sessions.
+
+### Phase 6: Benchmarks and Regression Gates
+
+- Extend the existing benchmark harness with capture-latency, allocation,
+  queue-depth, sink-throughput, load-time, and TUI-latency metrics.
+- Cover CPU-only, GPU-heavy, TensorFlow, mixed backend, quiet always-on, and
+  bursty error-heavy sessions.
+- Compare current V3 normalization against canonical-envelope normalization.
+- Require regression and budget gates before enabling new runtime writes.
+
+### Phase 7: Compatibility Sunset
+
+- Keep V2/V3 loaders and explicit legacy exports until the supported artifact
+  window expires.
+- Document removal criteria for each shim.
+- Remove old compatibility code only after fixtures, docs, and release notes
+  prove that user artifacts remain protected.
+
+## Follow-On Tasks
+
+- Tracker layer: introduce shared runtime-event-to-canonical adapter helpers for
+  PyTorch, CPU, and TensorFlow paths.
+- Sink layer: add canonical-envelope sink versioning while preserving append-only
+  recovery and retention behavior.
+- Loader layer: add version dispatch that upcasts V2, V3, and future envelope
+  records into one internal stream.
+- TUI/session layer: define and adopt the shared live/loaded session query
+  interface.
+- Benchmark layer: extend `examples.cli.benchmark_harness` and docs benchmark
+  assets with overhead, allocation, queue-depth, load-time, and TUI-latency
+  checks.
+- Compatibility layer: add explicit legacy import/export adapters and document
+  retirement criteria.
+
+## Non-Goals
+
+- Rewriting every tracker to emit fully normalized records immediately.
+- Changing the existing `TelemetryEvent v3` JSON schema in this issue.
+- Designing a new external protocol.
+- Changing user-facing CLI, TUI, or Python API behavior.
+- Optimizing for every future backend-specific field up front.

--- a/docs/telemetry_first_internal_model.md
+++ b/docs/telemetry_first_internal_model.md
@@ -2,176 +2,146 @@
 
 # Stormlog Telemetry-First Internal Model
 
-## Status
+Stormlog uses a telemetry-first internal projection to give runtime capture,
+append-only sink persistence, artifact loading, live display, and offline
+analysis one shared event model.
 
-This document records the target direction for consolidating Stormlog around one primary telemetry event model across
-runtime capture, append-only sink persistence, artifact loading, live display,
-and offline analysis. It does not change the current runtime API,
-`TelemetryEvent v3` schema, sink format, loader behavior, or TUI behavior.
+The existing `TelemetryEvent v3` format remains the stable artifact and sink
+format. The backend-neutral model is an internal projection over that format,
+implemented in `stormlog.telemetry_model` and exposed through
+`stormlog.telemetry`.
 
-## Decision
+## Implemented Model
 
-Stormlog should move toward one telemetry-first internal model for runtime
-capture, append-only sink persistence, artifact loading, live display, and
-offline analysis.
+The canonical projection is `CanonicalTelemetryRecord`. It is a small immutable
+event envelope with these fields:
 
-The preferred architecture is:
-
-1. Trackers capture compact runtime events with only cheap local fields.
-2. A shared adapter normalizes those events into canonical telemetry records as
-   early as possible outside the hottest capture path.
-3. Sinks persist canonical records only.
-4. Loaders convert every supported artifact version into canonical records.
-5. The TUI and analysis layers consume one session abstraction for live and
-   loaded data.
-
-This keeps tracker capture inexpensive while giving downstream code a stable
-record shape for queryability, aggregation, integrations, and schema evolution.
-
-## Current State
-
-Stormlog already has several pieces of this architecture:
-
-- `stormlog.telemetry.TelemetryEventV3` is the current canonical event used by
-  tracker exports, append-only sink segments, synthesized diagnose timelines,
-  and loader output.
-- `stormlog.telemetry.TelemetryEventV2` and permissive legacy loading preserve
-  older artifact compatibility.
-- PyTorch and CPU trackers keep lightweight `TrackingEvent` instances, then
-  convert them through `_telemetry_record_from_event(...)`.
-- The TensorFlow tracker builds normalized records in
-  `_build_telemetry_event_record(...)`.
-- `AppendOnlyTelemetrySink` writes newline-delimited JSON records and tracks
-  session summaries through its manifest.
-- `load_telemetry_sessions(...)` loads JSON, JSONL, and sink directories into
-  `LoadedTelemetrySession` objects grouped by `session_id`.
-- `stormlog.tui.monitor.TrackerSession` adapts live tracker output into TUI
-  view models and can expose normalized telemetry events.
-
-The gap is that the current V3 shape is still memory-metric oriented. It works
-well for today's CPU, CUDA, ROCm, MPS, and TensorFlow memory capture paths, but
-future queryability and backend-neutral integrations need a smaller canonical
-envelope with extensible attributes.
-
-## Target Record Contract
-
-The next canonical record should be small, immutable, versioned, and
-backend-neutral. Required fields should cover identity, time, classification,
-source context, and extensibility without hard-coding one runtime's memory
-model.
-
-Recommended fields:
-
-- `schema_version`: canonical envelope version.
-- `record_id`: stable unique identifier for the record.
-- `timestamp_ns`: event time from the source, in nanoseconds.
+- `schema_version`: internal canonical projection version.
+- `record_id`: deterministic identifier derived from the source telemetry
+  record.
+- `timestamp_ns`: event time from the source.
 - `observed_timestamp_ns`: time Stormlog observed or normalized the event.
 - `session_id`: capture/session identity.
 - `source_kind`: backend family such as `cpu`, `cuda`, `rocm`, `mps`,
   `tensorflow`, `tpu`, or `other`.
-- `event_type`: generic event classification such as `sample`, `start`,
-  `stop`, `phase_enter`, `phase_exit`, `warning`, `critical`, or `error`.
+- `event_type`: generic classification such as `sample`, `start`, `stop`,
+  `phase_enter`, `phase_exit`, `warning`, `critical`, or `error`.
 - `stage`: optional lifecycle or workload stage.
-- `severity`: optional normalized severity value.
-- `body`: primary message or payload for the event.
-- `resource`: runtime identity such as host, process, job, worker, backend,
-  device, framework, and version.
-- `attributes`: extensible metadata for backend-specific values such as memory
-  counters, stream identifiers, tensor shapes, batch sizes, driver versions, or
-  collector health.
-- `correlation`: run, trace, span, phase, rank, or parent identifiers used to
-  connect records.
+- `severity` and `severity_text`: normalized severity when meaningful.
+- `body`: primary message or payload.
+- `resource`: runtime identity such as host, process, backend, device, job, and
+  rank.
+- `attributes`: extensible metadata and backend-specific measurements.
+- `correlation`: session, job, rank, phase, and future trace/span alignment
+  fields.
 
-Memory-specific fields from `TelemetryEvent v3`, such as allocator counters,
-device counters, and collector health, should become named attributes or
-resource fields in the future envelope rather than top-level requirements.
+The projection keeps backend-specific details out of top-level fields. Memory
+counters from `TelemetryEvent v3`, collector health metadata, phase metadata,
+and future backend details are represented as attributes, resources, or
+correlation fields.
 
-## Compatibility Policy
+## Data Flow
 
-Compatibility must stay explicit and boundary-local:
+The current flow is:
+
+1. Trackers capture compact runtime events or tracker-local records.
+2. Existing normalizers produce `TelemetryEvent v3` records for exports, sink
+   writes, loaders, and TUI adapters.
+3. `canonical_record_from_telemetry_event(...)` projects V3 records into
+   `CanonicalTelemetryRecord`.
+4. `LoadedTelemetrySession.telemetry_records()` exposes canonical records for
+   loaded artifacts.
+5. `TrackerSession.telemetry_records()` exposes canonical records for live TUI
+   sessions.
+
+This keeps the capture path cheap while giving downstream code one stable
+backend-neutral view.
+
+## Compatibility
+
+Stormlog preserves existing compatibility boundaries:
 
 - Existing V2, V3, and legacy artifacts remain loadable.
-- The V3 schema remains the current write format until a separate migration
-  changes runtime behavior.
-- Future new writes should use the new canonical envelope only after sink,
-  loader, exporter, and TUI compatibility paths are ready.
-- Legacy input adapters convert old tracker shapes or artifact versions into
-  canonical records.
-- Legacy output adapters project canonical records back into old export shapes
-  only when callers explicitly request compatibility.
-- Compatibility shims should live outside the core model and include removal
-  criteria once supported artifact windows are old enough to retire.
+- `TelemetryEvent v3` remains the persisted artifact and append-only sink
+  record format.
+- Legacy artifact upcasting stays in loader and normalizer code.
+- Canonical projection is additive and does not change CLI, TUI, or Python API
+  behavior.
+- Legacy export shapes remain explicit compatibility paths.
 
-Older artifacts should be handled with versioned loaders:
+This lets analysis and UI code adopt the canonical projection without breaking
+older artifacts or changing the on-disk schema.
 
-1. Detect artifact or sink schema version.
-2. Parse records with the version-specific reader.
-3. Upcast into canonical records.
-4. Preserve source warnings when fields are missing or lossy.
-5. Build indexes after loading unless streaming UX requires incremental
-   indexing.
+## Live and Loaded Sessions
+
+Live and loaded data now share the same canonical record projection:
+
+- Loaded artifacts use `LoadedTelemetrySession.telemetry_records()`.
+- Loaded artifacts use `LoadedTelemetrySession.resources()` for unique observed
+  resources.
+- Loaded artifacts use `LoadedTelemetrySession.correlations()` for unique
+  correlation contexts.
+- Live TUI sessions use `TrackerSession.telemetry_records()`.
+
+The TUI can keep rendering lightweight view models, while analysis and future
+query code can use the canonical records regardless of whether the source is a
+live tracker or an artifact.
 
 ## Performance Policy
 
-Always-on capture must protect application liveness first. The capture path
-should avoid blocking I/O, reflection-heavy shaping, and heap-heavy
-serialization.
+Always-on capture protects application liveness first. The hot path should do
+only the work required to capture local fields, timestamp events, look up
+session/correlation identity, and append to bounded in-memory history or a
+queue.
 
-The hot path should do only:
+Capture code should avoid:
 
-- field capture,
-- timestamping,
-- correlation/session lookup,
-- bounded queue or history append,
-- optional fixed-cost normalization when it is proven cheap.
+- blocking on sink persistence,
+- heap-heavy serialization,
+- reflection-heavy shaping,
+- formatting strings before normalization when raw fields are enough.
 
-Sink persistence should remain batched and asynchronous. Under pressure,
+Sink persistence should remain batched and append-only. Under pressure,
 Stormlog should prefer explicit sampling or low-priority event shedding over
 blocking the application being measured.
 
-Benchmark acceptance should be based on:
+## Benchmark Plan
 
-- per-event capture latency,
+Benchmark validation should compare the existing V3 flow against the canonical
+projection path before any persisted-format migration.
+
+Measure:
+
+- events per second sustained,
+- average and p95 event capture latency,
 - allocations per event,
 - bytes allocated per second,
-- queue or bounded-history depth under bursts,
+- queue or bounded-history depth under burst load,
 - sink flush throughput,
-- p95 and p99 capture impact,
 - TUI update latency in live mode,
-- artifact load time for large sessions.
+- artifact load time for large sessions,
+- memory growth over long always-on runs.
 
-The benchmark suite should compare the current split model against the future
-canonical-envelope implementation before any runtime migration is accepted.
+Coverage should include:
 
-## Shared Session Interface
+- CPU-only workloads,
+- GPU-heavy workloads,
+- mixed backend workloads,
+- quiet long-running always-on sessions,
+- bursty error-heavy sessions.
 
-Live sessions and loaded artifacts should expose the same model to TUI and
-analysis code. The backing source may differ, but consumers should see the same
-query surface.
-
-Target interface capabilities:
-
-- `events()` returns canonical records.
-- `resources()` returns observed resources and backend identities.
-- `summary()` returns session lifecycle and high-level capture metadata.
-- `filter(query)` returns records matching event, resource, attribute, or time
-  predicates.
-- `timeline(range)` returns ordered records and derived markers.
-- `correlate(id)` returns related records for a run, phase, trace, rank, or
-  span-like identifier.
-
-Live implementations can be backed by a bounded async stream. Loaded
-implementations can be backed by indexed artifact readers. Both should feed the
-same TUI tables, timelines, summaries, and analysis code.
+The acceptance bar is that canonical projection must not materially harm the
+hot path. Any extra projection cost must be offset by simpler shared sinks,
+loaders, UI adapters, and analysis code.
 
 ## Migration Plan
 
-### Phase 1: Canonical Envelope
+### Phase 1: Canonical Projection
 
-- Define the next canonical record type and schema version.
-- Keep V3 as the current public artifact format until migration is ready.
-- Add conversion helpers from V2, V3, and legacy records into the new envelope.
-- Add deterministic serialization tests for the new envelope.
+- Keep `TelemetryEvent v3` as the persisted artifact format.
+- Project V3 records into `CanonicalTelemetryRecord`.
+- Expose canonical records from loaded sessions and live TUI sessions.
+- Cover projection behavior with deterministic tests.
 
 ### Phase 2: Tracker Adapters
 
@@ -183,55 +153,43 @@ same TUI tables, timelines, summaries, and analysis code.
 
 ### Phase 3: Sink Migration
 
-- Add a sink schema version that persists canonical envelope records.
+- Add a future sink schema version for persisted canonical records.
 - Keep append-only JSONL semantics and deterministic serialization.
-- Batch writes and preserve existing rollover, pruning, recovery, and manifest
-  behavior.
+- Preserve rollover, pruning, recovery, and manifest behavior.
 - Keep old sink loading paths for existing artifacts.
 
 ### Phase 4: Loader Migration
 
 - Dispatch by artifact and sink schema version.
-- Parse V2, V3, legacy JSON, JSONL, and canonical envelope records into the same
-  internal stream.
+- Parse V2, V3, legacy JSON, JSONL, and future persisted canonical records into
+  the same internal stream.
 - Keep compatibility transforms separate from primary parsing.
 - Preserve old fixtures through loader adapters instead of rewriting user data.
 
 ### Phase 5: TUI and Session Unification
 
-- Introduce the shared session abstraction for live and loaded data.
-- Render TUI monitoring and diagnostics from canonical records or derived view
+- Render live monitoring and diagnostics from canonical records or derived view
   models built from canonical records.
 - Keep TUI-specific formatting outside the core telemetry model.
 - Reuse the same query and marker logic for live and offline sessions.
 
 ### Phase 6: Benchmarks and Regression Gates
 
-- Extend the existing benchmark harness with capture-latency, allocation,
-  queue-depth, sink-throughput, load-time, and TUI-latency metrics.
-- Cover CPU-only, GPU-heavy, TensorFlow, mixed backend, quiet always-on, and
-  bursty error-heavy sessions.
-- Compare current V3 normalization against canonical-envelope normalization.
-- Require regression and budget gates before enabling new runtime writes.
-
-### Phase 7: Compatibility Sunset
-
-- Keep V2/V3 loaders and explicit legacy exports until the supported artifact
-  window expires.
-- Document removal criteria for each shim.
-- Remove old compatibility code only after fixtures, docs, and release notes
-  prove that user artifacts remain protected.
+- Extend the benchmark harness with capture-latency, allocation, queue-depth,
+  sink-throughput, load-time, and TUI-latency metrics.
+- Compare current V3 normalization against canonical projection and future
+  persisted-canonical writes.
+- Require regression and budget gates before enabling new persisted formats.
 
 ## Follow-On Tasks
 
 - Tracker layer: introduce shared runtime-event-to-canonical adapter helpers for
   PyTorch, CPU, and TensorFlow paths.
-- Sink layer: add canonical-envelope sink versioning while preserving append-only
+- Sink layer: add canonical-record sink versioning while preserving append-only
   recovery and retention behavior.
-- Loader layer: add version dispatch that upcasts V2, V3, and future envelope
-  records into one internal stream.
-- TUI/session layer: define and adopt the shared live/loaded session query
-  interface.
+- Loader layer: add version dispatch that upcasts V2, V3, and future persisted
+  canonical records into one internal stream.
+- TUI/session layer: move more live and loaded views onto canonical records.
 - Benchmark layer: extend `examples.cli.benchmark_harness` and docs benchmark
   assets with overhead, allocation, queue-depth, load-time, and TUI-latency
   checks.
@@ -241,7 +199,7 @@ same TUI tables, timelines, summaries, and analysis code.
 ## Non-Goals
 
 - Rewriting every tracker to emit fully normalized records immediately.
-- Changing the existing `TelemetryEvent v3` JSON schema in this issue.
+- Changing the existing `TelemetryEvent v3` JSON schema.
 - Designing a new external protocol.
 - Changing user-facing CLI, TUI, or Python API behavior.
 - Optimizing for every future backend-specific field up front.

--- a/docs/telemetry_first_internal_model.md
+++ b/docs/telemetry_first_internal_model.md
@@ -11,6 +11,40 @@ format. The backend-neutral model is an internal projection over that format,
 implemented in `stormlog.telemetry_model` and exposed through
 `stormlog.telemetry`.
 
+## Decision
+
+Stormlog should use a telemetry-first canonical projection as the shared
+internal model for analysis and UI code. Runtime trackers should keep emitting
+compact tracker-local events on the hot path, then normalize at tracker or
+loader edges before persistence, display, or analysis fan-out.
+
+The current implementation takes the first migration step: it keeps persisted
+records on `TelemetryEvent v3`, then projects those records into
+`CanonicalTelemetryRecord` for live and loaded sessions. Future sink migrations
+can persist the canonical envelope directly after benchmark gates prove the
+runtime cost is acceptable.
+
+## Current State Map
+
+Stormlog currently has several event shapes and normalization boundaries:
+
+- `TelemetryEventV3` is the stable memory telemetry contract used by artifact
+  exports and loader output.
+- Tracker `TrackingEvent` values stay lightweight for runtime capture and are
+  normalized through `_telemetry_record_from_event(...)`.
+- TensorFlow capture builds compatible telemetry dictionaries in the
+  TensorFlow tracker path before exporting or loading them.
+- Append-only sink JSONL entries persist normalized telemetry records and keep
+  recovery, rollover, pruning, and manifest behavior separate from the record
+  projection.
+- Artifact loaders group loaded records into `LoadedTelemetrySession` objects
+  after legacy V2, V3, JSON, and JSONL compatibility handling.
+- The live TUI uses `TrackerSession` as the display-facing session model.
+
+The canonical projection does not remove those boundaries yet. It gives them a
+shared target shape so migration can happen one layer at a time without
+changing the existing artifact schema.
+
 ## Implemented Model
 
 The canonical projection is `CanonicalTelemetryRecord`. It is a small immutable
@@ -39,6 +73,15 @@ The projection keeps backend-specific details out of top-level fields. Memory
 counters from `TelemetryEvent v3`, collector health metadata, phase metadata,
 and future backend details are represented as attributes, resources, or
 correlation fields.
+
+The smallest useful contract for runtime, sink, loader, TUI, and exported
+artifact views is:
+
+- identity: `schema_version`, `record_id`, and `session_id`,
+- time: `timestamp_ns` and `observed_timestamp_ns`,
+- classification: `source_kind`, `event_type`, `stage`, and severity fields,
+- payload: `body`,
+- projection data: `resource`, `attributes`, and `correlation`.
 
 ## Data Flow
 

--- a/docs/telemetry_projection.md
+++ b/docs/telemetry_projection.md
@@ -1,27 +1,28 @@
 [← Back to main docs](index.md)
 
-# Stormlog Telemetry-First Internal Model
+# Stormlog Telemetry Projection
 
 Stormlog uses a telemetry-first internal projection to give runtime capture,
 append-only sink persistence, artifact loading, live display, and offline
 analysis one shared event model.
 
-The existing `TelemetryEvent v3` format remains the stable artifact and sink
-format. The backend-neutral model is an internal projection over that format,
-implemented in `stormlog.telemetry_model` and exposed through
+`TelemetryEvent v3` remains Stormlog's canonical persisted event schema for
+artifacts, append-only sink segments, exports, and loader output. The
+backend-neutral envelope described here is an internal projection over that
+schema, implemented in `stormlog.telemetry_model` and exposed through
 `stormlog.telemetry`.
 
 ## Decision
 
-Stormlog should use a telemetry-first canonical projection as the shared
+Stormlog should use a telemetry-first internal projection as the shared
 internal model for analysis and UI code. Runtime trackers should keep emitting
 compact tracker-local events on the hot path, then normalize at tracker or
 loader edges before persistence, display, or analysis fan-out.
 
 The current implementation takes the first migration step: it keeps persisted
 records on `TelemetryEvent v3`, then projects those records into
-`CanonicalTelemetryRecord` for live and loaded sessions. Future sink migrations
-can persist the canonical envelope directly after benchmark gates prove the
+`ProjectedTelemetryRecord` for live and loaded sessions. Future sink migrations
+can persist the projected envelope directly after benchmark gates prove the
 runtime cost is acceptable.
 
 ## Current State Map
@@ -41,23 +42,23 @@ Stormlog currently has several event shapes and normalization boundaries:
   after legacy V2, V3, JSON, and JSONL compatibility handling.
 - The live TUI uses `TrackerSession` as the display-facing session model.
 
-The canonical projection does not remove those boundaries yet. It gives them a
-shared target shape so migration can happen one layer at a time without
+The projected telemetry envelope does not remove those boundaries yet. It gives
+them a shared target shape so migration can happen one layer at a time without
 changing the existing artifact schema.
 
 ## Implemented Model
 
-The canonical projection is `CanonicalTelemetryRecord`. It is a small immutable
-event envelope with these fields:
+The projected telemetry envelope is `ProjectedTelemetryRecord`. It is a small
+immutable event envelope with these fields:
 
-- `schema_version`: internal canonical projection version.
+- `schema_version`: internal projected telemetry envelope version.
 - `record_id`: deterministic identifier derived from the source telemetry
   record.
 - `timestamp_ns`: event time from the source.
 - `observed_timestamp_ns`: time Stormlog observed or normalized the event.
 - `session_id`: capture/session identity.
 - `source_kind`: backend family such as `cpu`, `cuda`, `rocm`, `mps`,
-  `tensorflow`, `tpu`, or `other`.
+  `tensorflow`, generic `gpu`, or `other`.
 - `event_type`: generic classification such as `sample`, `start`, `stop`,
   `phase_enter`, `phase_exit`, `warning`, `critical`, or `error`.
 - `stage`: optional lifecycle or workload stage.
@@ -83,6 +84,30 @@ artifact views is:
 - payload: `body`,
 - projection data: `resource`, `attributes`, and `correlation`.
 
+`source_kind` must stay a backend family. Distributed identity such as host,
+process id, device id, rank, local rank, world size, and future node ids belongs
+in `resource` or `correlation`, not in `source_kind`. Future backend families
+can be added when Stormlog adds collector support for them.
+
+Some identity values intentionally appear in more than one place. For example,
+`session_id` is top-level and also available in `correlation`, while
+`source_kind` is top-level and also available in `resource`. These copies are
+derived from the same normalized source record and must not drift; adapters that
+change one identity value must update every projected copy in the same
+projection step.
+
+## Projection Versioning
+
+`TELEMETRY_PROJECTION_SCHEMA_VERSION` versions only the internal projected
+envelope. It is separate from `TelemetryEvent v3` and does not change artifact
+compatibility by itself.
+
+When the projection shape changes incompatibly, update the version constant,
+the `ProjectedTelemetryRecord.schema_version` type annotation, serialization
+tests, this document, and compatibility behavior together. Compatibility code
+should be explicit about whether it can read both projection versions or must
+re-project from the persisted `TelemetryEvent v3` source.
+
 ## Data Flow
 
 The current flow is:
@@ -90,15 +115,18 @@ The current flow is:
 1. Trackers capture compact runtime events or tracker-local records.
 2. Existing normalizers produce `TelemetryEvent v3` records for exports, sink
    writes, loaders, and TUI adapters.
-3. `canonical_record_from_telemetry_event(...)` projects V3 records into
-   `CanonicalTelemetryRecord`.
-4. `LoadedTelemetrySession.telemetry_records()` exposes canonical records for
-   loaded artifacts.
-5. `TrackerSession.telemetry_records()` exposes canonical records for live TUI
-   sessions.
+3. `project_telemetry_event(...)` projects V3 records into
+   `ProjectedTelemetryRecord`.
+4. `LoadedTelemetrySession.telemetry_records()` exposes projected telemetry
+   records for loaded artifacts.
+5. `TrackerSession.telemetry_records()` exposes projected telemetry records for
+   live TUI sessions.
 
-This keeps the capture path cheap while giving downstream code one stable
-backend-neutral view.
+Because projection currently happens after existing V3 normalization, this keeps
+the capture path unchanged while giving downstream code one stable
+backend-neutral view. A future sink migration that persists the projected
+envelope directly still needs benchmark gates for capture latency, allocations,
+queue depth, and sink throughput before it can claim the same hot-path cost.
 
 ## Compatibility
 
@@ -108,16 +136,16 @@ Stormlog preserves existing compatibility boundaries:
 - `TelemetryEvent v3` remains the persisted artifact and append-only sink
   record format.
 - Legacy artifact upcasting stays in loader and normalizer code.
-- Canonical projection is additive and does not change CLI, TUI, or Python API
+- Telemetry projection is additive and does not change CLI, TUI, or Python API
   behavior.
 - Legacy export shapes remain explicit compatibility paths.
 
-This lets analysis and UI code adopt the canonical projection without breaking
-older artifacts or changing the on-disk schema.
+This lets analysis and UI code adopt the projected telemetry envelope without
+breaking older artifacts or changing the on-disk schema.
 
 ## Live and Loaded Sessions
 
-Live and loaded data now share the same canonical record projection:
+Live and loaded data now share the same projected telemetry record shape:
 
 - Loaded artifacts use `LoadedTelemetrySession.telemetry_records()`.
 - Loaded artifacts use `LoadedTelemetrySession.resources()` for unique observed
@@ -127,8 +155,8 @@ Live and loaded data now share the same canonical record projection:
 - Live TUI sessions use `TrackerSession.telemetry_records()`.
 
 The TUI can keep rendering lightweight view models, while analysis and future
-query code can use the canonical records regardless of whether the source is a
-live tracker or an artifact.
+query code can use the projected telemetry records regardless of whether the
+source is a live tracker or an artifact.
 
 ## Performance Policy
 
@@ -148,10 +176,21 @@ Sink persistence should remain batched and append-only. Under pressure,
 Stormlog should prefer explicit sampling or low-priority event shedding over
 blocking the application being measured.
 
+Pressure means any bounded buffer, queue, history, sink, or long-running session
+cannot accept events at the current production rate without unbounded memory
+growth or blocking the measured application. Examples include bounded history
+overflow, sink queue backlog, slow disk flushes, bursty alert streams, and
+always-on sessions that run longer than the retention budget.
+
+Any sampling or shedding policy must be visible in telemetry and diagnostics.
+At minimum, adapters and sinks should expose the active policy, queue or history
+depth, dropped sample count, dropped event count, dropped alert count when
+alerts are handled separately, and a reason for each class of drop.
+
 ## Benchmark Plan
 
-Benchmark validation should compare the existing V3 flow against the canonical
-projection path before any persisted-format migration.
+Benchmark validation should compare the existing V3 flow against the projection
+path before any persisted-format migration.
 
 Measure:
 
@@ -173,17 +212,17 @@ Coverage should include:
 - quiet long-running always-on sessions,
 - bursty error-heavy sessions.
 
-The acceptance bar is that canonical projection must not materially harm the
-hot path. Any extra projection cost must be offset by simpler shared sinks,
-loaders, UI adapters, and analysis code.
+The acceptance bar is that the projected telemetry envelope must not materially
+harm the hot path. Any extra projection cost must be offset by simpler shared
+sinks, loaders, UI adapters, and analysis code.
 
 ## Migration Plan
 
-### Phase 1: Canonical Projection
+### Phase 1: Telemetry Projection
 
 - Keep `TelemetryEvent v3` as the persisted artifact format.
-- Project V3 records into `CanonicalTelemetryRecord`.
-- Expose canonical records from loaded sessions and live TUI sessions.
+- Project V3 records into `ProjectedTelemetryRecord`.
+- Expose projected telemetry records from loaded sessions and live TUI sessions.
 - Cover projection behavior with deterministic tests.
 
 ### Phase 2: Tracker Adapters
@@ -196,7 +235,7 @@ loaders, UI adapters, and analysis code.
 
 ### Phase 3: Sink Migration
 
-- Add a future sink schema version for persisted canonical records.
+- Add a future sink schema version for persisted projected telemetry records.
 - Keep append-only JSONL semantics and deterministic serialization.
 - Preserve rollover, pruning, recovery, and manifest behavior.
 - Keep old sink loading paths for existing artifacts.
@@ -204,15 +243,15 @@ loaders, UI adapters, and analysis code.
 ### Phase 4: Loader Migration
 
 - Dispatch by artifact and sink schema version.
-- Parse V2, V3, legacy JSON, JSONL, and future persisted canonical records into
-  the same internal stream.
+- Parse V2, V3, legacy JSON, JSONL, and future persisted projected telemetry
+  records into the same internal stream.
 - Keep compatibility transforms separate from primary parsing.
 - Preserve old fixtures through loader adapters instead of rewriting user data.
 
 ### Phase 5: TUI and Session Unification
 
-- Render live monitoring and diagnostics from canonical records or derived view
-  models built from canonical records.
+- Render live monitoring and diagnostics from projected telemetry records or
+  derived view models built from projected telemetry records.
 - Keep TUI-specific formatting outside the core telemetry model.
 - Reuse the same query and marker logic for live and offline sessions.
 
@@ -220,19 +259,20 @@ loaders, UI adapters, and analysis code.
 
 - Extend the benchmark harness with capture-latency, allocation, queue-depth,
   sink-throughput, load-time, and TUI-latency metrics.
-- Compare current V3 normalization against canonical projection and future
-  persisted-canonical writes.
+- Compare current V3 normalization against the projected telemetry envelope and
+  future persisted-envelope writes.
 - Require regression and budget gates before enabling new persisted formats.
 
 ## Follow-On Tasks
 
-- Tracker layer: introduce shared runtime-event-to-canonical adapter helpers for
+- Tracker layer: introduce shared runtime-event-to-projection adapter helpers for
   PyTorch, CPU, and TensorFlow paths.
-- Sink layer: add canonical-record sink versioning while preserving append-only
+- Sink layer: add projected-record sink versioning while preserving append-only
   recovery and retention behavior.
 - Loader layer: add version dispatch that upcasts V2, V3, and future persisted
-  canonical records into one internal stream.
-- TUI/session layer: move more live and loaded views onto canonical records.
+  projected telemetry records into one internal stream.
+- TUI/session layer: move more live and loaded views onto projected telemetry
+  records.
 - Benchmark layer: extend `examples.cli.benchmark_harness` and docs benchmark
   assets with overhead, allocation, queue-depth, load-time, and TUI-latency
   checks.

--- a/docs/telemetry_schema.md
+++ b/docs/telemetry_schema.md
@@ -4,8 +4,8 @@
 
 `TelemetryEvent v3` is the canonical event format for tracker exports,
 append-only sink segments, synthesized diagnose timelines, and loader output.
-For the direction on consolidating Stormlog around one primary
-telemetry model without changing this schema yet, see
+For the backend-neutral internal projection over this stable artifact format,
+see
 [Stormlog Telemetry-First Internal Model](telemetry_first_internal_model.md).
 
 Schema files:

--- a/docs/telemetry_schema.md
+++ b/docs/telemetry_schema.md
@@ -4,9 +4,9 @@
 
 `TelemetryEvent v3` is the canonical event format for tracker exports,
 append-only sink segments, synthesized diagnose timelines, and loader output.
-For the backend-neutral internal projection over this stable artifact format,
-see
-[Stormlog Telemetry-First Internal Model](telemetry_first_internal_model.md).
+The backend-neutral `ProjectedTelemetryRecord` described in
+[Stormlog Telemetry Projection](telemetry_projection.md) is an internal view
+derived from this persisted schema; it is not a replacement artifact format.
 
 Schema files:
 

--- a/docs/telemetry_schema.md
+++ b/docs/telemetry_schema.md
@@ -4,6 +4,9 @@
 
 `TelemetryEvent v3` is the canonical event format for tracker exports,
 append-only sink segments, synthesized diagnose timelines, and loader output.
+For the direction on consolidating Stormlog around one primary
+telemetry model without changing this schema yet, see
+[Stormlog Telemetry-First Internal Model](telemetry_first_internal_model.md).
 
 Schema files:
 

--- a/stormlog/_wandb/tracking.py
+++ b/stormlog/_wandb/tracking.py
@@ -436,7 +436,7 @@ def sample_timeline_rows(rows: Sequence[dict[str, Any]]) -> list[dict[str, Any]]
 
 
 def _memory_plot_series(
-    rows: Sequence[Mapping[str, Any]]
+    rows: Sequence[Mapping[str, Any]],
 ) -> tuple[list[str], list[list[float]]]:
     keys: list[str] = []
     series: list[list[float]] = []

--- a/stormlog/telemetry.py
+++ b/stormlog/telemetry.py
@@ -16,10 +16,10 @@ from .session import (
     stable_legacy_session_id,
 )
 from .telemetry_model import (
-    CanonicalTelemetryRecord,
-    canonical_record_from_mapping,
-    unique_canonical_correlations,
-    unique_canonical_resources,
+    ProjectedTelemetryRecord,
+    project_telemetry_mapping,
+    unique_projected_correlations,
+    unique_projected_resources,
 )
 from .telemetry_sink import (
     read_telemetry_sink_manifest,
@@ -154,20 +154,20 @@ class LoadedTelemetrySession:
     sources_loaded: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
 
-    def telemetry_records(self) -> list[CanonicalTelemetryRecord]:
-        """Return backend-neutral canonical records for this loaded session."""
+    def telemetry_records(self) -> list[ProjectedTelemetryRecord]:
+        """Return backend-neutral projected records for this loaded session."""
 
-        return canonical_records_from_telemetry_events(self.events)
+        return project_telemetry_events(self.events)
 
     def resources(self) -> list[dict[str, Any]]:
         """Return unique observed resources for this loaded session."""
 
-        return unique_canonical_resources(self.telemetry_records())
+        return unique_projected_resources(self.telemetry_records())
 
     def correlations(self) -> list[dict[str, Any]]:
         """Return unique correlation contexts for this loaded session."""
 
-        return unique_canonical_correlations(self.telemetry_records())
+        return unique_projected_correlations(self.telemetry_records())
 
 
 def _is_int(value: Any) -> bool:
@@ -1163,41 +1163,43 @@ def load_telemetry_events(
     return list(selected.events) if selected is not None else []
 
 
-def canonical_record_from_telemetry_event(
+def project_telemetry_event(
     event: TelemetryEvent | Mapping[str, Any],
-) -> CanonicalTelemetryRecord:
+) -> ProjectedTelemetryRecord:
     """Project telemetry objects or compatible mappings into the shared model."""
 
-    record = (
-        telemetry_event_to_dict(event) if isinstance(event, TelemetryEventV3) else event
-    )
+    record: Mapping[str, Any]
+    if isinstance(event, TelemetryEventV3):
+        record = telemetry_event_to_dict(event)
+    else:
+        record = event
     normalized = (
         telemetry_event_from_record(record)
         if not isinstance(event, TelemetryEventV3)
         else event
     )
-    return canonical_record_from_mapping(telemetry_event_to_dict(normalized))
+    return project_telemetry_mapping(telemetry_event_to_dict(normalized))
 
 
-def canonical_records_from_telemetry_events(
+def project_telemetry_events(
     events: Iterable[TelemetryEvent | Mapping[str, Any]],
-) -> list[CanonicalTelemetryRecord]:
-    """Project existing telemetry events into backend-neutral canonical records."""
+) -> list[ProjectedTelemetryRecord]:
+    """Project existing telemetry events into backend-neutral records."""
 
-    return [canonical_record_from_telemetry_event(event) for event in events]
+    return [project_telemetry_event(event) for event in events]
 
 
 __all__ = [
     "SCHEMA_VERSION_V2",
     "SCHEMA_VERSION_V3",
     "SCHEMA_VERSION_LATEST",
-    "CanonicalTelemetryRecord",
+    "ProjectedTelemetryRecord",
     "LoadedTelemetrySession",
     "TelemetryEvent",
     "TelemetryEventV2",
     "TelemetryEventV3",
-    "canonical_record_from_telemetry_event",
-    "canonical_records_from_telemetry_events",
+    "project_telemetry_event",
+    "project_telemetry_events",
     "load_telemetry_sessions",
     "telemetry_event_from_record",
     "telemetry_event_to_dict",

--- a/stormlog/telemetry.py
+++ b/stormlog/telemetry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal, Mapping, Optional
+from typing import Any, Iterable, Literal, Mapping, Optional
 
 from .session import (
     SESSION_STATUS_INCOMPLETE,
@@ -14,6 +14,12 @@ from .session import (
     select_default_loaded_session,
     sort_session_summaries,
     stable_legacy_session_id,
+)
+from .telemetry_model import (
+    CanonicalTelemetryRecord,
+    canonical_record_from_mapping,
+    unique_canonical_correlations,
+    unique_canonical_resources,
 )
 from .telemetry_sink import (
     read_telemetry_sink_manifest,
@@ -147,6 +153,21 @@ class LoadedTelemetrySession:
     events: list[TelemetryEvent]
     sources_loaded: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
+
+    def telemetry_records(self) -> list[CanonicalTelemetryRecord]:
+        """Return backend-neutral canonical records for this loaded session."""
+
+        return canonical_records_from_telemetry_events(self.events)
+
+    def resources(self) -> list[dict[str, Any]]:
+        """Return unique observed resources for this loaded session."""
+
+        return unique_canonical_resources(self.telemetry_records())
+
+    def correlations(self) -> list[dict[str, Any]]:
+        """Return unique correlation contexts for this loaded session."""
+
+        return unique_canonical_correlations(self.telemetry_records())
 
 
 def _is_int(value: Any) -> bool:
@@ -1142,14 +1163,41 @@ def load_telemetry_events(
     return list(selected.events) if selected is not None else []
 
 
+def canonical_record_from_telemetry_event(
+    event: TelemetryEvent | Mapping[str, Any],
+) -> CanonicalTelemetryRecord:
+    """Project telemetry objects or compatible mappings into the shared model."""
+
+    record = (
+        telemetry_event_to_dict(event) if isinstance(event, TelemetryEventV3) else event
+    )
+    normalized = (
+        telemetry_event_from_record(record)
+        if not isinstance(event, TelemetryEventV3)
+        else event
+    )
+    return canonical_record_from_mapping(telemetry_event_to_dict(normalized))
+
+
+def canonical_records_from_telemetry_events(
+    events: Iterable[TelemetryEvent | Mapping[str, Any]],
+) -> list[CanonicalTelemetryRecord]:
+    """Project existing telemetry events into backend-neutral canonical records."""
+
+    return [canonical_record_from_telemetry_event(event) for event in events]
+
+
 __all__ = [
     "SCHEMA_VERSION_V2",
     "SCHEMA_VERSION_V3",
     "SCHEMA_VERSION_LATEST",
+    "CanonicalTelemetryRecord",
     "LoadedTelemetrySession",
     "TelemetryEvent",
     "TelemetryEventV2",
     "TelemetryEventV3",
+    "canonical_record_from_telemetry_event",
+    "canonical_records_from_telemetry_events",
     "load_telemetry_sessions",
     "telemetry_event_from_record",
     "telemetry_event_to_dict",

--- a/stormlog/telemetry_model.py
+++ b/stormlog/telemetry_model.py
@@ -1,0 +1,280 @@
+"""Backend-neutral canonical telemetry record projection."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Literal, Mapping, Optional, cast
+
+CANONICAL_TELEMETRY_SCHEMA_VERSION: Literal[1] = 1
+
+_SEVERITY_BY_EVENT_TYPE = {
+    "critical": "critical",
+    "error": "error",
+    "warning": "warning",
+    "collector_degraded": "warning",
+    "collector_recovered": "info",
+    "start": "info",
+    "stop": "info",
+    "phase_enter": "info",
+    "phase_exit": "info",
+    "sample": "info",
+}
+
+
+@dataclass(frozen=True)
+class CanonicalTelemetryRecord:
+    """Small immutable event envelope shared by live and loaded telemetry."""
+
+    schema_version: Literal[1]
+    record_id: str
+    timestamp_ns: int
+    observed_timestamp_ns: int
+    session_id: str
+    source_kind: str
+    event_type: str
+    stage: Optional[str]
+    severity: Optional[str]
+    severity_text: Optional[str]
+    body: Optional[str]
+    resource: dict[str, Any] = field(default_factory=dict)
+    attributes: dict[str, Any] = field(default_factory=dict)
+    correlation: dict[str, Any] = field(default_factory=dict)
+
+
+def _jsonable_mapping(payload: Mapping[str, Any]) -> dict[str, Any]:
+    result = json.loads(json.dumps(dict(payload), sort_keys=True, default=str))
+    return cast(dict[str, Any], result)
+
+
+def _record_id(record: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(
+        json.dumps(_jsonable_mapping(record), sort_keys=True).encode("utf-8")
+    ).hexdigest()
+    return f"telemetry-{digest[:32]}"
+
+
+def _source_kind(record: Mapping[str, Any], metadata: Mapping[str, Any]) -> str:
+    backend = metadata.get("backend")
+    if isinstance(backend, str) and backend.strip():
+        return backend.strip().lower()
+
+    collector = record.get("collector")
+    if isinstance(collector, str):
+        lowered = collector.lower()
+        for candidate in ("cuda", "rocm", "mps", "cpu", "tensorflow", "tpu"):
+            if candidate in lowered:
+                return candidate
+
+    device_id = record.get("device_id")
+    if isinstance(device_id, int) and device_id >= 0:
+        return "gpu"
+    return "other"
+
+
+def _phase_stage(metadata: Mapping[str, Any]) -> Optional[str]:
+    phase_scope = metadata.get("phase_scope")
+    if not isinstance(phase_scope, Mapping):
+        return None
+    name = phase_scope.get("name")
+    if isinstance(name, str) and name.strip():
+        return name
+    path = phase_scope.get("path")
+    if isinstance(path, list) and path:
+        tail = path[-1]
+        if isinstance(tail, str) and tail.strip():
+            return tail
+    return None
+
+
+def _severity(record: Mapping[str, Any], metadata: Mapping[str, Any]) -> Optional[str]:
+    explicit = metadata.get("severity")
+    if isinstance(explicit, str) and explicit.strip():
+        return explicit.strip().lower()
+    event_type = record.get("event_type")
+    if isinstance(event_type, str):
+        return _SEVERITY_BY_EVENT_TYPE.get(event_type.strip().lower())
+    return None
+
+
+def _resource(record: Mapping[str, Any], source_kind: str) -> dict[str, Any]:
+    return {
+        "source_kind": source_kind,
+        "collector": record.get("collector"),
+        "host": record.get("host"),
+        "pid": record.get("pid"),
+        "device_id": record.get("device_id"),
+        "job_id": record.get("job_id"),
+        "rank": record.get("rank"),
+        "local_rank": record.get("local_rank"),
+        "world_size": record.get("world_size"),
+    }
+
+
+def _attributes(
+    record: Mapping[str, Any],
+    metadata: Mapping[str, Any],
+) -> dict[str, Any]:
+    attributes = dict(metadata)
+    attributes.update(
+        {
+            "sampling.interval_ms": record.get("sampling_interval_ms"),
+            "memory.allocator.allocated_bytes": record.get("allocator_allocated_bytes"),
+            "memory.allocator.reserved_bytes": record.get("allocator_reserved_bytes"),
+            "memory.allocator.active_bytes": record.get("allocator_active_bytes"),
+            "memory.allocator.inactive_bytes": record.get("allocator_inactive_bytes"),
+            "memory.allocator.change_bytes": record.get("allocator_change_bytes"),
+            "memory.device.used_bytes": record.get("device_used_bytes"),
+            "memory.device.free_bytes": record.get("device_free_bytes"),
+            "memory.device.total_bytes": record.get("device_total_bytes"),
+        }
+    )
+    return attributes
+
+
+def _correlation(
+    record: Mapping[str, Any], metadata: Mapping[str, Any]
+) -> dict[str, Any]:
+    correlation = {
+        "session_id": record.get("session_id"),
+        "job_id": record.get("job_id"),
+        "rank": record.get("rank"),
+        "local_rank": record.get("local_rank"),
+        "world_size": record.get("world_size"),
+    }
+    phase_scope = metadata.get("phase_scope")
+    if isinstance(phase_scope, Mapping):
+        for key in ("scope_id", "parent_scope_id", "sequence"):
+            value = phase_scope.get(key)
+            if value is not None:
+                correlation[f"phase.{key}"] = value
+    return correlation
+
+
+def canonical_record_from_mapping(
+    record: Mapping[str, Any],
+    *,
+    observed_timestamp_ns: int | None = None,
+) -> CanonicalTelemetryRecord:
+    """Project a normalized telemetry mapping into the canonical envelope.
+
+    Args:
+        record: Existing normalized telemetry record, normally a
+            `TelemetryEvent v3` dictionary.
+        observed_timestamp_ns: Optional observation timestamp. Defaults to the
+            source timestamp when no separate observation time is available.
+
+    Returns:
+        Backend-neutral canonical telemetry record.
+
+    Raises:
+        ValueError: If required identity or timestamp fields are missing.
+    """
+
+    session_id = record.get("session_id")
+    if not isinstance(session_id, str) or not session_id.strip():
+        raise ValueError("canonical telemetry record requires session_id")
+
+    timestamp_ns = record.get("timestamp_ns")
+    if not isinstance(timestamp_ns, int) or isinstance(timestamp_ns, bool):
+        raise ValueError("canonical telemetry record requires integer timestamp_ns")
+
+    event_type = record.get("event_type")
+    if not isinstance(event_type, str) or not event_type.strip():
+        raise ValueError("canonical telemetry record requires event_type")
+
+    metadata_value = record.get("metadata", {})
+    if not isinstance(metadata_value, Mapping):
+        raise ValueError("canonical telemetry record metadata must be a mapping")
+    metadata = dict(metadata_value)
+    resolved_source_kind = _source_kind(record, metadata)
+    body = record.get("context")
+
+    return CanonicalTelemetryRecord(
+        schema_version=CANONICAL_TELEMETRY_SCHEMA_VERSION,
+        record_id=_record_id(record),
+        timestamp_ns=timestamp_ns,
+        observed_timestamp_ns=(
+            timestamp_ns if observed_timestamp_ns is None else observed_timestamp_ns
+        ),
+        session_id=session_id,
+        source_kind=resolved_source_kind,
+        event_type=event_type,
+        stage=_phase_stage(metadata),
+        severity=_severity(record, metadata),
+        severity_text=(
+            str(metadata["severity_text"])
+            if metadata.get("severity_text") is not None
+            else None
+        ),
+        body=str(body) if body is not None else None,
+        resource=_resource(record, resolved_source_kind),
+        attributes=_attributes(record, metadata),
+        correlation=_correlation(record, metadata),
+    )
+
+
+def canonical_record_to_dict(record: CanonicalTelemetryRecord) -> dict[str, Any]:
+    """Serialize a canonical telemetry record to a deterministic dictionary."""
+
+    return {
+        "schema_version": record.schema_version,
+        "record_id": record.record_id,
+        "timestamp_ns": record.timestamp_ns,
+        "observed_timestamp_ns": record.observed_timestamp_ns,
+        "session_id": record.session_id,
+        "source_kind": record.source_kind,
+        "event_type": record.event_type,
+        "stage": record.stage,
+        "severity": record.severity,
+        "severity_text": record.severity_text,
+        "body": record.body,
+        "resource": dict(record.resource),
+        "attributes": dict(record.attributes),
+        "correlation": dict(record.correlation),
+    }
+
+
+def unique_canonical_resources(
+    records: Iterable[CanonicalTelemetryRecord],
+) -> list[dict[str, Any]]:
+    """Return stable unique resource dictionaries for canonical records."""
+
+    seen: set[str] = set()
+    resources: list[dict[str, Any]] = []
+    for record in records:
+        resource = dict(record.resource)
+        key = json.dumps(_jsonable_mapping(resource), sort_keys=True)
+        if key in seen:
+            continue
+        seen.add(key)
+        resources.append(resource)
+    return resources
+
+
+def unique_canonical_correlations(
+    records: Iterable[CanonicalTelemetryRecord],
+) -> list[dict[str, Any]]:
+    """Return stable unique correlation dictionaries for canonical records."""
+
+    seen: set[str] = set()
+    correlations: list[dict[str, Any]] = []
+    for record in records:
+        correlation = dict(record.correlation)
+        key = json.dumps(_jsonable_mapping(correlation), sort_keys=True)
+        if key in seen:
+            continue
+        seen.add(key)
+        correlations.append(correlation)
+    return correlations
+
+
+__all__ = [
+    "CANONICAL_TELEMETRY_SCHEMA_VERSION",
+    "CanonicalTelemetryRecord",
+    "canonical_record_from_mapping",
+    "canonical_record_to_dict",
+    "unique_canonical_correlations",
+    "unique_canonical_resources",
+]

--- a/stormlog/telemetry_model.py
+++ b/stormlog/telemetry_model.py
@@ -1,4 +1,4 @@
-"""Backend-neutral canonical telemetry record projection."""
+"""Backend-neutral projection over the persisted telemetry event schema."""
 
 from __future__ import annotations
 
@@ -9,7 +9,14 @@ from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import Any, Iterable, Literal, Mapping, Optional, cast
 
-CANONICAL_TELEMETRY_SCHEMA_VERSION: Literal[1] = 1
+# Bump this only with the docs, dataclass annotation, serialization tests, and
+# compatibility behavior for the projected envelope.
+TELEMETRY_PROJECTION_SCHEMA_VERSION: Literal[1] = 1
+
+_SUPPORTED_METADATA_SOURCE_KINDS = frozenset(
+    {"cpu", "cuda", "rocm", "mps", "tensorflow"}
+)
+_INFERRED_COLLECTOR_SOURCE_KINDS = ("cuda", "rocm", "mps", "cpu", "tensorflow")
 
 _SEVERITY_BY_EVENT_TYPE = {
     "critical": "critical",
@@ -26,7 +33,7 @@ _SEVERITY_BY_EVENT_TYPE = {
 
 
 @dataclass(frozen=True)
-class CanonicalTelemetryRecord:
+class ProjectedTelemetryRecord:
     """Small immutable event envelope shared by live and loaded telemetry."""
 
     schema_version: Literal[1]
@@ -50,7 +57,7 @@ def _freeze_value(value: Any) -> Any:
         return MappingProxyType(
             {str(key): _freeze_value(nested) for key, nested in value.items()}
         )
-    if isinstance(value, list):
+    if isinstance(value, (list, tuple)):
         return tuple(_freeze_value(item) for item in value)
     return value
 
@@ -78,18 +85,22 @@ def _record_id(record: Mapping[str, Any]) -> str:
     digest = hashlib.sha256(
         json.dumps(_jsonable_mapping(record), sort_keys=True).encode("utf-8")
     ).hexdigest()
+    # The 32-character prefix keeps a compact 128-bit identity while preserving
+    # deterministic grouping for the projected envelope.
     return f"telemetry-{digest[:32]}"
 
 
 def _source_kind(record: Mapping[str, Any], metadata: Mapping[str, Any]) -> str:
     backend = metadata.get("backend")
     if isinstance(backend, str) and backend.strip():
-        return backend.strip().lower()
+        normalized_backend = backend.strip().lower()
+        if normalized_backend in _SUPPORTED_METADATA_SOURCE_KINDS:
+            return normalized_backend
 
     collector = record.get("collector")
     if isinstance(collector, str):
         lowered = collector.lower()
-        for candidate in ("cuda", "rocm", "mps", "cpu", "tensorflow", "tpu"):
+        for candidate in _INFERRED_COLLECTOR_SOURCE_KINDS:
             if candidate in lowered:
                 return candidate
 
@@ -178,12 +189,12 @@ def _correlation(
     return correlation
 
 
-def canonical_record_from_mapping(
+def project_telemetry_mapping(
     record: Mapping[str, Any],
     *,
     observed_timestamp_ns: int | None = None,
-) -> CanonicalTelemetryRecord:
-    """Project a normalized telemetry mapping into the canonical envelope.
+) -> ProjectedTelemetryRecord:
+    """Project a normalized telemetry mapping into the projected envelope.
 
     Args:
         record: Existing normalized telemetry record, normally a
@@ -192,7 +203,7 @@ def canonical_record_from_mapping(
             source timestamp when no separate observation time is available.
 
     Returns:
-        Backend-neutral canonical telemetry record.
+        Backend-neutral projected telemetry record.
 
     Raises:
         ValueError: If required identity or timestamp fields are missing.
@@ -200,25 +211,25 @@ def canonical_record_from_mapping(
 
     session_id = record.get("session_id")
     if not isinstance(session_id, str) or not session_id.strip():
-        raise ValueError("canonical telemetry record requires session_id")
+        raise ValueError("projected telemetry record requires session_id")
 
     timestamp_ns = record.get("timestamp_ns")
     if not isinstance(timestamp_ns, int) or isinstance(timestamp_ns, bool):
-        raise ValueError("canonical telemetry record requires integer timestamp_ns")
+        raise ValueError("projected telemetry record requires integer timestamp_ns")
 
     event_type = record.get("event_type")
     if not isinstance(event_type, str) or not event_type.strip():
-        raise ValueError("canonical telemetry record requires event_type")
+        raise ValueError("projected telemetry record requires event_type")
 
     metadata_value = record.get("metadata", {})
     if not isinstance(metadata_value, Mapping):
-        raise ValueError("canonical telemetry record metadata must be a mapping")
+        raise ValueError("projected telemetry record metadata must be a mapping")
     metadata = dict(metadata_value)
     resolved_source_kind = _source_kind(record, metadata)
     body = record.get("context")
 
-    return CanonicalTelemetryRecord(
-        schema_version=CANONICAL_TELEMETRY_SCHEMA_VERSION,
+    return ProjectedTelemetryRecord(
+        schema_version=TELEMETRY_PROJECTION_SCHEMA_VERSION,
         record_id=_record_id(record),
         timestamp_ns=timestamp_ns,
         observed_timestamp_ns=(
@@ -241,8 +252,8 @@ def canonical_record_from_mapping(
     )
 
 
-def canonical_record_to_dict(record: CanonicalTelemetryRecord) -> dict[str, Any]:
-    """Serialize a canonical telemetry record to a deterministic dictionary."""
+def projected_record_to_dict(record: ProjectedTelemetryRecord) -> dict[str, Any]:
+    """Serialize a projected telemetry record to a deterministic dictionary."""
 
     return {
         "schema_version": record.schema_version,
@@ -262,10 +273,10 @@ def canonical_record_to_dict(record: CanonicalTelemetryRecord) -> dict[str, Any]
     }
 
 
-def unique_canonical_resources(
-    records: Iterable[CanonicalTelemetryRecord],
+def unique_projected_resources(
+    records: Iterable[ProjectedTelemetryRecord],
 ) -> list[dict[str, Any]]:
-    """Return stable unique resource dictionaries for canonical records."""
+    """Return stable unique resource dictionaries for projected telemetry records."""
 
     seen: set[str] = set()
     resources: list[dict[str, Any]] = []
@@ -279,10 +290,10 @@ def unique_canonical_resources(
     return resources
 
 
-def unique_canonical_correlations(
-    records: Iterable[CanonicalTelemetryRecord],
+def unique_projected_correlations(
+    records: Iterable[ProjectedTelemetryRecord],
 ) -> list[dict[str, Any]]:
-    """Return stable unique correlation dictionaries for canonical records."""
+    """Return stable unique correlation dictionaries for projected telemetry records."""
 
     seen: set[str] = set()
     correlations: list[dict[str, Any]] = []
@@ -297,10 +308,10 @@ def unique_canonical_correlations(
 
 
 __all__ = [
-    "CANONICAL_TELEMETRY_SCHEMA_VERSION",
-    "CanonicalTelemetryRecord",
-    "canonical_record_from_mapping",
-    "canonical_record_to_dict",
-    "unique_canonical_correlations",
-    "unique_canonical_resources",
+    "TELEMETRY_PROJECTION_SCHEMA_VERSION",
+    "ProjectedTelemetryRecord",
+    "project_telemetry_mapping",
+    "projected_record_to_dict",
+    "unique_projected_correlations",
+    "unique_projected_resources",
 ]

--- a/stormlog/telemetry_model.py
+++ b/stormlog/telemetry_model.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Mapping as MappingABC
 from dataclasses import dataclass, field
+from types import MappingProxyType
 from typing import Any, Iterable, Literal, Mapping, Optional, cast
 
 CANONICAL_TELEMETRY_SCHEMA_VERSION: Literal[1] = 1
@@ -38,13 +40,37 @@ class CanonicalTelemetryRecord:
     severity: Optional[str]
     severity_text: Optional[str]
     body: Optional[str]
-    resource: dict[str, Any] = field(default_factory=dict)
-    attributes: dict[str, Any] = field(default_factory=dict)
-    correlation: dict[str, Any] = field(default_factory=dict)
+    resource: Mapping[str, Any] = field(default_factory=dict)
+    attributes: Mapping[str, Any] = field(default_factory=dict)
+    correlation: Mapping[str, Any] = field(default_factory=dict)
+
+
+def _freeze_value(value: Any) -> Any:
+    if isinstance(value, MappingABC):
+        return MappingProxyType(
+            {str(key): _freeze_value(nested) for key, nested in value.items()}
+        )
+    if isinstance(value, list):
+        return tuple(_freeze_value(item) for item in value)
+    return value
+
+
+def _freeze_mapping(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    return MappingProxyType(
+        {str(key): _freeze_value(value) for key, value in payload.items()}
+    )
+
+
+def _thaw_value(value: Any) -> Any:
+    if isinstance(value, MappingABC):
+        return {str(key): _thaw_value(nested) for key, nested in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw_value(item) for item in value]
+    return value
 
 
 def _jsonable_mapping(payload: Mapping[str, Any]) -> dict[str, Any]:
-    result = json.loads(json.dumps(dict(payload), sort_keys=True, default=str))
+    result = json.loads(json.dumps(_thaw_value(payload), sort_keys=True, default=str))
     return cast(dict[str, Any], result)
 
 
@@ -209,9 +235,9 @@ def canonical_record_from_mapping(
             else None
         ),
         body=str(body) if body is not None else None,
-        resource=_resource(record, resolved_source_kind),
-        attributes=_attributes(record, metadata),
-        correlation=_correlation(record, metadata),
+        resource=_freeze_mapping(_resource(record, resolved_source_kind)),
+        attributes=_freeze_mapping(_attributes(record, metadata)),
+        correlation=_freeze_mapping(_correlation(record, metadata)),
     )
 
 
@@ -230,9 +256,9 @@ def canonical_record_to_dict(record: CanonicalTelemetryRecord) -> dict[str, Any]
         "severity": record.severity,
         "severity_text": record.severity_text,
         "body": record.body,
-        "resource": dict(record.resource),
-        "attributes": dict(record.attributes),
-        "correlation": dict(record.correlation),
+        "resource": _thaw_value(record.resource),
+        "attributes": _thaw_value(record.attributes),
+        "correlation": _thaw_value(record.correlation),
     }
 
 
@@ -244,7 +270,7 @@ def unique_canonical_resources(
     seen: set[str] = set()
     resources: list[dict[str, Any]] = []
     for record in records:
-        resource = dict(record.resource)
+        resource = cast(dict[str, Any], _thaw_value(record.resource))
         key = json.dumps(_jsonable_mapping(resource), sort_keys=True)
         if key in seen:
             continue
@@ -261,7 +287,7 @@ def unique_canonical_correlations(
     seen: set[str] = set()
     correlations: list[dict[str, Any]] = []
     for record in records:
-        correlation = dict(record.correlation)
+        correlation = cast(dict[str, Any], _thaw_value(record.correlation))
         key = json.dumps(_jsonable_mapping(correlation), sort_keys=True)
         if key in seen:
             continue

--- a/stormlog/tui/monitor.py
+++ b/stormlog/tui/monitor.py
@@ -10,9 +10,9 @@ from typing import Any, Dict, List, Optional, cast
 
 from stormlog.session import SessionSummary
 from stormlog.telemetry import (
-    CanonicalTelemetryRecord,
+    ProjectedTelemetryRecord,
     TelemetryEvent,
-    canonical_records_from_telemetry_events,
+    project_telemetry_events,
     telemetry_event_from_record,
 )
 from stormlog.telemetry_sink import TelemetrySinkConfig
@@ -311,10 +311,10 @@ class TrackerSession:
 
         return normalized
 
-    def telemetry_records(self) -> list[CanonicalTelemetryRecord]:
-        """Return backend-neutral canonical records from the live tracker."""
+    def telemetry_records(self) -> list[ProjectedTelemetryRecord]:
+        """Return backend-neutral projected telemetry records from the live tracker."""
 
-        return canonical_records_from_telemetry_events(self.get_telemetry_events())
+        return project_telemetry_events(self.get_telemetry_events())
 
     def get_session_summary(self) -> Optional[SessionSummary]:
         """Return the underlying tracker session summary when available."""

--- a/stormlog/tui/monitor.py
+++ b/stormlog/tui/monitor.py
@@ -9,7 +9,12 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, cast
 
 from stormlog.session import SessionSummary
-from stormlog.telemetry import TelemetryEvent, telemetry_event_from_record
+from stormlog.telemetry import (
+    CanonicalTelemetryRecord,
+    TelemetryEvent,
+    canonical_records_from_telemetry_events,
+    telemetry_event_from_record,
+)
 from stormlog.telemetry_sink import TelemetrySinkConfig
 
 from ..utils import format_bytes
@@ -305,6 +310,11 @@ class TrackerSession:
                 )
 
         return normalized
+
+    def telemetry_records(self) -> list[CanonicalTelemetryRecord]:
+        """Return backend-neutral canonical records from the live tracker."""
+
+        return canonical_records_from_telemetry_events(self.get_telemetry_events())
 
     def get_session_summary(self) -> Optional[SessionSummary]:
         """Return the underlying tracker session summary when available."""

--- a/tests/test_telemetry_model.py
+++ b/tests/test_telemetry_model.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from stormlog.telemetry import (
     SCHEMA_VERSION_V3,
@@ -98,7 +99,7 @@ def test_canonical_record_accepts_legacy_mapping_through_existing_normalizer() -
 
 
 def test_loaded_session_exposes_canonical_records_resources_and_correlations(
-    tmp_path,
+    tmp_path: Path,
 ) -> None:
     path = tmp_path / "events.json"
     path.write_text(json.dumps([_v3_record()]), encoding="utf-8")

--- a/tests/test_telemetry_model.py
+++ b/tests/test_telemetry_model.py
@@ -5,15 +5,19 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from types import MappingProxyType
+from typing import cast
 
 from stormlog.telemetry import (
     SCHEMA_VERSION_V3,
-    canonical_record_from_telemetry_event,
-    canonical_records_from_telemetry_events,
     load_telemetry_sessions,
+    project_telemetry_event,
+    project_telemetry_events,
     telemetry_event_from_record,
 )
-from stormlog.telemetry_model import canonical_record_to_dict
+from stormlog.telemetry_model import (
+    TELEMETRY_PROJECTION_SCHEMA_VERSION,
+    projected_record_to_dict,
+)
 
 
 def _v3_record() -> dict[str, object]:
@@ -53,13 +57,13 @@ def _v3_record() -> dict[str, object]:
     }
 
 
-def test_canonical_record_projects_v3_into_backend_neutral_envelope() -> None:
+def test_projected_record_projects_v3_into_backend_neutral_envelope() -> None:
     event = telemetry_event_from_record(_v3_record())
 
-    canonical = canonical_record_from_telemetry_event(event)
-    payload = canonical_record_to_dict(canonical)
+    projected = project_telemetry_event(event)
+    payload = projected_record_to_dict(projected)
 
-    assert payload["schema_version"] == 1
+    assert payload["schema_version"] == TELEMETRY_PROJECTION_SCHEMA_VERSION
     assert payload["session_id"] == "session-1"
     assert payload["source_kind"] == "cuda"
     assert payload["event_type"] == "phase_enter"
@@ -68,32 +72,46 @@ def test_canonical_record_projects_v3_into_backend_neutral_envelope() -> None:
     assert payload["body"] == "Phase entered: train / forward"
     assert payload["resource"]["collector"] == "stormlog.cuda_tracker"
     assert payload["resource"]["device_id"] == 0
+    assert payload["resource"]["source_kind"] == payload["source_kind"]
     assert payload["attributes"]["memory.allocator.allocated_bytes"] == 1024
     assert payload["attributes"]["memory.device.total_bytes"] == 12288
+    assert payload["correlation"]["session_id"] == payload["session_id"]
     assert payload["correlation"]["phase.scope_id"] == "session-1:2"
 
 
-def test_canonical_record_id_is_deterministic_for_same_event() -> None:
+def test_projected_record_id_is_deterministic_compact_hash() -> None:
     event = telemetry_event_from_record(_v3_record())
 
-    first = canonical_record_from_telemetry_event(event)
-    second = canonical_record_from_telemetry_event(event)
+    first = project_telemetry_event(event)
+    second = project_telemetry_event(event)
 
     assert first.record_id == second.record_id
+    assert first.record_id.startswith("telemetry-")
+    assert len(first.record_id.removeprefix("telemetry-")) == 32
 
 
-def test_canonical_record_mappings_are_read_only() -> None:
-    event = telemetry_event_from_record(_v3_record())
+def test_projected_record_mappings_are_deeply_read_only() -> None:
+    record = _v3_record()
+    metadata = cast(dict[str, object], record["metadata"]).copy()
+    metadata["tuple_values"] = ({"nested": "value"},)
+    record["metadata"] = metadata
+    event = telemetry_event_from_record(record)
 
-    canonical = canonical_record_from_telemetry_event(event)
+    projected = project_telemetry_event(event)
+    payload = projected_record_to_dict(projected)
 
-    assert isinstance(canonical.resource, MappingProxyType)
-    assert isinstance(canonical.attributes, MappingProxyType)
-    assert isinstance(canonical.correlation, MappingProxyType)
+    assert isinstance(projected.resource, MappingProxyType)
+    assert isinstance(projected.attributes, MappingProxyType)
+    assert isinstance(projected.correlation, MappingProxyType)
+    assert isinstance(projected.attributes["phase_scope"], MappingProxyType)
+    tuple_values = projected.attributes["tuple_values"]
+    assert isinstance(tuple_values, tuple)
+    assert isinstance(tuple_values[0], MappingProxyType)
+    assert payload["attributes"]["tuple_values"] == [{"nested": "value"}]
 
 
-def test_canonical_record_accepts_legacy_mapping_through_existing_normalizer() -> None:
-    canonical = canonical_record_from_telemetry_event(
+def test_projected_record_accepts_legacy_mapping_through_existing_normalizer() -> None:
+    projected = project_telemetry_event(
         {
             "timestamp": 1_700_000_000.0,
             "event_type": "sample",
@@ -104,12 +122,22 @@ def test_canonical_record_accepts_legacy_mapping_through_existing_normalizer() -
         }
     )
 
-    assert canonical.source_kind == "cpu"
-    assert canonical.attributes["memory.allocator.allocated_bytes"] == 1024
-    assert canonical.resource["collector"] == "stormlog.cpu_tracker"
+    assert projected.source_kind == "cpu"
+    assert projected.attributes["memory.allocator.allocated_bytes"] == 1024
+    assert projected.resource["collector"] == "stormlog.cpu_tracker"
 
 
-def test_loaded_session_exposes_canonical_records_resources_and_correlations(
+def test_projected_record_does_not_advertise_unknown_future_backend() -> None:
+    record = _v3_record()
+    record["metadata"] = {"backend": "tpu"}
+
+    projected = project_telemetry_event(record)
+
+    assert projected.source_kind == "cuda"
+    assert projected.attributes["backend"] == "tpu"
+
+
+def test_loaded_session_exposes_projected_records_resources_and_correlations(
     tmp_path: Path,
 ) -> None:
     path = tmp_path / "events.json"
@@ -128,7 +156,7 @@ def test_loaded_session_exposes_canonical_records_resources_and_correlations(
     assert correlations == [records[0].correlation]
 
 
-def test_canonical_records_from_telemetry_events_preserves_order() -> None:
+def test_project_telemetry_events_preserves_order() -> None:
     first_record = _v3_record()
     second_record = dict(first_record)
     second_record["timestamp_ns"] = 1_700_000_000_000_000_100
@@ -139,6 +167,6 @@ def test_canonical_records_from_telemetry_events_preserves_order() -> None:
         telemetry_event_from_record(second_record),
     ]
 
-    records = canonical_records_from_telemetry_events(events)
+    records = project_telemetry_events(events)
 
     assert [record.event_type for record in records] == ["phase_enter", "phase_exit"]

--- a/tests/test_telemetry_model.py
+++ b/tests/test_telemetry_model.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import MappingProxyType
 
 from stormlog.telemetry import (
     SCHEMA_VERSION_V3,
@@ -79,6 +80,16 @@ def test_canonical_record_id_is_deterministic_for_same_event() -> None:
     second = canonical_record_from_telemetry_event(event)
 
     assert first.record_id == second.record_id
+
+
+def test_canonical_record_mappings_are_read_only() -> None:
+    event = telemetry_event_from_record(_v3_record())
+
+    canonical = canonical_record_from_telemetry_event(event)
+
+    assert isinstance(canonical.resource, MappingProxyType)
+    assert isinstance(canonical.attributes, MappingProxyType)
+    assert isinstance(canonical.correlation, MappingProxyType)
 
 
 def test_canonical_record_accepts_legacy_mapping_through_existing_normalizer() -> None:

--- a/tests/test_telemetry_model.py
+++ b/tests/test_telemetry_model.py
@@ -1,0 +1,132 @@
+"""Tests for backend-neutral telemetry record projection."""
+
+from __future__ import annotations
+
+import json
+
+from stormlog.telemetry import (
+    SCHEMA_VERSION_V3,
+    canonical_record_from_telemetry_event,
+    canonical_records_from_telemetry_events,
+    load_telemetry_sessions,
+    telemetry_event_from_record,
+)
+from stormlog.telemetry_model import canonical_record_to_dict
+
+
+def _v3_record() -> dict[str, object]:
+    return {
+        "schema_version": SCHEMA_VERSION_V3,
+        "session_id": "session-1",
+        "timestamp_ns": 1_700_000_000_000_000_000,
+        "event_type": "phase_enter",
+        "collector": "stormlog.cuda_tracker",
+        "sampling_interval_ms": 100,
+        "pid": 1234,
+        "host": "host-a",
+        "job_id": "job-1",
+        "rank": 1,
+        "local_rank": 0,
+        "world_size": 2,
+        "device_id": 0,
+        "allocator_allocated_bytes": 1024,
+        "allocator_reserved_bytes": 2048,
+        "allocator_active_bytes": 512,
+        "allocator_inactive_bytes": 256,
+        "allocator_change_bytes": 128,
+        "device_used_bytes": 4096,
+        "device_free_bytes": 8192,
+        "device_total_bytes": 12288,
+        "context": "Phase entered: train / forward",
+        "metadata": {
+            "backend": "cuda",
+            "phase_scope": {
+                "action": "enter",
+                "name": "forward",
+                "scope_id": "session-1:2",
+                "parent_scope_id": "session-1:1",
+                "sequence": 2,
+            },
+        },
+    }
+
+
+def test_canonical_record_projects_v3_into_backend_neutral_envelope() -> None:
+    event = telemetry_event_from_record(_v3_record())
+
+    canonical = canonical_record_from_telemetry_event(event)
+    payload = canonical_record_to_dict(canonical)
+
+    assert payload["schema_version"] == 1
+    assert payload["session_id"] == "session-1"
+    assert payload["source_kind"] == "cuda"
+    assert payload["event_type"] == "phase_enter"
+    assert payload["stage"] == "forward"
+    assert payload["severity"] == "info"
+    assert payload["body"] == "Phase entered: train / forward"
+    assert payload["resource"]["collector"] == "stormlog.cuda_tracker"
+    assert payload["resource"]["device_id"] == 0
+    assert payload["attributes"]["memory.allocator.allocated_bytes"] == 1024
+    assert payload["attributes"]["memory.device.total_bytes"] == 12288
+    assert payload["correlation"]["phase.scope_id"] == "session-1:2"
+
+
+def test_canonical_record_id_is_deterministic_for_same_event() -> None:
+    event = telemetry_event_from_record(_v3_record())
+
+    first = canonical_record_from_telemetry_event(event)
+    second = canonical_record_from_telemetry_event(event)
+
+    assert first.record_id == second.record_id
+
+
+def test_canonical_record_accepts_legacy_mapping_through_existing_normalizer() -> None:
+    canonical = canonical_record_from_telemetry_event(
+        {
+            "timestamp": 1_700_000_000.0,
+            "event_type": "sample",
+            "memory_allocated": 1024,
+            "memory_reserved": 2048,
+            "memory_change": 0,
+            "metadata": {"backend": "cpu"},
+        }
+    )
+
+    assert canonical.source_kind == "cpu"
+    assert canonical.attributes["memory.allocator.allocated_bytes"] == 1024
+    assert canonical.resource["collector"] == "stormlog.cpu_tracker"
+
+
+def test_loaded_session_exposes_canonical_records_resources_and_correlations(
+    tmp_path,
+) -> None:
+    path = tmp_path / "events.json"
+    path.write_text(json.dumps([_v3_record()]), encoding="utf-8")
+
+    sessions = load_telemetry_sessions(path)
+
+    assert len(sessions) == 1
+    loaded = sessions[0]
+    records = loaded.telemetry_records()
+    resources = loaded.resources()
+    correlations = loaded.correlations()
+
+    assert len(records) == 1
+    assert resources == [records[0].resource]
+    assert correlations == [records[0].correlation]
+
+
+def test_canonical_records_from_telemetry_events_preserves_order() -> None:
+    first_record = _v3_record()
+    second_record = dict(first_record)
+    second_record["timestamp_ns"] = 1_700_000_000_000_000_100
+    second_record["event_type"] = "phase_exit"
+
+    events = [
+        telemetry_event_from_record(first_record),
+        telemetry_event_from_record(second_record),
+    ]
+
+    records = canonical_records_from_telemetry_events(events)
+
+    assert [record.event_type for record in records] == ["phase_enter", "phase_exit"]

--- a/tests/tui/test_monitor.py
+++ b/tests/tui/test_monitor.py
@@ -150,6 +150,12 @@ def test_tracker_session_get_telemetry_events_normalizes_cpu_events(
     assert first.world_size == 4
     assert first.job_id == "job-123"
 
+    telemetry_records = session.telemetry_records()
+    assert len(telemetry_records) == 1
+    assert telemetry_records[0].source_kind == "cpu"
+    assert telemetry_records[0].resource["collector"] == "stormlog.cpu_tracker"
+    assert telemetry_records[0].attributes["memory.allocator.allocated_bytes"] == 1024
+
 
 def test_tracker_session_preserves_collector_health_metadata(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Implements the telemetry-first internal model work by adding a canonical, backend-neutral telemetry projection over the existing `TelemetryEvent v3` contract and documenting the architecture decision in the project docs.

This keeps the current artifact and sink formats backward-compatible while giving runtime, loaded artifacts, live/TUI sessions, and future analysis code a shared internal event model.

## Changes

- Added `CanonicalTelemetryRecord` and projection helpers in `stormlog.telemetry_model`.
- Added canonical record helpers in `stormlog.telemetry`.
- Exposed canonical telemetry records from:
  - `LoadedTelemetrySession.telemetry_records()`
  - `LoadedTelemetrySession.resources()`
  - `LoadedTelemetrySession.correlations()`
  - `TrackerSession.telemetry_records()`
- Preserved existing V2/V3 artifact loading and current sink/export behavior.
- Added tests for canonical projection, deterministic record IDs, immutability, legacy mapping normalization, loaded sessions, and TUI session projection.
- Added `docs/telemetry_first_internal_model.md`.
- Linked the new guide from the docs index and API/reference docs.
- Cross-referenced the current telemetry schema without changing the schema itself.
- Cleaned Sphinx API navigation duplication.

## Design Notes

- Trackers can continue emitting compact runtime-local events.
- Normalization remains at the tracker/loader edge.
- `TelemetryEvent v3` remains the persisted artifact and append-only sink format for now.
- The canonical model is an additive internal projection, not a breaking schema migration.
- Backend-specific details live in `resource`, `attributes`, and `correlation` rather than top-level backend-specific fields.
- Future persisted canonical writes are documented as a separate migration phase gated by benchmark results.

## Compatibility

- Existing V2, V3, legacy JSON, and JSONL artifacts remain loadable.
- No runtime public API behavior was removed.
- No existing JSON schema was changed.
- Legacy export and loader paths remain explicit compatibility boundaries.

## Validation

Passed locally with `.venv`:

- `pre-commit run --all-files`
- `python -m black --check stormlog/ tests/ examples/`
- `python -m isort --check --diff stormlog/ tests/ examples/`
- `python -m flake8 stormlog/ tests/ examples/ --show-source --statistics`
- `python -m mypy stormlog/`
- `python -m sphinx -W --keep-going -b html docs docs/_build/html`
- `python -m pytest tests/ -m "not tui_pilot and not tui_snapshot and not tui_pty" -q`
- `python -m pytest tests/tui/ -m "tui_pilot or tui_snapshot" -q`
- `python -m pytest tests/e2e/test_tui_pty.py -m tui_pty -q`
- `python -m build --outdir /private/tmp/stormlog-dist`
- `python -m twine check /private/tmp/stormlog-dist/*`

Benchmark gate note:

- CPU gpumemprof regression metrics passed.
- Full benchmark command failed only because TensorFlow is not installed in the local `.venv`.

Closes #106 