### PR TITLE
Feature/local query layer for telemetry sessions

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -33,6 +33,10 @@ pip install "stormlog[tui,torch]"
 stormlog
 ```
 
+The `stormlog` command is also a small dispatcher. Running it without
+arguments still launches the TUI, while `stormlog query ...` runs the local
+artifact query CLI without importing Textual.
+
 ## `gpumemprof`
 
 The current command groups are:
@@ -224,6 +228,72 @@ active-memory table in one file. For a maintained workflow example of that
 artifact, continue with [PyTorch Production Recipes](cookbook/pytorch.md). On
 MPS, ROCm, or CPU-only runtimes, the command fails explicitly instead of
 pretending support.
+
+## `stormlog query`
+
+`stormlog query` asks structured questions over local artifact directories. It
+uses the same canonical telemetry loaders as `gpumemprof analyze`, but exposes
+rows that are easier to filter, export, and reuse from automation.
+
+The query surface is local-first and file-backed. It reads sink manifests and
+bundle manifests before loading raw events, so listing sessions or OOM bundles
+does not require parsing every JSONL segment in a large sink directory.
+
+List sessions:
+
+```bash
+stormlog query sessions ./live_sink --status interrupted --json
+stormlog query sessions ./artifacts --has-oom-bundle --table
+```
+
+Query events:
+
+```bash
+stormlog query events ./live_sink \
+  --session-id 2b30f4a4-7d2d-48f7-a9f6-7d40c14eb95e \
+  --rank 0 \
+  --event-type collector_degraded \
+  --limit 50
+```
+
+List OOM bundles:
+
+```bash
+stormlog query ooms ./artifacts --backend cuda --table
+stormlog query ooms ./artifacts --created-after 2026-05-12T00:00:00Z --json
+```
+
+Run built-in summaries:
+
+```bash
+stormlog query summary ./live_sink \
+  --metric peak_allocator_reserved_bytes \
+  --group-by session
+
+stormlog query summary ./live_sink \
+  --metric hidden_memory_gap_growth \
+  --group-by session-rank
+```
+
+Supported output formats:
+
+- `--table`: readable table output, used by default
+- `--json`: machine-readable rows
+- `--csv`: row-query exports for `sessions`, `events`, and `ooms`
+
+The Python API behind the CLI is available as:
+
+```python
+import stormlog.query
+
+store = stormlog.query.open(["./live_sink", "./oom_dumps"])
+sessions = store.list_sessions()
+events = store.query_events()
+ooms = store.list_oom_bundles()
+```
+
+For engine-choice details and follow-on work, see
+[Local Query Layer](query_layer.md).
 
 ## `tfmemprof`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ compatibility_matrix
 benchmark_harness
 telemetry_schema
 telemetry_projection
+query_layer
 pytorch_testing_guide
 tensorflow_testing_guide
 article

--- a/docs/query_layer.md
+++ b/docs/query_layer.md
@@ -1,0 +1,105 @@
+[← Back to docs](index.md)
+
+# Local Query Layer
+
+Stormlog exposes a local, file-backed query surface for telemetry sessions and
+artifact bundles through `stormlog.query` and `stormlog query`. The v1 design is
+pure Python and in-process: it reads existing artifact files directly and does
+not require a database server, hosted service, or persistent index.
+
+## Engine Choice
+
+The query layer starts with a pure Python row model instead of adopting DuckDB
+as a required runtime dependency.
+
+DuckDB is still a good future acceleration path. The current DuckDB Python
+docs show that `read_json` can auto-detect regular JSON and newline-delimited
+JSON files, infer object schemas, and read multiple files. The JSON extension is
+also shipped by default or autoloaded on first use. Those traits make DuckDB a
+strong candidate once Stormlog has enough large multi-session datasets to need a
+columnar execution engine.
+
+For v1, the harder product problem is not SQL execution. It is stable artifact
+discovery, schema projection, session linkage, and a public contract that CLI,
+TUI, notebooks, and automation can share. Keeping the first version in Python
+lets Stormlog define that contract without designing around one backend too
+early.
+
+References:
+
+- [DuckDB Python data ingestion](https://duckdb.org/docs/current/clients/python/data_ingestion.html)
+- [DuckDB JSON loading](https://duckdb.org/docs/current/data/json/loading_json)
+- [DuckDB JSON extension loading](https://duckdb.org/docs/current/data/json/installing_and_loading.html)
+
+## Catalog and Projection
+
+`ArtifactCatalog` discovers available artifacts before loading every event row.
+It recognizes:
+
+- append-only telemetry sink directories and JSONL segments
+- flat JSON, JSONL, and CSV telemetry files
+- diagnose bundles with session manifests
+- OOM dump bundles with stable manifests and metadata
+
+Discovery is manifest-first. Sink manifests provide session rows, segment paths,
+and event counts without parsing all segment records. Diagnose and OOM manifests
+provide bundle/session linkage without loading timelines or OOM event buffers.
+Flat telemetry files are loaded only when a query needs their session or event
+rows because they do not have a separate manifest ledger.
+
+The row contracts are explicit and automation-friendly:
+
+- `SessionRow`: session identity, status, rank metadata, source provenance,
+  event count when known, warning count, and linked OOM bundle count
+- `EventRow`: canonical `TelemetryEvent` fields plus `source_path`,
+  `source_kind`, and `session_status`
+- `OOMBundleRow`: bundle path, creation time, backend, reason, event count,
+  session linkage, and exception type/module
+- `SummaryRow`: built-in metric results with session/rank/status grouping
+
+The canonical telemetry schema remains the event contract. Query rows add
+provenance but do not mutate persisted telemetry records.
+
+## Caching and Loading
+
+`QueryStore` caches loaded sessions in memory per source path and source kind.
+There is no persistent index in v1. This keeps discovery cheap, avoids stale
+cache invalidation rules, and makes the behavior easy to reason about for local
+artifact directories that may still be written by long-running jobs.
+
+Event materialization happens only for:
+
+- `query_events(...)`
+- summaries that require raw telemetry rows
+- flat telemetry files whose sessions cannot be listed from a manifest
+
+Session listing from a sink manifest and OOM bundle listing do not require JSONL
+segment materialization.
+
+## Built-In Summaries
+
+The v1 query layer intentionally provides a small set of summaries instead of a
+custom aggregation language:
+
+- session count by status
+- peak allocator allocated/reserved bytes
+- peak device used bytes
+- alert count by session or rank
+- collector degradation transitions
+- interrupted sessions with linked OOM bundles
+- hidden-memory gap growth using `device_used_bytes - allocator_reserved_bytes`
+
+These cover the immediate operational questions while leaving room for a DuckDB
+adapter or richer aggregation API later.
+
+## Follow-On Tasks
+
+- Add an optional DuckDB adapter behind the same row model for very large JSONL
+  sink directories.
+- Reuse `ArtifactCatalog` in TUI and distributed diagnostics loaders where it
+  can replace bespoke discovery logic.
+- Add notebook examples that use `stormlog.query.open([...])` directly.
+- Add persistent indexing only after measuring real multi-session directory
+  costs and defining invalidation behavior.
+- Add automation-specific schemas on top of query rows rather than changing the
+  artifact contract.

--- a/stormlog/derived_fields.py
+++ b/stormlog/derived_fields.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import dataclasses
 from collections.abc import Mapping as MappingABC
-from typing import Any, Dict, Sequence, TypedDict
+from typing import Any, Dict, Sequence, TypedDict, cast
 
 from .collector_health import COLLECTOR_HEALTH_DEGRADED
 
@@ -230,7 +230,7 @@ def enrich_event(event: Any) -> Dict[str, Any]:
     if isinstance(event, MappingABC):
         raw: Dict[str, Any] = dict(event)
     elif dataclasses.is_dataclass(event):
-        raw = dataclasses.asdict(event)
+        raw = dataclasses.asdict(cast(Any, event))
     else:
         raw = dict(vars(event))
 

--- a/stormlog/query.py
+++ b/stormlog/query.py
@@ -544,8 +544,6 @@ class QueryStore:
                     )
                     if _event_matches(row, filters):
                         rows.append(row)
-                        if filters.limit is not None and len(rows) >= filters.limit:
-                            return rows
 
         rows.sort(key=lambda row: (row.event.timestamp_ns, row.event.session_id))
         if filters.limit is not None:
@@ -558,9 +556,7 @@ class QueryStore:
     ) -> list[OOMBundleRow]:
         """Return filtered OOM bundle rows."""
         filters = filters or OOMBundleFilter()
-        session_status_by_id = {
-            row.session_id: row.status for row in self.list_sessions(SessionFilter())
-        }
+        session_status_by_id = self._manifest_session_status_by_id()
         rows = [
             OOMBundleRow(
                 bundle_path=str(bundle.bundle_path),
@@ -585,6 +581,24 @@ class QueryStore:
         rows = [row for row in rows if _oom_matches(row, filters)]
         rows.sort(key=lambda row: (row.created_at_utc or "", row.bundle_path))
         return rows
+
+    def _manifest_session_status_by_id(self) -> dict[str, str]:
+        statuses: dict[str, str] = {}
+        for source in self.catalog.sources:
+            if source.source_kind == "sink":
+                manifest = read_telemetry_sink_manifest(source.path)
+                if manifest is None:
+                    continue
+                for summary in manifest.sessions:
+                    statuses.setdefault(summary.session_id, summary.status)
+            elif source.source_kind == "diagnose_bundle":
+                diagnose_summary = _diagnose_session_summary(source.manifest_path)
+                if diagnose_summary is not None:
+                    statuses.setdefault(
+                        diagnose_summary.session_id,
+                        diagnose_summary.status,
+                    )
+        return statuses
 
     def summarize(
         self,

--- a/stormlog/query.py
+++ b/stormlog/query.py
@@ -1,0 +1,1189 @@
+"""Local query API for Stormlog artifact directories and telemetry files."""
+
+from __future__ import annotations
+
+import builtins
+import csv
+import json
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+from .session import (
+    SESSION_STATUS_INTERRUPTED,
+    SessionSummary,
+    infer_session_summary_from_events,
+    session_summary_from_dict,
+    session_summary_to_dict,
+    stable_legacy_session_id,
+)
+from .telemetry import (
+    LoadedTelemetrySession,
+    TelemetryEvent,
+    load_telemetry_sessions,
+    telemetry_event_from_record,
+    telemetry_event_to_dict,
+)
+from .telemetry_sink import (
+    MANIFEST_FILENAME,
+    SEGMENT_SUFFIX,
+    TelemetrySinkManifest,
+    read_telemetry_sink_manifest,
+    resolve_telemetry_sink_segment_paths,
+)
+
+SourceKind = Literal[
+    "sink",
+    "telemetry_json",
+    "telemetry_jsonl",
+    "telemetry_csv",
+    "diagnose_bundle",
+    "oom_bundle",
+]
+SummaryMetric = Literal[
+    "session_count_by_status",
+    "peak_allocator_allocated_bytes",
+    "peak_allocator_reserved_bytes",
+    "peak_device_used_bytes",
+    "alert_count",
+    "collector_degradation_transitions",
+    "interrupted_sessions_with_oom_bundles",
+    "hidden_memory_gap_growth",
+]
+SummaryGroupBy = Literal["session", "session-rank", "rank", "status"]
+
+_ALERT_EVENT_TYPES = frozenset({"warning", "critical", "error"})
+_COLLECTOR_TRANSITION_TYPES = frozenset({"collector_degraded", "collector_recovered"})
+_TELEMETRY_FILE_NAME_PARTS = ("event", "events", "track", "telemetry")
+
+
+@dataclass(frozen=True)
+class CatalogWarning:
+    """Non-fatal discovery or loading warning."""
+
+    path: str
+    message: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"path": self.path, "message": self.message}
+
+
+@dataclass(frozen=True)
+class CatalogSource:
+    """One discovered source of queryable artifact data."""
+
+    path: Path
+    source_kind: SourceKind
+    event_paths: tuple[Path, ...] = ()
+    manifest_path: Path | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "source_kind": self.source_kind,
+            "event_paths": [str(path) for path in self.event_paths],
+            "manifest_path": (
+                str(self.manifest_path) if self.manifest_path is not None else None
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class CatalogOOMBundle:
+    """Manifest-backed OOM dump bundle discovered during cataloging."""
+
+    bundle_path: Path
+    manifest_path: Path
+    created_at_utc: str | None
+    backend: str | None
+    reason: str | None
+    event_count: int | None
+    session_id: str | None
+    session_status: str | None
+    exception_type: str | None = None
+    exception_module: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "bundle_path": str(self.bundle_path),
+            "manifest_path": str(self.manifest_path),
+            "created_at_utc": self.created_at_utc,
+            "backend": self.backend,
+            "reason": self.reason,
+            "event_count": self.event_count,
+            "session_id": self.session_id,
+            "session_status": self.session_status,
+            "exception_type": self.exception_type,
+            "exception_module": self.exception_module,
+        }
+
+
+@dataclass(frozen=True)
+class SessionFilter:
+    """Filters for catalog/session rows."""
+
+    session_id: str | None = None
+    status: str | None = None
+    job_id: str | None = None
+    rank: int | None = None
+    world_size: int | None = None
+    has_oom_bundle: bool | None = None
+    source_kind: str | None = None
+
+
+@dataclass(frozen=True)
+class EventFilter:
+    """Filters for canonical telemetry event rows."""
+
+    session_id: str | None = None
+    event_type: str | None = None
+    rank: int | None = None
+    collector: str | None = None
+    status: str | None = None
+    time_start_ns: int | None = None
+    time_end_ns: int | None = None
+    has_alert: bool | None = None
+    collector_health_status: str | None = None
+    backend: str | None = None
+    limit: int | None = None
+
+
+@dataclass(frozen=True)
+class OOMBundleFilter:
+    """Filters for OOM bundle rows."""
+
+    session_id: str | None = None
+    backend: str | None = None
+    reason: str | None = None
+    created_after: str | None = None
+    created_before: str | None = None
+
+
+@dataclass(frozen=True)
+class SessionRow:
+    """Query row describing one loaded or manifest-backed session."""
+
+    session_id: str
+    status: str
+    started_at_ns: int
+    ended_at_ns: int | None
+    host: str
+    pid: int
+    job_id: str | None
+    rank: int
+    local_rank: int
+    world_size: int
+    source: str
+    source_path: str
+    source_kind: str
+    source_count: int
+    warning_count: int
+    event_count: int | None
+    oom_bundle_count: int
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "status": self.status,
+            "started_at_ns": self.started_at_ns,
+            "ended_at_ns": self.ended_at_ns,
+            "host": self.host,
+            "pid": self.pid,
+            "job_id": self.job_id,
+            "rank": self.rank,
+            "local_rank": self.local_rank,
+            "world_size": self.world_size,
+            "source": self.source,
+            "source_path": self.source_path,
+            "source_kind": self.source_kind,
+            "source_count": self.source_count,
+            "warning_count": self.warning_count,
+            "event_count": self.event_count,
+            "oom_bundle_count": self.oom_bundle_count,
+        }
+
+
+@dataclass(frozen=True)
+class EventRow:
+    """Query row wrapping a canonical telemetry event and provenance."""
+
+    event: TelemetryEvent
+    source_path: str
+    source_kind: str
+    session_status: str
+
+    def as_dict(self) -> dict[str, Any]:
+        row = telemetry_event_to_dict(self.event)
+        row["source_path"] = self.source_path
+        row["source_kind"] = self.source_kind
+        row["session_status"] = self.session_status
+        return row
+
+
+@dataclass(frozen=True)
+class OOMBundleRow:
+    """Query row for one OOM bundle manifest."""
+
+    bundle_path: str
+    created_at_utc: str | None
+    backend: str | None
+    reason: str | None
+    event_count: int | None
+    session_id: str | None
+    session_status: str | None
+    exception_type: str | None
+    exception_module: str | None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "bundle_path": self.bundle_path,
+            "created_at_utc": self.created_at_utc,
+            "backend": self.backend,
+            "reason": self.reason,
+            "event_count": self.event_count,
+            "session_id": self.session_id,
+            "session_status": self.session_status,
+            "exception_type": self.exception_type,
+            "exception_module": self.exception_module,
+        }
+
+
+@dataclass(frozen=True)
+class SummaryRow:
+    """Built-in summary result row."""
+
+    metric: str
+    group_by: str
+    value: int | float | str | None
+    session_id: str | None = None
+    rank: int | None = None
+    status: str | None = None
+    details: Mapping[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        row = {
+            "metric": self.metric,
+            "group_by": self.group_by,
+            "session_id": self.session_id,
+            "rank": self.rank,
+            "status": self.status,
+            "value": self.value,
+        }
+        row.update(dict(self.details))
+        return row
+
+
+class ArtifactCatalog:
+    """Manifest-first catalog of local Stormlog artifacts."""
+
+    def __init__(self, paths: Sequence[str | Path]) -> None:
+        self.paths = tuple(Path(path) for path in paths)
+        self.sources: list[CatalogSource] = []
+        self.oom_bundles: list[CatalogOOMBundle] = []
+        self.warnings: list[CatalogWarning] = []
+        self._source_keys: set[tuple[Path, SourceKind]] = set()
+        self._oom_bundle_paths: set[Path] = set()
+        self._covered_event_paths: set[Path] = set()
+        self._discover()
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "paths": [str(path) for path in self.paths],
+            "sources": [source.as_dict() for source in self.sources],
+            "oom_bundles": [bundle.as_dict() for bundle in self.oom_bundles],
+            "warnings": [warning.as_dict() for warning in self.warnings],
+        }
+
+    def _discover(self) -> None:
+        for path in self.paths:
+            self._discover_path(path)
+
+    def _discover_path(self, path: Path) -> None:
+        if not path.exists():
+            self._warn(path, "path does not exist")
+            return
+        if path.is_file():
+            self._discover_file(path)
+            return
+        if not path.is_dir():
+            self._warn(path, "path is neither a file nor a directory")
+            return
+        self._discover_directory(path)
+
+    def _discover_directory(self, directory: Path) -> None:
+        manifest_path = directory / MANIFEST_FILENAME
+        manifest_payload = _read_json_object(manifest_path)
+        if manifest_payload is not None:
+            if _is_oom_manifest(manifest_payload):
+                self._add_oom_bundle(directory, manifest_path, manifest_payload)
+                return
+            if _is_diagnose_manifest(manifest_payload):
+                self._add_source(
+                    CatalogSource(
+                        path=directory,
+                        source_kind="diagnose_bundle",
+                        manifest_path=manifest_path,
+                    )
+                )
+            if _is_sink_manifest(manifest_payload):
+                segment_paths = tuple(resolve_telemetry_sink_segment_paths(directory))
+                self._covered_event_paths.update(segment_paths)
+                self._add_source(
+                    CatalogSource(
+                        path=directory,
+                        source_kind="sink",
+                        event_paths=segment_paths,
+                        manifest_path=manifest_path,
+                    )
+                )
+
+        for nested_manifest in sorted(directory.rglob(MANIFEST_FILENAME)):
+            if nested_manifest == manifest_path:
+                continue
+            payload = _read_json_object(nested_manifest)
+            if payload is None:
+                continue
+            parent = nested_manifest.parent
+            if _is_oom_manifest(payload):
+                self._add_oom_bundle(parent, nested_manifest, payload)
+            elif _is_diagnose_manifest(payload):
+                self._add_source(
+                    CatalogSource(
+                        path=parent,
+                        source_kind="diagnose_bundle",
+                        manifest_path=nested_manifest,
+                    )
+                )
+            elif _is_sink_manifest(payload):
+                segment_paths = tuple(resolve_telemetry_sink_segment_paths(parent))
+                self._covered_event_paths.update(segment_paths)
+                self._add_source(
+                    CatalogSource(
+                        path=parent,
+                        source_kind="sink",
+                        event_paths=segment_paths,
+                        manifest_path=nested_manifest,
+                    )
+                )
+
+        for candidate in self._discover_candidate_files(directory):
+            if candidate in self._covered_event_paths:
+                continue
+            self._discover_file(candidate)
+
+    def _discover_file(self, path: Path) -> None:
+        if path.name == MANIFEST_FILENAME:
+            payload = _read_json_object(path)
+            if payload is None:
+                self._warn(path, "manifest is not a JSON object")
+                return
+            if _is_oom_manifest(payload):
+                self._add_oom_bundle(path.parent, path, payload)
+                return
+            if _is_diagnose_manifest(payload):
+                self._add_source(
+                    CatalogSource(
+                        path=path.parent,
+                        source_kind="diagnose_bundle",
+                        manifest_path=path,
+                    )
+                )
+                return
+            if _is_sink_manifest(payload):
+                segment_paths = tuple(resolve_telemetry_sink_segment_paths(path))
+                self._covered_event_paths.update(segment_paths)
+                self._add_source(
+                    CatalogSource(
+                        path=path.parent,
+                        source_kind="sink",
+                        event_paths=segment_paths,
+                        manifest_path=path,
+                    )
+                )
+                return
+            self._warn(path, "unrecognized manifest shape")
+            return
+
+        suffix = path.suffix.lower()
+        if suffix == SEGMENT_SUFFIX:
+            self._add_source(
+                CatalogSource(
+                    path=path,
+                    source_kind="telemetry_jsonl",
+                    event_paths=(path,),
+                )
+            )
+        elif suffix == ".json":
+            self._add_source(
+                CatalogSource(
+                    path=path,
+                    source_kind="telemetry_json",
+                    event_paths=(path,),
+                )
+            )
+        elif suffix == ".csv":
+            self._add_source(
+                CatalogSource(
+                    path=path,
+                    source_kind="telemetry_csv",
+                    event_paths=(path,),
+                )
+            )
+
+    def _discover_candidate_files(self, directory: Path) -> list[Path]:
+        candidates: set[Path] = set()
+        for suffix in ("*.json", "*.jsonl", "*.csv"):
+            for path in directory.rglob(suffix):
+                if not path.is_file() or path.name == MANIFEST_FILENAME:
+                    continue
+                if self._is_inside_discovered_bundle(path):
+                    continue
+                if path.suffix.lower() == SEGMENT_SUFFIX:
+                    candidates.add(path)
+                    continue
+                lowered = path.name.lower()
+                if any(part in lowered for part in _TELEMETRY_FILE_NAME_PARTS):
+                    candidates.add(path)
+        return sorted(candidates)
+
+    def _is_inside_discovered_bundle(self, path: Path) -> bool:
+        return any(
+            bundle_path in path.parents for bundle_path in self._oom_bundle_paths
+        )
+
+    def _add_source(self, source: CatalogSource) -> None:
+        key = (source.path.resolve(), source.source_kind)
+        if key in self._source_keys:
+            return
+        self._source_keys.add(key)
+        self.sources.append(source)
+
+    def _add_oom_bundle(
+        self,
+        bundle_path: Path,
+        manifest_path: Path,
+        payload: Mapping[str, Any],
+    ) -> None:
+        resolved = bundle_path.resolve()
+        if resolved in self._oom_bundle_paths:
+            return
+        self._oom_bundle_paths.add(resolved)
+        metadata = _read_json_object(bundle_path / "metadata.json") or {}
+        self.oom_bundles.append(
+            CatalogOOMBundle(
+                bundle_path=bundle_path,
+                manifest_path=manifest_path,
+                created_at_utc=_string_or_none(payload.get("created_at_utc")),
+                backend=_string_or_none(payload.get("backend")),
+                reason=_string_or_none(payload.get("reason")),
+                event_count=_int_or_none(payload.get("event_count")),
+                session_id=_string_or_none(payload.get("session_id")),
+                session_status=_string_or_none(payload.get("session_status")),
+                exception_type=_string_or_none(metadata.get("exception_type")),
+                exception_module=_string_or_none(metadata.get("exception_module")),
+            )
+        )
+
+    def _warn(self, path: Path, message: str) -> None:
+        self.warnings.append(CatalogWarning(path=str(path), message=message))
+
+
+class QueryStore:
+    """Reusable local query surface over Stormlog artifacts."""
+
+    def __init__(self, catalog: ArtifactCatalog) -> None:
+        self.catalog = catalog
+        self._loaded_sessions_by_source: dict[
+            tuple[Path, SourceKind], list[LoadedTelemetrySession]
+        ] = {}
+
+    def list_sessions(self, filters: SessionFilter | None = None) -> list[SessionRow]:
+        """Return session rows from manifest metadata or loaded flat files."""
+        filters = filters or SessionFilter()
+        oom_counts = _count_oom_bundles_by_session(self.catalog.oom_bundles)
+        rows: list[SessionRow] = []
+        seen: set[tuple[str, str, str]] = set()
+
+        for source in self.catalog.sources:
+            for row in self._session_rows_for_source(source, oom_counts):
+                key = (row.session_id, row.source_path, row.source_kind)
+                if key in seen:
+                    continue
+                seen.add(key)
+                if _session_matches(row, filters):
+                    rows.append(row)
+
+        rows.sort(key=lambda row: (row.started_at_ns, row.session_id), reverse=True)
+        return rows
+
+    def query_events(self, filters: EventFilter | None = None) -> list[EventRow]:
+        """Return filtered canonical telemetry event rows."""
+        filters = filters or EventFilter()
+        rows: list[EventRow] = []
+
+        for source in self.catalog.sources:
+            if source.source_kind in {"diagnose_bundle", "oom_bundle"}:
+                continue
+            for loaded in self._load_sessions_for_source(source):
+                summary = loaded.summary
+                if filters.session_id is not None and (
+                    summary.session_id != filters.session_id
+                ):
+                    continue
+                if filters.status is not None and summary.status != filters.status:
+                    continue
+                for event in loaded.events:
+                    row = EventRow(
+                        event=event,
+                        source_path=_event_source_path(loaded, source),
+                        source_kind=source.source_kind,
+                        session_status=summary.status,
+                    )
+                    if _event_matches(row, filters):
+                        rows.append(row)
+                        if filters.limit is not None and len(rows) >= filters.limit:
+                            return rows
+
+        rows.sort(key=lambda row: (row.event.timestamp_ns, row.event.session_id))
+        if filters.limit is not None:
+            return rows[: filters.limit]
+        return rows
+
+    def list_oom_bundles(
+        self,
+        filters: OOMBundleFilter | None = None,
+    ) -> list[OOMBundleRow]:
+        """Return filtered OOM bundle rows."""
+        filters = filters or OOMBundleFilter()
+        session_status_by_id = {
+            row.session_id: row.status for row in self.list_sessions(SessionFilter())
+        }
+        rows = [
+            OOMBundleRow(
+                bundle_path=str(bundle.bundle_path),
+                created_at_utc=bundle.created_at_utc,
+                backend=bundle.backend,
+                reason=bundle.reason,
+                event_count=bundle.event_count,
+                session_id=bundle.session_id,
+                session_status=(
+                    bundle.session_status
+                    or (
+                        session_status_by_id.get(bundle.session_id)
+                        if bundle.session_id is not None
+                        else None
+                    )
+                ),
+                exception_type=bundle.exception_type,
+                exception_module=bundle.exception_module,
+            )
+            for bundle in self.catalog.oom_bundles
+        ]
+        rows = [row for row in rows if _oom_matches(row, filters)]
+        rows.sort(key=lambda row: (row.created_at_utc or "", row.bundle_path))
+        return rows
+
+    def summarize(
+        self,
+        metric: SummaryMetric,
+        *,
+        group_by: SummaryGroupBy | None = None,
+    ) -> list[SummaryRow]:
+        """Run one built-in summary query."""
+        if metric == "session_count_by_status":
+            return self._summarize_session_count_by_status()
+        if metric == "interrupted_sessions_with_oom_bundles":
+            return self._summarize_interrupted_sessions_with_oom_bundles()
+
+        resolved_group_by: SummaryGroupBy = group_by or "session"
+        events = self.query_events(EventFilter())
+        if metric in {
+            "peak_allocator_allocated_bytes",
+            "peak_allocator_reserved_bytes",
+            "peak_device_used_bytes",
+        }:
+            field_name = {
+                "peak_allocator_allocated_bytes": "allocator_allocated_bytes",
+                "peak_allocator_reserved_bytes": "allocator_reserved_bytes",
+                "peak_device_used_bytes": "device_used_bytes",
+            }[metric]
+            return _summarize_peak(events, metric, field_name, resolved_group_by)
+        if metric == "alert_count":
+            alert_events = [row for row in events if _is_alert_event(row.event)]
+            return _summarize_count(alert_events, metric, resolved_group_by)
+        if metric == "collector_degradation_transitions":
+            transition_events = [
+                row
+                for row in events
+                if row.event.event_type in _COLLECTOR_TRANSITION_TYPES
+            ]
+            return _summarize_count(transition_events, metric, resolved_group_by)
+        if metric == "hidden_memory_gap_growth":
+            return _summarize_hidden_memory_gap_growth(events, resolved_group_by)
+        raise ValueError(f"unsupported summary metric: {metric}")
+
+    def _session_rows_for_source(
+        self,
+        source: CatalogSource,
+        oom_counts: Mapping[str, int],
+    ) -> list[SessionRow]:
+        if source.source_kind == "sink":
+            manifest = read_telemetry_sink_manifest(source.path)
+            if manifest is not None and manifest.sessions:
+                return [
+                    _session_row_from_manifest(
+                        summary=summary,
+                        manifest=manifest,
+                        source=source,
+                        oom_count=oom_counts.get(summary.session_id, 0),
+                    )
+                    for summary in manifest.sessions
+                ]
+
+        if source.source_kind == "diagnose_bundle":
+            summary = _diagnose_session_summary(source.manifest_path)
+            if summary is None:
+                return []
+            return [
+                _session_row_from_summary(
+                    summary=summary,
+                    source=source,
+                    source_count=1,
+                    warning_count=0,
+                    event_count=None,
+                    oom_count=oom_counts.get(summary.session_id, 0),
+                )
+            ]
+
+        rows: list[SessionRow] = []
+        for loaded in self._load_sessions_for_source(source):
+            rows.append(
+                _session_row_from_summary(
+                    summary=loaded.summary,
+                    source=source,
+                    source_count=len(loaded.sources_loaded) or 1,
+                    warning_count=len(loaded.warnings),
+                    event_count=len(loaded.events),
+                    oom_count=oom_counts.get(loaded.summary.session_id, 0),
+                )
+            )
+        return rows
+
+    def _load_sessions_for_source(
+        self,
+        source: CatalogSource,
+    ) -> list[LoadedTelemetrySession]:
+        key = (source.path.resolve(), source.source_kind)
+        cached = self._loaded_sessions_by_source.get(key)
+        if cached is not None:
+            return cached
+
+        try:
+            if source.source_kind == "telemetry_csv":
+                loaded = _load_csv_sessions(source.path)
+            elif source.source_kind in {"sink", "telemetry_json", "telemetry_jsonl"}:
+                loaded = load_telemetry_sessions(source.path, permissive_legacy=True)
+            else:
+                loaded = []
+        except Exception as exc:
+            self.catalog.warnings.append(
+                CatalogWarning(path=str(source.path), message=f"load failed: {exc}")
+            )
+            loaded = []
+
+        self._loaded_sessions_by_source[key] = loaded
+        return loaded
+
+    def _summarize_session_count_by_status(self) -> list[SummaryRow]:
+        counts: dict[str, int] = defaultdict(int)
+        for row in self.list_sessions(SessionFilter()):
+            counts[row.status] += 1
+        return [
+            SummaryRow(
+                metric="session_count_by_status",
+                group_by="status",
+                status=status,
+                value=count,
+            )
+            for status, count in sorted(counts.items())
+        ]
+
+    def _summarize_interrupted_sessions_with_oom_bundles(self) -> list[SummaryRow]:
+        oom_counts = _count_oom_bundles_by_session(self.catalog.oom_bundles)
+        rows: list[SummaryRow] = []
+        for session in self.list_sessions(
+            SessionFilter(
+                status=SESSION_STATUS_INTERRUPTED,
+                has_oom_bundle=True,
+            )
+        ):
+            rows.append(
+                SummaryRow(
+                    metric="interrupted_sessions_with_oom_bundles",
+                    group_by="session",
+                    session_id=session.session_id,
+                    status=session.status,
+                    value=oom_counts.get(session.session_id, 0),
+                )
+            )
+        return rows
+
+
+def open(paths: Sequence[str | Path]) -> QueryStore:
+    """Open one or more local artifact paths for in-process querying."""
+    return QueryStore(ArtifactCatalog(paths))
+
+
+def _read_json_object(path: Path) -> dict[str, Any] | None:
+    if not path.exists() or not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    return dict(payload) if isinstance(payload, Mapping) else None
+
+
+def _is_sink_manifest(payload: Mapping[str, Any]) -> bool:
+    fmt = payload.get("format")
+    return fmt == "stormlog.append_only_telemetry_sink" or "segments" in payload
+
+
+def _is_oom_manifest(payload: Mapping[str, Any]) -> bool:
+    return (
+        "bundle_name" in payload
+        and "reason" in payload
+        and "backend" in payload
+        and "event_count" in payload
+    )
+
+
+def _is_diagnose_manifest(payload: Mapping[str, Any]) -> bool:
+    return (
+        "command_line" in payload
+        and "files" in payload
+        and "risk_detected" in payload
+        and "session_id" in payload
+    )
+
+
+def _diagnose_session_summary(manifest_path: Path | None) -> SessionSummary | None:
+    if manifest_path is None:
+        return None
+    payload = _read_json_object(manifest_path)
+    if payload is None:
+        return None
+    session_payload = payload.get("session")
+    if isinstance(session_payload, Mapping):
+        try:
+            return session_summary_from_dict(session_payload)
+        except Exception:
+            pass
+    session_id = _string_or_none(payload.get("session_id"))
+    if session_id is None:
+        return None
+    try:
+        return session_summary_from_dict(
+            {
+                "session_id": session_id,
+                "status": payload.get("session_status", "incomplete"),
+                "started_at_ns": 0,
+                "ended_at_ns": None,
+                "host": "unknown",
+                "pid": -1,
+                "job_id": None,
+                "rank": 0,
+                "local_rank": 0,
+                "world_size": 1,
+                "source": "stormlog.diagnose",
+            }
+        )
+    except Exception:
+        return None
+
+
+def _session_row_from_manifest(
+    *,
+    summary: SessionSummary,
+    manifest: TelemetrySinkManifest,
+    source: CatalogSource,
+    oom_count: int,
+) -> SessionRow:
+    session_segments = [
+        segment
+        for segment in manifest.segments
+        if segment.session_id == summary.session_id
+    ]
+    event_count = sum(segment.event_count for segment in session_segments)
+    return _session_row_from_summary(
+        summary=summary,
+        source=source,
+        source_count=len(session_segments),
+        warning_count=0,
+        event_count=event_count,
+        oom_count=oom_count,
+    )
+
+
+def _session_row_from_summary(
+    *,
+    summary: SessionSummary,
+    source: CatalogSource,
+    source_count: int,
+    warning_count: int,
+    event_count: int | None,
+    oom_count: int,
+) -> SessionRow:
+    payload = session_summary_to_dict(summary)
+    return SessionRow(
+        session_id=str(payload["session_id"]),
+        status=str(payload["status"]),
+        started_at_ns=int(payload["started_at_ns"]),
+        ended_at_ns=(
+            int(payload["ended_at_ns"])
+            if payload.get("ended_at_ns") is not None
+            else None
+        ),
+        host=str(payload["host"]),
+        pid=int(payload["pid"]),
+        job_id=_string_or_none(payload.get("job_id")),
+        rank=int(payload["rank"]),
+        local_rank=int(payload["local_rank"]),
+        world_size=int(payload["world_size"]),
+        source=str(payload["source"]),
+        source_path=str(source.path),
+        source_kind=source.source_kind,
+        source_count=source_count,
+        warning_count=warning_count,
+        event_count=event_count,
+        oom_bundle_count=oom_count,
+    )
+
+
+def _load_csv_sessions(path: Path) -> list[LoadedTelemetrySession]:
+    warnings: list[str] = []
+    events: list[TelemetryEvent] = []
+    default_session_id = stable_legacy_session_id(str(path.resolve()), "csv")
+
+    with builtins.open(path, "r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        for line_number, row in enumerate(reader, start=2):
+            try:
+                event = telemetry_event_from_record(
+                    _normalize_csv_record(row),
+                    permissive_legacy=True,
+                    default_collector="legacy.csv",
+                    default_sampling_interval_ms=0,
+                    default_session_id=default_session_id,
+                )
+                events.append(event)
+            except Exception as exc:
+                warnings.append(f"CSV parse error {path}:{line_number}: {exc}")
+
+    grouped: dict[str, list[TelemetryEvent]] = defaultdict(list)
+    for event in events:
+        grouped[event.session_id].append(event)
+
+    sessions: list[LoadedTelemetrySession] = []
+    for session_id, session_events in grouped.items():
+        session_events.sort(key=lambda event: event.timestamp_ns)
+        summary = infer_session_summary_from_events(
+            session_id=session_id,
+            events=session_events,
+            source=f"artifact:{path.name or path.resolve()}",
+        )
+        sessions.append(
+            LoadedTelemetrySession(
+                summary=summary,
+                events=session_events,
+                sources_loaded=[str(path.resolve())],
+                warnings=warnings,
+            )
+        )
+    return sessions
+
+
+def _normalize_csv_record(row: Mapping[str, str]) -> dict[str, Any]:
+    int_fields = {
+        "schema_version",
+        "timestamp_ns",
+        "sampling_interval_ms",
+        "pid",
+        "rank",
+        "local_rank",
+        "world_size",
+        "device_id",
+        "allocator_allocated_bytes",
+        "allocator_reserved_bytes",
+        "allocator_active_bytes",
+        "allocator_inactive_bytes",
+        "allocator_change_bytes",
+        "device_used_bytes",
+        "device_free_bytes",
+        "device_total_bytes",
+        "memory_allocated",
+        "memory_reserved",
+        "memory_change",
+        "total_memory",
+    }
+    float_fields = {"timestamp"}
+    normalized: dict[str, Any] = {}
+    for key, raw_value in row.items():
+        value: Any = raw_value.strip() if isinstance(raw_value, str) else raw_value
+        if value == "":
+            normalized[key] = None
+        elif key == "metadata" and isinstance(value, str):
+            try:
+                parsed = json.loads(value)
+            except json.JSONDecodeError:
+                parsed = {}
+            normalized[key] = parsed if isinstance(parsed, dict) else {}
+        elif key in int_fields:
+            normalized[key] = int(float(value))
+        elif key in float_fields:
+            normalized[key] = float(value)
+        else:
+            normalized[key] = value
+    return normalized
+
+
+def _count_oom_bundles_by_session(
+    bundles: Iterable[CatalogOOMBundle],
+) -> dict[str, int]:
+    counts: dict[str, int] = defaultdict(int)
+    for bundle in bundles:
+        if bundle.session_id is not None:
+            counts[bundle.session_id] += 1
+    return counts
+
+
+def _session_matches(row: SessionRow, filters: SessionFilter) -> bool:
+    if filters.session_id is not None and row.session_id != filters.session_id:
+        return False
+    if filters.status is not None and row.status != filters.status:
+        return False
+    if filters.job_id is not None and row.job_id != filters.job_id:
+        return False
+    if filters.rank is not None and row.rank != filters.rank:
+        return False
+    if filters.world_size is not None and row.world_size != filters.world_size:
+        return False
+    if filters.has_oom_bundle is not None and (
+        (row.oom_bundle_count > 0) != filters.has_oom_bundle
+    ):
+        return False
+    if filters.source_kind is not None and row.source_kind != filters.source_kind:
+        return False
+    return True
+
+
+def _event_matches(row: EventRow, filters: EventFilter) -> bool:
+    event = row.event
+    if filters.event_type is not None and event.event_type != filters.event_type:
+        return False
+    if filters.rank is not None and event.rank != filters.rank:
+        return False
+    if filters.collector is not None and event.collector != filters.collector:
+        return False
+    if filters.time_start_ns is not None and event.timestamp_ns < filters.time_start_ns:
+        return False
+    if filters.time_end_ns is not None and event.timestamp_ns > filters.time_end_ns:
+        return False
+    if filters.has_alert is not None and (_is_alert_event(event) != filters.has_alert):
+        return False
+    metadata = event.metadata
+    if filters.collector_health_status is not None and (
+        metadata.get("collector_health_status") != filters.collector_health_status
+    ):
+        return False
+    if filters.backend is not None and metadata.get("backend") != filters.backend:
+        return False
+    return True
+
+
+def _oom_matches(row: OOMBundleRow, filters: OOMBundleFilter) -> bool:
+    if filters.session_id is not None and row.session_id != filters.session_id:
+        return False
+    if filters.backend is not None and row.backend != filters.backend:
+        return False
+    if filters.reason is not None and row.reason != filters.reason:
+        return False
+    created = _parse_datetime(row.created_at_utc)
+    after = _parse_datetime(filters.created_after)
+    before = _parse_datetime(filters.created_before)
+    if after is not None and (created is None or created < after):
+        return False
+    if before is not None and (created is None or created > before):
+        return False
+    return True
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _is_alert_event(event: TelemetryEvent) -> bool:
+    if event.event_type in _ALERT_EVENT_TYPES:
+        return True
+    severity = event.metadata.get("severity")
+    return severity in {"warning", "critical", "error"}
+
+
+def _event_source_path(loaded: LoadedTelemetrySession, source: CatalogSource) -> str:
+    if loaded.sources_loaded:
+        return loaded.sources_loaded[0]
+    return str(source.path)
+
+
+def _summary_group_key(
+    row: EventRow,
+    group_by: SummaryGroupBy,
+) -> tuple[str | None, int | None, str | None]:
+    if group_by == "rank":
+        return None, row.event.rank, None
+    if group_by == "session-rank":
+        return row.event.session_id, row.event.rank, None
+    if group_by == "status":
+        return None, None, row.session_status
+    return row.event.session_id, None, None
+
+
+def _summarize_peak(
+    rows: Sequence[EventRow],
+    metric: str,
+    field_name: str,
+    group_by: SummaryGroupBy,
+) -> list[SummaryRow]:
+    best: dict[tuple[str | None, int | None, str | None], tuple[int, EventRow]] = {}
+    for row in rows:
+        value = int(getattr(row.event, field_name))
+        key = _summary_group_key(row, group_by)
+        existing = best.get(key)
+        if existing is None or value > existing[0]:
+            best[key] = (value, row)
+
+    output: list[SummaryRow] = []
+    for key, (value, event_row) in sorted(best.items(), key=lambda item: str(item[0])):
+        session_id, rank, status = key
+        output.append(
+            SummaryRow(
+                metric=metric,
+                group_by=group_by,
+                session_id=session_id,
+                rank=rank,
+                status=status,
+                value=value,
+                details={"timestamp_ns": event_row.event.timestamp_ns},
+            )
+        )
+    return output
+
+
+def _summarize_count(
+    rows: Sequence[EventRow],
+    metric: str,
+    group_by: SummaryGroupBy,
+) -> list[SummaryRow]:
+    counts: dict[tuple[str | None, int | None, str | None], int] = defaultdict(int)
+    for row in rows:
+        counts[_summary_group_key(row, group_by)] += 1
+    output: list[SummaryRow] = []
+    for session_id, rank, status in sorted(counts, key=str):
+        output.append(
+            SummaryRow(
+                metric=metric,
+                group_by=group_by,
+                session_id=session_id,
+                rank=rank,
+                status=status,
+                value=counts[(session_id, rank, status)],
+            )
+        )
+    return output
+
+
+def _summarize_hidden_memory_gap_growth(
+    rows: Sequence[EventRow],
+    group_by: SummaryGroupBy,
+) -> list[SummaryRow]:
+    grouped: dict[tuple[str | None, int | None, str | None], list[EventRow]] = (
+        defaultdict(list)
+    )
+    for row in rows:
+        if row.event.event_type != "sample":
+            continue
+        grouped[_summary_group_key(row, group_by)].append(row)
+
+    output: list[SummaryRow] = []
+    for key, group_rows in sorted(grouped.items(), key=lambda item: str(item[0])):
+        group_rows.sort(key=lambda row: row.event.timestamp_ns)
+        gaps = [
+            row.event.device_used_bytes - row.event.allocator_reserved_bytes
+            for row in group_rows
+        ]
+        if not gaps:
+            continue
+        session_id, rank, status = key
+        output.append(
+            SummaryRow(
+                metric="hidden_memory_gap_growth",
+                group_by=group_by,
+                session_id=session_id,
+                rank=rank,
+                status=status,
+                value=gaps[-1] - gaps[0],
+                details={
+                    "first_gap_bytes": gaps[0],
+                    "latest_gap_bytes": gaps[-1],
+                    "peak_gap_bytes": max(gaps),
+                    "sample_count": len(gaps),
+                },
+            )
+        )
+    return output
+
+
+def _string_or_none(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _int_or_none(value: object) -> int | None:
+    if value is None:
+        return None
+    if not isinstance(value, (int, float, str)) or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+__all__ = [
+    "ArtifactCatalog",
+    "CatalogOOMBundle",
+    "CatalogSource",
+    "CatalogWarning",
+    "EventFilter",
+    "EventRow",
+    "OOMBundleFilter",
+    "OOMBundleRow",
+    "QueryStore",
+    "SessionFilter",
+    "SessionRow",
+    "SummaryRow",
+    "open",
+]

--- a/stormlog/query_cli.py
+++ b/stormlog/query_cli.py
@@ -1,0 +1,334 @@
+"""Command-line interface for local Stormlog artifact queries."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from . import query as query_api
+
+
+@dataclass(frozen=True)
+class _OutputMode:
+    json: bool = False
+    csv: bool = False
+    table: bool = False
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the `stormlog query` CLI."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.command is None:
+        parser.print_help()
+        return 0
+
+    store = query_api.open(args.paths)
+    output_mode = _OutputMode(
+        json=bool(getattr(args, "json", False)),
+        csv=bool(getattr(args, "csv", False)),
+        table=bool(getattr(args, "table", False)),
+    )
+
+    try:
+        if args.command == "sessions":
+            rows = [
+                row.as_dict()
+                for row in store.list_sessions(
+                    query_api.SessionFilter(
+                        session_id=args.session_id,
+                        status=args.status,
+                        job_id=args.job_id,
+                        rank=args.rank,
+                        world_size=args.world_size,
+                        has_oom_bundle=args.has_oom_bundle,
+                        source_kind=args.source_kind,
+                    )
+                )
+            ]
+            _emit_rows(rows, output_mode, _SESSION_COLUMNS)
+        elif args.command == "events":
+            rows = [
+                row.as_dict()
+                for row in store.query_events(
+                    query_api.EventFilter(
+                        session_id=args.session_id,
+                        event_type=args.event_type,
+                        rank=args.rank,
+                        collector=args.collector,
+                        status=args.status,
+                        time_start_ns=args.time_start_ns,
+                        time_end_ns=args.time_end_ns,
+                        has_alert=args.has_alert,
+                        collector_health_status=args.collector_health_status,
+                        backend=args.backend,
+                        limit=args.limit,
+                    )
+                )
+            ]
+            _emit_rows(rows, output_mode, _EVENT_COLUMNS)
+        elif args.command == "ooms":
+            rows = [
+                row.as_dict()
+                for row in store.list_oom_bundles(
+                    query_api.OOMBundleFilter(
+                        session_id=args.session_id,
+                        backend=args.backend,
+                        reason=args.reason,
+                        created_after=args.created_after,
+                        created_before=args.created_before,
+                    )
+                )
+            ]
+            _emit_rows(rows, output_mode, _OOM_COLUMNS)
+        elif args.command == "summary":
+            if output_mode.csv:
+                print(
+                    "Error: --csv is not supported for summary queries", file=sys.stderr
+                )
+                return 2
+            rows = [
+                row.as_dict()
+                for row in store.summarize(args.metric, group_by=args.group_by)
+            ]
+            _emit_rows(rows, output_mode, _SUMMARY_COLUMNS)
+    except BrokenPipeError:
+        return 1
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="stormlog query",
+        description="Query local Stormlog telemetry sessions and artifact bundles.",
+    )
+    subparsers = parser.add_subparsers(dest="command", help="Query targets")
+
+    sessions = subparsers.add_parser("sessions", help="List artifact sessions")
+    _add_paths(sessions)
+    _add_output_flags(sessions, include_csv=True)
+    sessions.add_argument("--session-id")
+    sessions.add_argument("--status")
+    sessions.add_argument("--job-id")
+    sessions.add_argument("--rank", type=int)
+    sessions.add_argument("--world-size", type=int)
+    sessions.add_argument("--source-kind")
+    sessions.add_argument(
+        "--has-oom-bundle",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Filter sessions by linked OOM bundle presence.",
+    )
+
+    events = subparsers.add_parser("events", help="Query telemetry events")
+    _add_paths(events)
+    _add_output_flags(events, include_csv=True)
+    events.add_argument("--session-id", "--session", dest="session_id")
+    events.add_argument("--event-type")
+    events.add_argument("--rank", type=int)
+    events.add_argument("--collector")
+    events.add_argument("--status")
+    events.add_argument("--time-start-ns", type=int)
+    events.add_argument("--time-end-ns", type=int)
+    events.add_argument(
+        "--has-alert",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Filter warning, critical, error, or severity-marked events.",
+    )
+    events.add_argument("--collector-health-status")
+    events.add_argument("--backend")
+    events.add_argument("--limit", type=int)
+
+    ooms = subparsers.add_parser("ooms", help="List OOM dump bundles")
+    _add_paths(ooms)
+    _add_output_flags(ooms, include_csv=True)
+    ooms.add_argument("--session-id", "--session", dest="session_id")
+    ooms.add_argument("--backend")
+    ooms.add_argument("--reason")
+    ooms.add_argument("--created-after")
+    ooms.add_argument("--created-before")
+
+    summary = subparsers.add_parser("summary", help="Run built-in summaries")
+    _add_paths(summary)
+    _add_output_flags(summary, include_csv=True)
+    summary.add_argument(
+        "--metric",
+        required=True,
+        choices=[
+            "session_count_by_status",
+            "peak_allocator_allocated_bytes",
+            "peak_allocator_reserved_bytes",
+            "peak_device_used_bytes",
+            "alert_count",
+            "collector_degradation_transitions",
+            "interrupted_sessions_with_oom_bundles",
+            "hidden_memory_gap_growth",
+        ],
+    )
+    summary.add_argument(
+        "--group-by",
+        choices=["session", "session-rank", "rank", "status"],
+        default=None,
+    )
+    return parser
+
+
+def _add_paths(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("paths", nargs="+", help="Artifact paths to query")
+
+
+def _add_output_flags(
+    parser: argparse.ArgumentParser,
+    *,
+    include_csv: bool,
+) -> None:
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--json", action="store_true", help="Emit JSON rows")
+    group.add_argument("--table", action="store_true", help="Emit a readable table")
+    if include_csv:
+        group.add_argument("--csv", action="store_true", help="Emit CSV rows")
+
+
+def _emit_rows(
+    rows: Sequence[Mapping[str, Any]],
+    output_mode: _OutputMode,
+    preferred_columns: Sequence[str],
+) -> None:
+    columns = _columns_for_rows(rows, preferred_columns)
+    if output_mode.json:
+        print(json.dumps(rows, indent=2, sort_keys=True, default=str))
+    elif output_mode.csv:
+        _emit_csv(rows, columns)
+    else:
+        print(_format_table(rows, columns))
+
+
+def _columns_for_rows(
+    rows: Sequence[Mapping[str, Any]],
+    preferred_columns: Sequence[str],
+) -> list[str]:
+    discovered = {key for row in rows for key in row}
+    columns = [column for column in preferred_columns if column in discovered]
+    columns.extend(sorted(discovered - set(columns)))
+    return columns or list(preferred_columns)
+
+
+def _emit_csv(rows: Sequence[Mapping[str, Any]], columns: Sequence[str]) -> None:
+    writer = csv.DictWriter(sys.stdout, fieldnames=list(columns), extrasaction="ignore")
+    writer.writeheader()
+    for row in rows:
+        writer.writerow({key: _csv_value(row.get(key)) for key in columns})
+
+
+def _format_table(
+    rows: Sequence[Mapping[str, Any]],
+    columns: Sequence[str],
+) -> str:
+    if not rows:
+        return "No rows."
+    labels = [_label(column) for column in columns]
+    widths = [
+        max(len(label), *[len(_table_value(row.get(column))) for row in rows])
+        for label, column in zip(labels, columns)
+    ]
+    header = "  ".join(
+        label.ljust(width) for label, width in zip(labels, widths)
+    ).rstrip()
+    separator = "  ".join("-" * width for width in widths).rstrip()
+    body = [
+        "  ".join(
+            _table_value(row.get(column)).ljust(width)
+            for column, width in zip(columns, widths)
+        ).rstrip()
+        for row in rows
+    ]
+    return "\n".join([header, separator, *body])
+
+
+def _table_value(value: Any) -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, sort_keys=True, default=str)
+    return str(value)
+
+
+def _csv_value(value: Any) -> Any:
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, sort_keys=True, default=str)
+    return value
+
+
+def _label(column: str) -> str:
+    return column.replace("_", " ").title()
+
+
+_SESSION_COLUMNS = (
+    "session_id",
+    "status",
+    "started_at_ns",
+    "ended_at_ns",
+    "host",
+    "pid",
+    "job_id",
+    "rank",
+    "local_rank",
+    "world_size",
+    "source_kind",
+    "source_path",
+    "source_count",
+    "warning_count",
+    "event_count",
+    "oom_bundle_count",
+)
+_EVENT_COLUMNS = (
+    "session_id",
+    "timestamp_ns",
+    "event_type",
+    "rank",
+    "local_rank",
+    "world_size",
+    "collector",
+    "allocator_allocated_bytes",
+    "allocator_reserved_bytes",
+    "device_used_bytes",
+    "source_kind",
+    "source_path",
+    "session_status",
+)
+_OOM_COLUMNS = (
+    "bundle_path",
+    "created_at_utc",
+    "backend",
+    "reason",
+    "event_count",
+    "session_id",
+    "session_status",
+    "exception_type",
+    "exception_module",
+)
+_SUMMARY_COLUMNS = (
+    "metric",
+    "group_by",
+    "session_id",
+    "rank",
+    "status",
+    "value",
+    "timestamp_ns",
+    "first_gap_bytes",
+    "latest_gap_bytes",
+    "peak_gap_bytes",
+    "sample_count",
+)
+
+
+__all__ = ["main"]

--- a/stormlog/tui/__init__.py
+++ b/stormlog/tui/__init__.py
@@ -1,8 +1,23 @@
-"""Textual-based terminal UI for Stormlog."""
+"""Textual-based terminal UI and top-level Stormlog dispatcher."""
+
+from __future__ import annotations
+
+import sys
 
 
-def run_app() -> None:
-    """Launch the TUI app while keeping textual imports lazy."""
+def run_app(argv: list[str] | None = None) -> None:
+    """Launch the TUI app or dispatch top-level Stormlog subcommands."""
+    resolved_argv = list(sys.argv[1:] if argv is None else argv)
+    if resolved_argv and resolved_argv[0] == "query":
+        from stormlog.query_cli import main as query_main
+
+        raise SystemExit(query_main(resolved_argv[1:]))
+    if resolved_argv and resolved_argv[0] in {"-h", "--help"}:
+        print("usage: stormlog [query ...]\n")
+        print("Launches the Stormlog TUI with no arguments.")
+        print("Use `stormlog query --help` to query local artifact directories.")
+        return
+
     try:
         from .app import run_app as _run_app
     except ModuleNotFoundError as exc:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+import stormlog.query as query_api
+from stormlog.session import (
+    SESSION_STATUS_COMPLETED,
+    SESSION_STATUS_INCOMPLETE,
+    SESSION_STATUS_INTERRUPTED,
+    create_session_summary,
+    session_summary_to_dict,
+)
+from stormlog.telemetry_sink import AppendOnlyTelemetrySink, TelemetrySinkConfig
+
+
+def _event_record(
+    *,
+    session_id: str,
+    timestamp_ns: int,
+    event_type: str = "sample",
+    rank: int = 0,
+    allocated: int = 100,
+    reserved: int = 150,
+    used: int = 175,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": 3,
+        "session_id": session_id,
+        "timestamp_ns": timestamp_ns,
+        "event_type": event_type,
+        "collector": "stormlog.cuda_tracker",
+        "sampling_interval_ms": 100,
+        "pid": 123,
+        "host": "host-a",
+        "job_id": "job-a",
+        "rank": rank,
+        "local_rank": rank,
+        "world_size": 2,
+        "device_id": 0,
+        "allocator_allocated_bytes": allocated,
+        "allocator_reserved_bytes": reserved,
+        "allocator_active_bytes": None,
+        "allocator_inactive_bytes": None,
+        "allocator_change_bytes": reserved - allocated,
+        "device_used_bytes": used,
+        "device_free_bytes": None,
+        "device_total_bytes": 1000,
+        "context": event_type,
+        "metadata": metadata or {"backend": "cuda"},
+    }
+
+
+def _write_json_events(path: Path, records: list[dict[str, Any]]) -> None:
+    path.write_text(json.dumps(records), encoding="utf-8")
+
+
+def _write_oom_bundle(
+    root: Path,
+    *,
+    session_id: str,
+    session_status: str = SESSION_STATUS_INTERRUPTED,
+) -> Path:
+    bundle = root / "oom_dump_20260512T000000Z_123_cuda_1"
+    bundle.mkdir(parents=True)
+    manifest = {
+        "schema_version": 2,
+        "bundle_name": bundle.name,
+        "created_at_utc": "2026-05-12T00:00:00Z",
+        "reason": "message_pattern:out of memory",
+        "backend": "cuda",
+        "event_count": 2,
+        "session_id": session_id,
+        "session_status": session_status,
+        "files": ["manifest.json", "metadata.json"],
+    }
+    metadata = {
+        "exception_type": "RuntimeError",
+        "exception_module": "builtins",
+    }
+    (bundle / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    (bundle / "metadata.json").write_text(json.dumps(metadata), encoding="utf-8")
+    return bundle
+
+
+def test_list_sessions_uses_sink_manifest_without_loading_events(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    sink = AppendOnlyTelemetrySink(
+        TelemetrySinkConfig(
+            root_dir=tmp_path,
+            flush_every_events=1,
+            flush_every_seconds=1.0,
+        )
+    )
+    sink.append(_event_record(session_id="session-a", timestamp_ns=1))
+    sink.close()
+
+    def _fail_load(*args: Any, **kwargs: Any) -> list[Any]:
+        raise AssertionError("list_sessions should not materialize sink events")
+
+    monkeypatch.setattr(query_api, "load_telemetry_sessions", _fail_load)
+
+    store = query_api.open([tmp_path])
+    rows = store.list_sessions()
+
+    assert len(rows) == 1
+    assert rows[0].session_id == "session-a"
+    assert rows[0].status == SESSION_STATUS_COMPLETED
+    assert rows[0].source_kind == "sink"
+    assert rows[0].event_count == 1
+
+
+def test_query_events_filters_and_adds_provenance(tmp_path: Path) -> None:
+    path = tmp_path / "track.json"
+    _write_json_events(
+        path,
+        [
+            _event_record(session_id="session-a", timestamp_ns=1, rank=0),
+            _event_record(
+                session_id="session-a",
+                timestamp_ns=2,
+                event_type="collector_degraded",
+                rank=1,
+                metadata={
+                    "backend": "cuda",
+                    "collector_health_status": "degraded",
+                },
+            ),
+        ],
+    )
+
+    rows = query_api.open([path]).query_events(
+        query_api.EventFilter(
+            rank=1,
+            event_type="collector_degraded",
+            collector_health_status="degraded",
+            backend="cuda",
+        )
+    )
+
+    assert len(rows) == 1
+    payload = rows[0].as_dict()
+    assert payload["session_id"] == "session-a"
+    assert payload["rank"] == 1
+    assert payload["source_kind"] == "telemetry_json"
+    assert payload["source_path"].endswith("track.json")
+    assert payload["session_status"] == SESSION_STATUS_INCOMPLETE
+
+
+def test_list_oom_bundles_links_to_sessions(tmp_path: Path) -> None:
+    session = create_session_summary(
+        source="stormlog.test",
+        status=SESSION_STATUS_INTERRUPTED,
+        session_id="session-oom",
+        started_at_ns=10,
+        host="host-a",
+        pid=123,
+    )
+    diagnose = tmp_path / "diag"
+    diagnose.mkdir()
+    (diagnose / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "created_iso": "2026-05-12T00:00:00Z",
+                "command_line": "gpumemprof diagnose",
+                "files": ["manifest.json"],
+                "exit_code": 2,
+                "risk_detected": True,
+                "session_id": "session-oom",
+                "session_status": SESSION_STATUS_INTERRUPTED,
+                "session": session_summary_to_dict(session),
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_oom_bundle(tmp_path, session_id="session-oom")
+
+    store = query_api.open([tmp_path])
+    session_rows = store.list_sessions(query_api.SessionFilter(has_oom_bundle=True))
+    oom_rows = store.list_oom_bundles(query_api.OOMBundleFilter(backend="cuda"))
+
+    assert [row.session_id for row in session_rows] == ["session-oom"]
+    assert session_rows[0].oom_bundle_count == 1
+    assert len(oom_rows) == 1
+    assert oom_rows[0].session_id == "session-oom"
+    assert oom_rows[0].session_status == SESSION_STATUS_INTERRUPTED
+    assert oom_rows[0].exception_type == "RuntimeError"
+
+
+def test_query_summaries_cover_sessions_peaks_alerts_and_gap_growth(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "events.json"
+    _write_json_events(
+        path,
+        [
+            _event_record(
+                session_id="session-a",
+                timestamp_ns=1,
+                rank=0,
+                allocated=100,
+                reserved=150,
+                used=200,
+            ),
+            _event_record(
+                session_id="session-a",
+                timestamp_ns=2,
+                rank=0,
+                allocated=180,
+                reserved=220,
+                used=330,
+            ),
+            _event_record(
+                session_id="session-a",
+                timestamp_ns=3,
+                event_type="warning",
+                rank=0,
+            ),
+            _event_record(
+                session_id="session-a",
+                timestamp_ns=4,
+                event_type="collector_degraded",
+                rank=1,
+            ),
+        ],
+    )
+    store = query_api.open([path])
+
+    status_rows = store.summarize("session_count_by_status")
+    peak_rows = store.summarize(
+        "peak_allocator_reserved_bytes",
+        group_by="session",
+    )
+    alert_rows = store.summarize("alert_count", group_by="session-rank")
+    collector_rows = store.summarize(
+        "collector_degradation_transitions",
+        group_by="rank",
+    )
+    gap_rows = store.summarize("hidden_memory_gap_growth", group_by="session")
+
+    assert status_rows[0].status == "incomplete"
+    assert status_rows[0].value == 1
+    assert peak_rows[0].value == 220
+    assert alert_rows[0].value == 1
+    assert collector_rows[0].rank == 1
+    assert collector_rows[0].value == 1
+    assert gap_rows[0].value == 60
+    assert gap_rows[0].details["peak_gap_bytes"] == 110
+
+
+def test_catalog_discovers_csv_telemetry(tmp_path: Path) -> None:
+    path = tmp_path / "track.csv"
+    record = _event_record(session_id="session-csv", timestamp_ns=1)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(record))
+        writer.writeheader()
+        writer.writerow(
+            {
+                key: json.dumps(value) if key == "metadata" else value
+                for key, value in record.items()
+            }
+        )
+
+    rows = query_api.open([tmp_path]).list_sessions(
+        query_api.SessionFilter(source_kind="telemetry_csv")
+    )
+
+    assert len(rows) == 1
+    assert rows[0].session_id == "session-csv"
+    assert rows[0].source_kind == "telemetry_csv"

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -62,7 +62,7 @@ def _write_oom_bundle(
     root: Path,
     *,
     session_id: str,
-    session_status: str = SESSION_STATUS_INTERRUPTED,
+    session_status: str | None = SESSION_STATUS_INTERRUPTED,
 ) -> Path:
     bundle = root / "oom_dump_20260512T000000Z_123_cuda_1"
     bundle.mkdir(parents=True)
@@ -74,9 +74,10 @@ def _write_oom_bundle(
         "backend": "cuda",
         "event_count": 2,
         "session_id": session_id,
-        "session_status": session_status,
         "files": ["manifest.json", "metadata.json"],
     }
+    if session_status is not None:
+        manifest["session_status"] = session_status
     metadata = {
         "exception_type": "RuntimeError",
         "exception_module": "builtins",
@@ -152,6 +153,27 @@ def test_query_events_filters_and_adds_provenance(tmp_path: Path) -> None:
     assert payload["session_status"] == SESSION_STATUS_INCOMPLETE
 
 
+def test_query_events_limit_applies_after_global_sort(tmp_path: Path) -> None:
+    late_path = tmp_path / "late_track.json"
+    early_path = tmp_path / "early_track.json"
+    _write_json_events(
+        late_path,
+        [_event_record(session_id="session-late", timestamp_ns=200)],
+    )
+    _write_json_events(
+        early_path,
+        [_event_record(session_id="session-early", timestamp_ns=100)],
+    )
+
+    rows = query_api.open([late_path, early_path]).query_events(
+        query_api.EventFilter(limit=1)
+    )
+
+    assert len(rows) == 1
+    assert rows[0].event.session_id == "session-early"
+    assert rows[0].event.timestamp_ns == 100
+
+
 def test_list_oom_bundles_links_to_sessions(tmp_path: Path) -> None:
     session = create_session_summary(
         source="stormlog.test",
@@ -191,6 +213,58 @@ def test_list_oom_bundles_links_to_sessions(tmp_path: Path) -> None:
     assert oom_rows[0].session_id == "session-oom"
     assert oom_rows[0].session_status == SESSION_STATUS_INTERRUPTED
     assert oom_rows[0].exception_type == "RuntimeError"
+
+
+def test_list_oom_bundles_uses_only_manifest_backed_session_status(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    session = create_session_summary(
+        source="stormlog.test",
+        status=SESSION_STATUS_COMPLETED,
+        session_id="session-manifest-only",
+        started_at_ns=10,
+        host="host-a",
+        pid=123,
+    )
+    diagnose = tmp_path / "diag"
+    diagnose.mkdir()
+    (diagnose / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "created_iso": "2026-05-12T00:00:00Z",
+                "command_line": "gpumemprof diagnose",
+                "files": ["manifest.json"],
+                "exit_code": 0,
+                "risk_detected": False,
+                "session_id": "session-manifest-only",
+                "session_status": SESSION_STATUS_COMPLETED,
+                "session": session_summary_to_dict(session),
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_oom_bundle(
+        tmp_path,
+        session_id="session-manifest-only",
+        session_status=None,
+    )
+    _write_json_events(
+        tmp_path / "track.json",
+        [_event_record(session_id="flat-session", timestamp_ns=1)],
+    )
+
+    def _fail_load(*args: Any, **kwargs: Any) -> list[Any]:
+        raise AssertionError("OOM listing should not materialize flat telemetry")
+
+    monkeypatch.setattr(query_api, "load_telemetry_sessions", _fail_load)
+
+    rows = query_api.open([tmp_path]).list_oom_bundles()
+
+    assert len(rows) == 1
+    assert rows[0].session_id == "session-manifest-only"
+    assert rows[0].session_status == SESSION_STATUS_COMPLETED
 
 
 def test_query_summaries_cover_sessions_peaks_alerts_and_gap_growth(

--- a/tests/test_query_cli.py
+++ b/tests/test_query_cli.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from stormlog.query_cli import main as query_main
+from stormlog.tui import run_app
+
+
+def _event_record(
+    *,
+    session_id: str = "session-cli",
+    timestamp_ns: int = 1,
+    event_type: str = "sample",
+    rank: int = 0,
+) -> dict[str, Any]:
+    return {
+        "schema_version": 3,
+        "session_id": session_id,
+        "timestamp_ns": timestamp_ns,
+        "event_type": event_type,
+        "collector": "stormlog.cuda_tracker",
+        "sampling_interval_ms": 100,
+        "pid": 123,
+        "host": "host-a",
+        "job_id": "job-a",
+        "rank": rank,
+        "local_rank": rank,
+        "world_size": 2,
+        "device_id": 0,
+        "allocator_allocated_bytes": 100,
+        "allocator_reserved_bytes": 150,
+        "allocator_active_bytes": None,
+        "allocator_inactive_bytes": None,
+        "allocator_change_bytes": 50,
+        "device_used_bytes": 200,
+        "device_free_bytes": None,
+        "device_total_bytes": 1000,
+        "context": event_type,
+        "metadata": {"backend": "cuda"},
+    }
+
+
+def _write_json_events(path: Path, records: list[dict[str, Any]]) -> None:
+    path.write_text(json.dumps(records), encoding="utf-8")
+
+
+def test_query_sessions_json_output(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = tmp_path / "track.json"
+    _write_json_events(path, [_event_record()])
+
+    assert query_main(["sessions", str(path), "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0]["session_id"] == "session-cli"
+    assert payload[0]["source_kind"] == "telemetry_json"
+
+
+def test_query_events_table_and_limit(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = tmp_path / "track.json"
+    _write_json_events(
+        path,
+        [
+            _event_record(timestamp_ns=1, rank=0),
+            _event_record(timestamp_ns=2, rank=1),
+        ],
+    )
+
+    assert query_main(["events", str(path), "--rank", "1", "--limit", "1"]) == 0
+
+    output = capsys.readouterr().out
+    assert "Session Id" in output
+    assert "session-cli" in output
+    assert "  1  " in output or output.rstrip().endswith("  1")
+
+
+def test_query_ooms_csv_output(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bundle = tmp_path / "oom_dump_20260512T000000Z_123_cuda_1"
+    bundle.mkdir()
+    (bundle / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "bundle_name": bundle.name,
+                "created_at_utc": "2026-05-12T00:00:00Z",
+                "reason": "message_pattern:out of memory",
+                "backend": "cuda",
+                "event_count": 1,
+                "session_id": "session-cli",
+                "session_status": "interrupted",
+                "files": ["manifest.json"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert query_main(["ooms", str(tmp_path), "--csv"]) == 0
+
+    output = capsys.readouterr().out
+    assert "bundle_path,created_at_utc,backend" in output
+    assert "session-cli" in output
+
+
+def test_query_summary_rejects_csv(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = tmp_path / "track.json"
+    _write_json_events(path, [_event_record()])
+
+    assert (
+        query_main(
+            [
+                "summary",
+                str(path),
+                "--metric",
+                "session_count_by_status",
+                "--csv",
+            ]
+        )
+        == 2
+    )
+
+    assert "--csv is not supported" in capsys.readouterr().err
+
+
+def test_stormlog_dispatcher_preserves_no_arg_tui(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    fake_app = types.ModuleType("stormlog.tui.app")
+
+    def _fake_run_app() -> None:
+        calls.append("tui")
+
+    fake_app.run_app = _fake_run_app  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "stormlog.tui.app", fake_app)
+
+    run_app([])
+
+    assert calls == ["tui"]
+
+
+def test_stormlog_dispatcher_routes_query(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = tmp_path / "track.json"
+    _write_json_events(path, [_event_record()])
+
+    with pytest.raises(SystemExit) as excinfo:
+        run_app(["query", "sessions", str(path), "--json"])
+
+    assert excinfo.value.code == 0
+    assert json.loads(capsys.readouterr().out)[0]["session_id"] == "session-cli"


### PR DESCRIPTION
## Summary

Implements GitHub issue #107: a local, file-backed query surface for Stormlog telemetry sessions and artifact bundles.

This adds a pure Python v1 query layer that can discover Stormlog artifacts, list sessions, query canonical telemetry events, list OOM bundles, link OOM bundles back to sessions, and run built-in summaries without requiring DuckDB, a database server, or any external service.

## What Changed

- Added `stormlog.query` public API:
  - `stormlog.query.open(paths)`
  - `QueryStore.list_sessions(...)`
  - `QueryStore.query_events(...)`
  - `QueryStore.list_oom_bundles(...)`
  - `QueryStore.summarize(...)`

- Added manifest-first artifact discovery:
  - append-only telemetry sink directories and JSONL segments
  - flat JSON, JSONL, and CSV telemetry files
  - diagnose bundles
  - OOM dump bundles
  - non-fatal catalog warnings

- Added explicit query row/filter models:
  - session rows with lifecycle, rank, source, warning, event, and OOM-linkage fields
  - event rows using canonical telemetry fields plus provenance
  - OOM bundle rows with manifest and exception metadata
  - summary rows for reusable built-in metrics

- Added lazy loading behavior:
  - sink session listing uses manifests without eagerly parsing JSONL events
  - raw event loading happens only for event queries and summaries that require events
  - loaded sessions are cached in-process per source

- Added built-in summaries:
  - session count by status
  - peak allocator allocated bytes
  - peak allocator reserved bytes
  - peak device used bytes
  - alert count
  - collector degradation transitions
  - interrupted sessions with linked OOM bundles
  - hidden-memory gap growth by rank/session

- Added `stormlog query` CLI:
  - `stormlog query sessions <paths...>`
  - `stormlog query events <paths...>`
  - `stormlog query ooms <paths...>`
  - `stormlog query summary <paths...>`

- Preserved existing TUI behavior:
  - `stormlog` with no args still launches the TUI
  - `stormlog query ...` dispatches to the new query CLI without importing Textual

- Added output formats:
  - `--table`
  - `--json`
  - `--csv` for row queries

- Added filters for:
  - sessions: session id, status, job id, rank, world size, OOM linkage, source kind
  - events: session id, event type, rank, collector, status, time range, alerts, collector health, backend, limit
  - OOM bundles: session id, backend, reason, created-after, created-before

- Added docs:
  - CLI examples for `stormlog query`
  - design note for the local query layer
  - DuckDB evaluation notes explaining why DuckDB remains an optional future backend

## Design Notes

The first implementation intentionally uses a pure Python in-process query engine. The goal is to stabilize Stormlog’s artifact catalog, row model, CLI contract, and session/OOM linkage before introducing an optional DuckDB backend.

DuckDB remains a good future acceleration path for large JSONL datasets, but this PR avoids adding it as a runtime dependency.

## Tests Added

- Catalog discovery tests for:
  - sink directories
  - flat JSON telemetry
  - CSV telemetry
  - diagnose bundles
  - OOM bundles
  - mixed artifact directories

- Query API tests for:
  - manifest-first session listing
  - event filtering
  - event provenance fields
  - OOM bundle/session linkage
  - built-in summaries

- CLI tests for:
  - JSON output
  - table output
  - CSV output
  - event filtering and limits
  - summary CSV rejection
  - `stormlog` no-arg TUI compatibility
  - `stormlog query ...` dispatcher routing

## Validation

- `pytest tests/test_query*.py tests/test_telemetry_sink.py tests/test_cli_analyze.py`
  - 32 passed

- `pytest tests/ -m "not tui_pilot and not tui_snapshot and not tui_pty"`
  - 555 passed
  - 18 skipped
  - 19 deselected

- `isort --check --diff stormlog/ tests/ examples/`
  - passed

- `black --check stormlog/ tests/ examples/`
  - passed

- `flake8 stormlog/ tests/ examples/ --show-source --statistics`
  - passed

- `mypy stormlog/`
  - passed

- `pre-commit run --all-files`
  - passed

## Commits

- `4132193` Add local artifact query API
- `51863ec` Add stormlog query CLI
- `f559a79` Document local query layer
