### PR TITLE
feature/investigate recurring issue grouping for ooms

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -263,6 +263,13 @@ stormlog query ooms ./artifacts --backend cuda --table
 stormlog query ooms ./artifacts --created-after 2026-05-12T00:00:00Z --json
 ```
 
+List grouped recurring issues:
+
+```bash
+stormlog query issues ./live_sink ./oom_dumps --kind oom --json
+stormlog query issues ./artifacts --severity warning --session-id session-123
+```
+
 Run built-in summaries:
 
 ```bash
@@ -290,10 +297,13 @@ store = stormlog.query.open(["./live_sink", "./oom_dumps"])
 sessions = store.list_sessions()
 events = store.query_events()
 ooms = store.list_oom_bundles()
+issues = store.list_issues()
 ```
 
 For engine-choice details and follow-on work, see
 [Local Query Layer](query_layer.md).
+For issue grouping rules and schema details, see
+[Durable Issue Fingerprinting](issue_fingerprinting.md).
 
 ## `tfmemprof`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,6 +47,7 @@ benchmark_harness
 telemetry_schema
 telemetry_projection
 query_layer
+issue_fingerprinting
 pytorch_testing_guide
 tensorflow_testing_guide
 article

--- a/docs/issue_fingerprinting.md
+++ b/docs/issue_fingerprinting.md
@@ -61,13 +61,12 @@ OOM fingerprints use:
 
 - `backend`
 - `reason`
-- `exception_module`
-- `exception_type`
-- `collector`
-- `device_id`
 
-OOM details keep volatile evidence such as bundle path, event count, session
-status, context, and exact timestamps.
+OOM details and evidence keep volatile or inconsistently available fields such
+as exception module/type, collector, device id, rank, bundle path, event count,
+session status, context, and exact timestamps. This lets the same OOM group
+together whether it is discovered from an OOM bundle manifest or from telemetry
+events.
 
 Collector degradation fingerprints use:
 
@@ -112,11 +111,7 @@ OOM bundle:
   "kind": "oom",
   "dimensions": {
     "backend": "cuda",
-    "reason": "message_pattern:out of memory",
-    "exception_module": "builtins",
-    "exception_type": "runtimeerror",
-    "collector": "unknown",
-    "device_id": "unknown"
+    "reason": "message_pattern:out of memory"
   }
 }
 ```

--- a/docs/issue_fingerprinting.md
+++ b/docs/issue_fingerprinting.md
@@ -1,0 +1,198 @@
+[← Back to docs](index.md)
+
+# Durable Issue Fingerprinting
+
+Stormlog issue fingerprinting is a deterministic summarization layer over
+existing artifacts. It groups repeated failures across sessions without mutating
+`TelemetryEvent v3`, append-only sink segments, diagnose bundles, or OOM flight
+recorder bundles.
+
+The v1 implementation follows two outside patterns:
+
+- [Sentry SDK Fingerprinting](https://docs.sentry.io/platforms/dotnet/guides/apple/usage/sdk-fingerprinting/)
+  treats fingerprints as explicit grouping dimensions.
+- [OpenTelemetry Trace Concepts](https://opentelemetry.io/docs/concepts/signals/traces/)
+  keeps evidence linkable through context, events, attributes, and links.
+
+## Issue Object
+
+`stormlog.issues.StormlogIssue` is the grouped issue row returned by
+`stormlog.query.QueryStore.list_issues()`.
+
+Canonical fields:
+
+- `fingerprint_id`: deterministic hash of schema version, issue kind, and
+  normalized fingerprint dimensions
+- `fingerprint`: `kind`, `schema_version`, `fingerprint_id`, and `dimensions`
+- `kind`: `oom`, `collector_degradation`, `alert`, or `hidden_memory_anomaly`
+- `state`: `open`, `resolved`, `ignored`, or `regressed`
+- `severity`: `info`, `warning`, or `critical`
+- `title`
+- `hit_count`
+- `first_seen_ns`, `last_seen_ns`
+- `affected_sessions`
+- `representative_evidence`
+- `evidence`
+- `details`
+
+`representative_evidence` and each entry in `evidence` can link back to:
+
+- `session_id`
+- `timestamp_ns`
+- `rank`
+- `source_path`
+- `source_kind`
+- `event_type`
+- `bundle_path`
+- low-cardinality `metadata`
+
+Current query output defaults derived issues to `open`. State overrides are
+accepted by fingerprint id in the Python API so a future persisted sidecar can
+restore `resolved`, `ignored`, or `regressed` state without changing raw
+telemetry.
+
+## Fingerprint Rules
+
+Fingerprints contain stable grouping dimensions. They intentionally exclude
+session ids, timestamps, raw file paths, full exception messages, and metric
+magnitudes unless the value is converted into a stable category.
+
+OOM fingerprints use:
+
+- `backend`
+- `reason`
+- `exception_module`
+- `exception_type`
+- `collector`
+- `device_id`
+
+OOM details keep volatile evidence such as bundle path, event count, session
+status, context, and exact timestamps.
+
+Collector degradation fingerprints use:
+
+- `collector`
+- `backend`
+- `health_status`
+- sorted `partial_fields`
+- normalized `error_stem`
+
+Collector details keep retry timestamps, consecutive failure counts, and source
+event metadata.
+
+Alert fingerprints use:
+
+- `event_type`
+- `severity`
+- `collector`
+- `backend`
+- normalized alert `category`
+
+High-fragmentation alerts use the stable category `high_fragmentation`, so
+`High fragmentation: 40.0%` and `High fragmentation: 51.5%` group together.
+
+Hidden-memory anomaly fingerprints use:
+
+- `classification`: `transient_spike`, `persistent_drift`, or
+  `fragmentation_like`
+- `severity`
+- stable phase summary when available
+- `collector`
+- `backend`
+
+Hidden-memory details keep confidence, z-score, slope, gap bytes,
+fragmentation ratios, sample counts, and phase-attribution payloads.
+
+## Worked Examples
+
+OOM bundle:
+
+```json
+{
+  "kind": "oom",
+  "dimensions": {
+    "backend": "cuda",
+    "reason": "message_pattern:out of memory",
+    "exception_module": "builtins",
+    "exception_type": "runtimeerror",
+    "collector": "unknown",
+    "device_id": "unknown"
+  }
+}
+```
+
+Collector degradation:
+
+```json
+{
+  "kind": "collector_degradation",
+  "dimensions": {
+    "backend": "cuda",
+    "collector": "stormlog.cuda_tracker",
+    "error_stem": "runtimeerror",
+    "health_status": "degraded",
+    "partial_fields": ["device_free_bytes"]
+  }
+}
+```
+
+High-fragmentation alert:
+
+```json
+{
+  "kind": "alert",
+  "dimensions": {
+    "backend": "cuda",
+    "category": "high_fragmentation",
+    "collector": "stormlog.cuda_tracker",
+    "event_type": "warning",
+    "severity": "warning"
+  }
+}
+```
+
+Hidden-memory drift:
+
+```json
+{
+  "kind": "hidden_memory_anomaly",
+  "dimensions": {
+    "backend": "cuda",
+    "classification": "persistent_drift",
+    "collector": "stormlog.cuda_tracker",
+    "phase": "train / forward",
+    "severity": "critical"
+  }
+}
+```
+
+## Where Issues Live
+
+In v1, grouped issues are derived at query time:
+
+```bash
+stormlog query issues ./live_sink ./oom_dumps --json
+```
+
+Python callers can use:
+
+```python
+import stormlog.query
+
+store = stormlog.query.open(["./live_sink", "./oom_dumps"])
+issues = store.list_issues()
+```
+
+A future persistence pass should write a derived artifact-level `issues.json`
+sidecar next to the artifact set. That sidecar should contain grouped issue
+state and cached summaries only. It should not rewrite telemetry events, sink
+segments, diagnose manifests, or OOM bundle manifests.
+
+## Follow-On Tasks
+
+- Persist and reload `issues.json` state overrides by `fingerprint_id`.
+- Add TUI issue tables and issue-detail panes backed by `list_issues()`.
+- Add issue-oriented report schema fields for agent automation.
+- Add regression detection by comparing current issue fingerprints with a
+  previous persisted sidecar.
+- Add controls for ignoring known noisy fingerprints from CLI/TUI surfaces.

--- a/docs/query_layer.md
+++ b/docs/query_layer.md
@@ -55,10 +55,19 @@ The row contracts are explicit and automation-friendly:
   `source_kind`, and `session_status`
 - `OOMBundleRow`: bundle path, creation time, backend, reason, event count,
   session linkage, and exception type/module
+- `StormlogIssue`: grouped issue fingerprint, state, hit count, first/last
+  seen timestamps, affected sessions, representative evidence, and evidence
+  links back to raw sessions/events/bundles
 - `SummaryRow`: built-in metric results with session/rank/status grouping
 
 The canonical telemetry schema remains the event contract. Query rows add
 provenance but do not mutate persisted telemetry records.
+
+Issue grouping is also derived. `QueryStore.list_issues()` groups OOMs,
+collector degradation, alerts, and hidden-memory anomalies using deterministic
+fingerprints. The current implementation computes these rows during query/load;
+a future sidecar can persist issue state by fingerprint id without changing raw
+telemetry artifacts. See [Durable Issue Fingerprinting](issue_fingerprinting.md).
 
 ## Caching and Loading
 
@@ -103,3 +112,5 @@ adapter or richer aggregation API later.
   costs and defining invalidation behavior.
 - Add automation-specific schemas on top of query rows rather than changing the
   artifact contract.
+- Persist grouped issue state in an artifact-level `issues.json` sidecar after
+  the fingerprint schema has been exercised by CLI/TUI users.

--- a/stormlog/issues.py
+++ b/stormlog/issues.py
@@ -7,6 +7,7 @@ import json
 import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
+from types import MappingProxyType
 from typing import Any, Literal
 
 IssueKind = Literal[
@@ -50,7 +51,7 @@ class IssueFingerprint:
         object.__setattr__(
             self,
             "dimensions",
-            normalize_dimensions(self.dimensions),
+            freeze_dimensions(normalize_dimensions(self.dimensions)),
         )
 
     @property
@@ -60,7 +61,7 @@ class IssueFingerprint:
         payload = {
             "schema_version": self.schema_version,
             "kind": self.kind,
-            "dimensions": dict(self.dimensions),
+            "dimensions": json_safe_dimensions(self.dimensions),
         }
         encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"))
         return f"issue:{hashlib.sha256(encoded.encode('utf-8')).hexdigest()[:24]}"
@@ -72,7 +73,7 @@ class IssueFingerprint:
             "schema_version": self.schema_version,
             "fingerprint_id": self.fingerprint_id,
             "kind": self.kind,
-            "dimensions": dict(self.dimensions),
+            "dimensions": json_safe_dimensions(self.dimensions),
         }
 
 
@@ -187,6 +188,25 @@ def normalize_dimensions(dimensions: Mapping[str, Any]) -> dict[str, Any]:
     return dict(sorted(normalized.items()))
 
 
+def freeze_dimensions(dimensions: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return a recursively immutable canonical dimension mapping."""
+
+    frozen = {
+        key: _freeze_dimension_value(value)
+        for key, value in sorted(dimensions.items(), key=lambda item: item[0])
+    }
+    return MappingProxyType(frozen)
+
+
+def json_safe_dimensions(dimensions: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a mutable JSON-safe copy of canonical dimension material."""
+
+    return {
+        key: _json_safe_dimension_value(value)
+        for key, value in sorted(dimensions.items(), key=lambda item: item[0])
+    }
+
+
 def normalize_text_dimension(value: object, *, default: str = "unknown") -> str:
     """Return a low-cardinality text token for fingerprint dimensions."""
 
@@ -246,6 +266,22 @@ def _normalize_dimension_value(value: Any) -> Any:
     return normalize_text_dimension(value)
 
 
+def _freeze_dimension_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return freeze_dimensions(value)
+    if isinstance(value, list):
+        return tuple(_freeze_dimension_value(item) for item in value)
+    return value
+
+
+def _json_safe_dimension_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return json_safe_dimensions(value)
+    if isinstance(value, tuple):
+        return [_json_safe_dimension_value(item) for item in value]
+    return value
+
+
 __all__ = [
     "ISSUE_FINGERPRINT_SCHEMA_VERSION",
     "ISSUE_STATE_OPEN",
@@ -255,6 +291,8 @@ __all__ = [
     "IssueState",
     "StormlogIssue",
     "categorize_alert_context",
+    "freeze_dimensions",
+    "json_safe_dimensions",
     "normalize_dimensions",
     "normalize_issue_state",
     "normalize_text_dimension",

--- a/stormlog/issues.py
+++ b/stormlog/issues.py
@@ -1,0 +1,262 @@
+"""Durable issue fingerprints and grouped issue row models."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+IssueKind = Literal[
+    "oom",
+    "collector_degradation",
+    "alert",
+    "hidden_memory_anomaly",
+]
+IssueState = Literal["open", "resolved", "ignored", "regressed"]
+
+ISSUE_FINGERPRINT_SCHEMA_VERSION = 1
+ISSUE_STATE_OPEN: IssueState = "open"
+
+_ISSUE_KINDS = frozenset(
+    {
+        "oom",
+        "collector_degradation",
+        "alert",
+        "hidden_memory_anomaly",
+    }
+)
+_ISSUE_STATES = frozenset({"open", "resolved", "ignored", "regressed"})
+_RE_NUMERIC_TOKEN = re.compile(r"(?<!\w)\d+(?:\.\d+)?%?(?!\w)")
+_RE_HEX_TOKEN = re.compile(r"0x[0-9a-fA-F]+")
+_RE_WHITESPACE = re.compile(r"\s+")
+
+
+@dataclass(frozen=True)
+class IssueFingerprint:
+    """Stable grouping identity for recurring Stormlog issues."""
+
+    kind: IssueKind
+    dimensions: Mapping[str, Any]
+    schema_version: int = ISSUE_FINGERPRINT_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.kind not in _ISSUE_KINDS:
+            raise ValueError(f"unsupported issue kind: {self.kind}")
+        if self.schema_version < 1:
+            raise ValueError("schema_version must be >= 1")
+        object.__setattr__(
+            self,
+            "dimensions",
+            normalize_dimensions(self.dimensions),
+        )
+
+    @property
+    def fingerprint_id(self) -> str:
+        """Return a deterministic hash for this fingerprint."""
+
+        payload = {
+            "schema_version": self.schema_version,
+            "kind": self.kind,
+            "dimensions": dict(self.dimensions),
+        }
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        return f"issue:{hashlib.sha256(encoded.encode('utf-8')).hexdigest()[:24]}"
+
+    def as_dict(self) -> dict[str, Any]:
+        """Serialize the fingerprint into a JSON-safe mapping."""
+
+        return {
+            "schema_version": self.schema_version,
+            "fingerprint_id": self.fingerprint_id,
+            "kind": self.kind,
+            "dimensions": dict(self.dimensions),
+        }
+
+
+@dataclass(frozen=True)
+class IssueEvidenceLink:
+    """Link from a grouped issue back to raw session, event, or bundle evidence."""
+
+    session_id: str | None = None
+    timestamp_ns: int | None = None
+    rank: int | None = None
+    source_path: str | None = None
+    source_kind: str | None = None
+    event_type: str | None = None
+    bundle_path: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+    def as_dict(self) -> dict[str, Any]:
+        """Serialize the evidence link into a JSON-safe mapping."""
+
+        return {
+            "session_id": self.session_id,
+            "timestamp_ns": self.timestamp_ns,
+            "rank": self.rank,
+            "source_path": self.source_path,
+            "source_kind": self.source_kind,
+            "event_type": self.event_type,
+            "bundle_path": self.bundle_path,
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class StormlogIssue:
+    """Grouped issue suitable for CLI/TUI presentation and future persistence."""
+
+    fingerprint: IssueFingerprint
+    title: str
+    severity: str
+    hit_count: int
+    first_seen_ns: int | None
+    last_seen_ns: int | None
+    affected_sessions: Sequence[str]
+    representative_evidence: IssueEvidenceLink
+    evidence: Sequence[IssueEvidenceLink]
+    state: IssueState = ISSUE_STATE_OPEN
+    details: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "state", normalize_issue_state(self.state))
+        if self.hit_count < 1:
+            raise ValueError("hit_count must be >= 1")
+        object.__setattr__(
+            self,
+            "affected_sessions",
+            tuple(sorted({session for session in self.affected_sessions if session})),
+        )
+        object.__setattr__(self, "evidence", tuple(self.evidence))
+        object.__setattr__(self, "details", dict(self.details))
+
+    @property
+    def fingerprint_id(self) -> str:
+        """Return the issue fingerprint id."""
+
+        return self.fingerprint.fingerprint_id
+
+    @property
+    def kind(self) -> IssueKind:
+        """Return the issue kind."""
+
+        return self.fingerprint.kind
+
+    def as_dict(self) -> dict[str, Any]:
+        """Serialize the grouped issue into a JSON-safe mapping."""
+
+        return {
+            "fingerprint_id": self.fingerprint_id,
+            "fingerprint": self.fingerprint.as_dict(),
+            "kind": self.kind,
+            "state": self.state,
+            "severity": self.severity,
+            "title": self.title,
+            "hit_count": self.hit_count,
+            "first_seen_ns": self.first_seen_ns,
+            "last_seen_ns": self.last_seen_ns,
+            "affected_sessions": list(self.affected_sessions),
+            "representative_evidence": self.representative_evidence.as_dict(),
+            "evidence": [link.as_dict() for link in self.evidence],
+            "details": dict(self.details),
+        }
+
+
+def normalize_issue_state(state: str) -> IssueState:
+    """Validate and normalize an issue state string."""
+
+    normalized = state.strip().lower()
+    if normalized not in _ISSUE_STATES:
+        raise ValueError(f"unsupported issue state: {state}")
+    return normalized  # type: ignore[return-value]
+
+
+def normalize_dimensions(dimensions: Mapping[str, Any]) -> dict[str, Any]:
+    """Normalize fingerprint dimensions into a canonical JSON-safe mapping."""
+
+    normalized: dict[str, Any] = {}
+    for key, value in dimensions.items():
+        if not isinstance(key, str) or not key.strip():
+            raise ValueError("fingerprint dimension keys must be non-empty strings")
+        normalized[key] = _normalize_dimension_value(value)
+    return dict(sorted(normalized.items()))
+
+
+def normalize_text_dimension(value: object, *, default: str = "unknown") -> str:
+    """Return a low-cardinality text token for fingerprint dimensions."""
+
+    if value is None:
+        return default
+    text = str(value).strip().lower()
+    if not text:
+        return default
+    text = _RE_HEX_TOKEN.sub("<hex>", text)
+    text = _RE_NUMERIC_TOKEN.sub("<num>", text)
+    text = _RE_WHITESPACE.sub(" ", text)
+    return text
+
+
+def categorize_alert_context(context: object) -> str:
+    """Return a stable alert category from event context text."""
+
+    normalized = normalize_text_dimension(context)
+    if "fragmentation" in normalized:
+        return "high_fragmentation"
+    if "oom" in normalized or "out of memory" in normalized:
+        return "oom_alert"
+    if normalized == "unknown":
+        return "generic_alert"
+    return normalized
+
+
+def normalized_error_stem(error: object) -> str:
+    """Return a stable low-cardinality error stem."""
+
+    text = normalize_text_dimension(error)
+    if text == "unknown":
+        return text
+    separators = (":", "\n")
+    for separator in separators:
+        if separator in text:
+            text = text.split(separator, 1)[0].strip()
+    return text[:120] or "unknown"
+
+
+def _normalize_dimension_value(value: Any) -> Any:
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    if isinstance(value, float):
+        return round(value, 6)
+    if isinstance(value, str):
+        return normalize_text_dimension(value)
+    if isinstance(value, (list, tuple, set, frozenset)):
+        normalized_items = [_normalize_dimension_value(item) for item in value]
+        return sorted(
+            normalized_items, key=lambda item: json.dumps(item, sort_keys=True)
+        )
+    if isinstance(value, Mapping):
+        return normalize_dimensions(value)
+    return normalize_text_dimension(value)
+
+
+__all__ = [
+    "ISSUE_FINGERPRINT_SCHEMA_VERSION",
+    "ISSUE_STATE_OPEN",
+    "IssueEvidenceLink",
+    "IssueFingerprint",
+    "IssueKind",
+    "IssueState",
+    "StormlogIssue",
+    "categorize_alert_context",
+    "normalize_dimensions",
+    "normalize_issue_state",
+    "normalize_text_dimension",
+    "normalized_error_stem",
+]

--- a/stormlog/query.py
+++ b/stormlog/query.py
@@ -10,8 +10,26 @@ from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
+from .gap_analysis import analyze_hidden_memory_gaps
+from .issues import (
+    ISSUE_STATE_OPEN,
+    IssueEvidenceLink,
+    IssueFingerprint,
+    IssueKind,
+    IssueState,
+    StormlogIssue,
+    categorize_alert_context,
+    normalize_issue_state,
+    normalize_text_dimension,
+    normalized_error_stem,
+)
+from .phases import (
+    PhaseReplayIndex,
+    phase_attribution_to_payload,
+    summarize_phase_attribution,
+)
 from .session import (
     SESSION_STATUS_INTERRUPTED,
     SessionSummary,
@@ -23,6 +41,7 @@ from .session import (
 from .telemetry import (
     LoadedTelemetrySession,
     TelemetryEvent,
+    TelemetryEventV2,
     load_telemetry_sessions,
     telemetry_event_from_record,
     telemetry_event_to_dict,
@@ -34,6 +53,7 @@ from .telemetry_sink import (
     read_telemetry_sink_manifest,
     resolve_telemetry_sink_segment_paths,
 )
+from .utils import format_bytes
 
 SourceKind = Literal[
     "sink",
@@ -58,6 +78,15 @@ SummaryGroupBy = Literal["session", "session-rank", "rank", "status"]
 _ALERT_EVENT_TYPES = frozenset({"warning", "critical", "error"})
 _COLLECTOR_TRANSITION_TYPES = frozenset({"collector_degraded", "collector_recovered"})
 _TELEMETRY_FILE_NAME_PARTS = ("event", "events", "track", "telemetry")
+_COLLECTOR_DEGRADED_STATUSES = frozenset({"degraded", "unhealthy"})
+_GAP_ANALYSIS_THRESHOLDS = {
+    "gap_ratio_threshold": 0.05,
+    "gap_spike_zscore": 2.0,
+    "gap_drift_r_squared": 0.6,
+    "gap_fragmentation_ratio": 0.3,
+}
+_GAP_REMEDIATION_BY_CLASSIFICATION: Mapping[str, list[str]] = {}
+_SEVERITY_RANK = {"critical": 0, "error": 0, "warning": 1, "info": 2}
 
 
 @dataclass(frozen=True)
@@ -160,6 +189,17 @@ class OOMBundleFilter:
     reason: str | None = None
     created_after: str | None = None
     created_before: str | None = None
+
+
+@dataclass(frozen=True)
+class IssueFilter:
+    """Filters for grouped issue rows."""
+
+    fingerprint_id: str | None = None
+    kind: IssueKind | None = None
+    state: IssueState | None = None
+    severity: str | None = None
+    session_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -581,6 +621,49 @@ class QueryStore:
         rows = [row for row in rows if _oom_matches(row, filters)]
         rows.sort(key=lambda row: (row.created_at_utc or "", row.bundle_path))
         return rows
+
+    def list_issues(
+        self,
+        filters: IssueFilter | None = None,
+        *,
+        state_overrides: Mapping[str, str] | None = None,
+    ) -> list[StormlogIssue]:
+        """Return grouped issues derived from discovered artifacts."""
+        filters = filters or IssueFilter()
+        state_by_fingerprint = {
+            fingerprint_id: normalize_issue_state(state)
+            for fingerprint_id, state in (state_overrides or {}).items()
+        }
+        accumulator: dict[str, _IssueAccumulator] = {}
+
+        for oom_row in self.list_oom_bundles():
+            _accumulate_oom_bundle_issue(accumulator, oom_row)
+
+        event_rows = self.query_events(EventFilter())
+        for event_row in event_rows:
+            if _is_oom_event(event_row.event):
+                _accumulate_oom_event_issue(accumulator, event_row)
+            elif _is_collector_degradation_event(event_row.event):
+                _accumulate_collector_issue(accumulator, event_row)
+            elif _is_alert_event(event_row.event):
+                _accumulate_alert_issue(accumulator, event_row)
+
+        for source in self.catalog.sources:
+            for loaded in self._load_sessions_for_source(source):
+                _accumulate_hidden_memory_issues(accumulator, loaded, source)
+
+        issues = [
+            item.to_issue(
+                state=state_by_fingerprint.get(
+                    item.fingerprint.fingerprint_id,
+                    ISSUE_STATE_OPEN,
+                )
+            )
+            for item in accumulator.values()
+        ]
+        issues = [issue for issue in issues if _issue_matches(issue, filters)]
+        issues.sort(key=_issue_sort_key)
+        return issues
 
     def _manifest_session_status_by_id(self) -> dict[str, str]:
         statuses: dict[str, str] = {}
@@ -1050,11 +1133,48 @@ def _parse_datetime(value: str | None) -> datetime | None:
     return parsed.astimezone(timezone.utc)
 
 
+def _datetime_to_ns(value: datetime | None) -> int | None:
+    if value is None:
+        return None
+    return int(value.timestamp() * 1_000_000_000)
+
+
 def _is_alert_event(event: TelemetryEvent) -> bool:
     if event.event_type in _ALERT_EVENT_TYPES:
         return True
     severity = event.metadata.get("severity")
     return severity in {"warning", "critical", "error"}
+
+
+def _is_oom_event(event: TelemetryEvent) -> bool:
+    if event.event_type != "error":
+        return False
+    metadata = event.metadata
+    return any(key in metadata for key in ("oom_reason", "oom_dump_path"))
+
+
+def _is_collector_degradation_event(event: TelemetryEvent) -> bool:
+    metadata = event.metadata
+    health_status = normalize_text_dimension(metadata.get("collector_health_status"))
+    return (
+        event.event_type == "collector_degraded"
+        or health_status in _COLLECTOR_DEGRADED_STATUSES
+    )
+
+
+def _event_severity(event: TelemetryEvent) -> str:
+    metadata_severity = event.metadata.get("severity")
+    if isinstance(metadata_severity, str) and metadata_severity.strip():
+        return normalize_text_dimension(metadata_severity)
+    if event.event_type in {"critical", "error"}:
+        return "critical"
+    if event.event_type == "warning":
+        return "warning"
+    return "info"
+
+
+def _event_backend(event: TelemetryEvent) -> str:
+    return normalize_text_dimension(event.metadata.get("backend"))
 
 
 def _event_source_path(loaded: LoadedTelemetrySession, source: CatalogSource) -> str:
@@ -1074,6 +1194,400 @@ def _summary_group_key(
     if group_by == "status":
         return None, None, row.session_status
     return row.event.session_id, None, None
+
+
+@dataclass
+class _IssueAccumulator:
+    fingerprint: IssueFingerprint
+    title: str
+    severity: str
+    details: dict[str, Any] = field(default_factory=dict)
+    evidence: list[IssueEvidenceLink] = field(default_factory=list)
+    affected_sessions: set[str] = field(default_factory=set)
+    first_seen_ns: int | None = None
+    last_seen_ns: int | None = None
+
+    def add(
+        self,
+        *,
+        evidence: IssueEvidenceLink,
+        seen_ns: int | None,
+        session_id: str | None,
+        severity: str | None = None,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Add one evidence hit to this accumulator."""
+        self.evidence.append(evidence)
+        if session_id is not None:
+            self.affected_sessions.add(session_id)
+        if seen_ns is not None:
+            if self.first_seen_ns is None or seen_ns < self.first_seen_ns:
+                self.first_seen_ns = seen_ns
+            if self.last_seen_ns is None or seen_ns > self.last_seen_ns:
+                self.last_seen_ns = seen_ns
+        if severity is not None:
+            self.severity = _max_severity(self.severity, severity)
+        if details:
+            self.details.update(details)
+
+    def to_issue(self, *, state: IssueState) -> StormlogIssue:
+        """Build an immutable issue row from accumulated hits."""
+        representative = self.evidence[0]
+        return StormlogIssue(
+            fingerprint=self.fingerprint,
+            title=self.title,
+            state=state,
+            severity=self.severity,
+            hit_count=len(self.evidence),
+            first_seen_ns=self.first_seen_ns,
+            last_seen_ns=self.last_seen_ns,
+            affected_sessions=tuple(self.affected_sessions),
+            representative_evidence=representative,
+            evidence=tuple(self.evidence),
+            details=dict(self.details),
+        )
+
+
+def _accumulate_issue(
+    accumulator: dict[str, _IssueAccumulator],
+    *,
+    fingerprint: IssueFingerprint,
+    title: str,
+    severity: str,
+    evidence: IssueEvidenceLink,
+    seen_ns: int | None,
+    session_id: str | None,
+    details: Mapping[str, Any] | None = None,
+) -> None:
+    fingerprint_id = fingerprint.fingerprint_id
+    issue = accumulator.get(fingerprint_id)
+    if issue is None:
+        issue = _IssueAccumulator(
+            fingerprint=fingerprint,
+            title=title,
+            severity=severity,
+            details=dict(details or {}),
+        )
+        accumulator[fingerprint_id] = issue
+    issue.add(
+        evidence=evidence,
+        seen_ns=seen_ns,
+        session_id=session_id,
+        severity=severity,
+        details=details,
+    )
+
+
+def _accumulate_oom_bundle_issue(
+    accumulator: dict[str, _IssueAccumulator],
+    row: OOMBundleRow,
+) -> None:
+    fingerprint = IssueFingerprint(
+        kind="oom",
+        dimensions={
+            "backend": row.backend,
+            "reason": row.reason,
+            "exception_module": row.exception_module,
+            "exception_type": row.exception_type,
+            "collector": "unknown",
+            "device_id": "unknown",
+        },
+    )
+    seen_ns = _datetime_to_ns(_parse_datetime(row.created_at_utc))
+    evidence = IssueEvidenceLink(
+        session_id=row.session_id,
+        timestamp_ns=seen_ns,
+        source_path=row.bundle_path,
+        source_kind="oom_bundle",
+        bundle_path=row.bundle_path,
+        metadata={
+            "created_at_utc": row.created_at_utc,
+            "event_count": row.event_count,
+            "session_status": row.session_status,
+        },
+    )
+    _accumulate_issue(
+        accumulator,
+        fingerprint=fingerprint,
+        title="OOM captured by flight recorder",
+        severity="critical",
+        evidence=evidence,
+        seen_ns=seen_ns,
+        session_id=row.session_id,
+        details={
+            "backend": row.backend,
+            "reason": row.reason,
+            "exception_type": row.exception_type,
+            "exception_module": row.exception_module,
+        },
+    )
+
+
+def _accumulate_oom_event_issue(
+    accumulator: dict[str, _IssueAccumulator],
+    row: EventRow,
+) -> None:
+    event = row.event
+    metadata = event.metadata
+    reason = metadata.get("oom_reason")
+    bundle_path = _string_or_none(metadata.get("oom_dump_path"))
+    fingerprint = IssueFingerprint(
+        kind="oom",
+        dimensions={
+            "backend": _event_backend(event),
+            "reason": reason,
+            "exception_module": metadata.get("exception_module"),
+            "exception_type": metadata.get("exception_type"),
+            "collector": event.collector,
+            "device_id": event.device_id,
+        },
+    )
+    evidence = IssueEvidenceLink(
+        session_id=event.session_id,
+        timestamp_ns=event.timestamp_ns,
+        rank=event.rank,
+        source_path=row.source_path,
+        source_kind=row.source_kind,
+        event_type=event.event_type,
+        bundle_path=bundle_path,
+        metadata={"context": event.context, "session_status": row.session_status},
+    )
+    _accumulate_issue(
+        accumulator,
+        fingerprint=fingerprint,
+        title="OOM telemetry event",
+        severity="critical",
+        evidence=evidence,
+        seen_ns=event.timestamp_ns,
+        session_id=event.session_id,
+        details={
+            "backend": _event_backend(event),
+            "reason": reason,
+            "collector": event.collector,
+            "device_id": event.device_id,
+        },
+    )
+
+
+def _accumulate_collector_issue(
+    accumulator: dict[str, _IssueAccumulator],
+    row: EventRow,
+) -> None:
+    event = row.event
+    metadata = event.metadata
+    health_status = normalize_text_dimension(
+        metadata.get("collector_health_status"),
+        default="degraded",
+    )
+    partial_fields = metadata.get("collector_partial_fields")
+    if not isinstance(partial_fields, Sequence) or isinstance(partial_fields, str):
+        partial_fields = ()
+    last_error = metadata.get("collector_last_error")
+    fingerprint = IssueFingerprint(
+        kind="collector_degradation",
+        dimensions={
+            "collector": event.collector,
+            "backend": _event_backend(event),
+            "health_status": health_status,
+            "partial_fields": list(partial_fields),
+            "error_stem": normalized_error_stem(last_error),
+        },
+    )
+    evidence = IssueEvidenceLink(
+        session_id=event.session_id,
+        timestamp_ns=event.timestamp_ns,
+        rank=event.rank,
+        source_path=row.source_path,
+        source_kind=row.source_kind,
+        event_type=event.event_type,
+        metadata={
+            "collector_consecutive_failures": metadata.get(
+                "collector_consecutive_failures"
+            ),
+            "collector_next_retry_epoch_s": metadata.get(
+                "collector_next_retry_epoch_s"
+            ),
+            "session_status": row.session_status,
+        },
+    )
+    _accumulate_issue(
+        accumulator,
+        fingerprint=fingerprint,
+        title="Collector degradation",
+        severity="critical" if health_status == "unhealthy" else "warning",
+        evidence=evidence,
+        seen_ns=event.timestamp_ns,
+        session_id=event.session_id,
+        details={
+            "collector": event.collector,
+            "backend": _event_backend(event),
+            "health_status": health_status,
+            "partial_fields": list(partial_fields),
+            "error_stem": normalized_error_stem(last_error),
+        },
+    )
+
+
+def _accumulate_alert_issue(
+    accumulator: dict[str, _IssueAccumulator],
+    row: EventRow,
+) -> None:
+    event = row.event
+    severity = _event_severity(event)
+    category = categorize_alert_context(event.context)
+    fingerprint = IssueFingerprint(
+        kind="alert",
+        dimensions={
+            "event_type": event.event_type,
+            "severity": severity,
+            "collector": event.collector,
+            "backend": _event_backend(event),
+            "category": category,
+        },
+    )
+    evidence = IssueEvidenceLink(
+        session_id=event.session_id,
+        timestamp_ns=event.timestamp_ns,
+        rank=event.rank,
+        source_path=row.source_path,
+        source_kind=row.source_kind,
+        event_type=event.event_type,
+        metadata={"context": event.context, "session_status": row.session_status},
+    )
+    _accumulate_issue(
+        accumulator,
+        fingerprint=fingerprint,
+        title=f"Alert: {category.replace('_', ' ')}",
+        severity=severity,
+        evidence=evidence,
+        seen_ns=event.timestamp_ns,
+        session_id=event.session_id,
+        details={
+            "event_type": event.event_type,
+            "collector": event.collector,
+            "backend": _event_backend(event),
+            "category": category,
+        },
+    )
+
+
+def _accumulate_hidden_memory_issues(
+    accumulator: dict[str, _IssueAccumulator],
+    loaded: LoadedTelemetrySession,
+    source: CatalogSource,
+) -> None:
+    if len(loaded.events) < 3:
+        return
+    phase_resolver = PhaseReplayIndex.from_events(loaded.events)
+    findings = analyze_hidden_memory_gaps(
+        events=cast(Sequence[TelemetryEventV2], loaded.events),
+        thresholds=_GAP_ANALYSIS_THRESHOLDS,
+        format_memory=format_bytes,
+        remediation_by_classification=_GAP_REMEDIATION_BY_CLASSIFICATION,
+        phase_resolver=phase_resolver,
+    )
+    for finding in findings:
+        evidence_event = _event_at_timestamp(
+            loaded.events,
+            finding.evidence_timestamp_ns,
+        )
+        phase_label = summarize_phase_attribution(finding.phase_attribution)
+        fingerprint = IssueFingerprint(
+            kind="hidden_memory_anomaly",
+            dimensions={
+                "classification": finding.classification,
+                "severity": finding.severity,
+                "phase": phase_label,
+                "collector": (
+                    evidence_event.collector
+                    if evidence_event is not None
+                    else "unknown"
+                ),
+                "backend": (
+                    _event_backend(evidence_event)
+                    if evidence_event is not None
+                    else "unknown"
+                ),
+            },
+        )
+        evidence = IssueEvidenceLink(
+            session_id=loaded.summary.session_id,
+            timestamp_ns=finding.evidence_timestamp_ns,
+            rank=evidence_event.rank if evidence_event is not None else None,
+            source_path=_event_source_path(loaded, source),
+            source_kind=source.source_kind,
+            event_type=(
+                evidence_event.event_type if evidence_event is not None else "sample"
+            ),
+            metadata={
+                "classification": finding.classification,
+                "confidence": finding.confidence,
+                "phase_attribution": phase_attribution_to_payload(
+                    finding.phase_attribution
+                ),
+            },
+        )
+        _accumulate_issue(
+            accumulator,
+            fingerprint=fingerprint,
+            title=f"Hidden-memory anomaly: {finding.classification}",
+            severity=finding.severity,
+            evidence=evidence,
+            seen_ns=finding.evidence_timestamp_ns,
+            session_id=loaded.summary.session_id,
+            details={
+                "classification": finding.classification,
+                "description": finding.description,
+                "confidence": finding.confidence,
+                "evidence": dict(finding.evidence),
+                "phase": phase_label,
+            },
+        )
+
+
+def _event_at_timestamp(
+    events: Sequence[TelemetryEvent],
+    timestamp_ns: int | None,
+) -> TelemetryEvent | None:
+    if timestamp_ns is None:
+        return None
+    for event in events:
+        if event.timestamp_ns == timestamp_ns:
+            return event
+    return None
+
+
+def _max_severity(first: str, second: str) -> str:
+    first_rank = _SEVERITY_RANK.get(first, 9)
+    second_rank = _SEVERITY_RANK.get(second, 9)
+    return second if second_rank < first_rank else first
+
+
+def _issue_matches(issue: StormlogIssue, filters: IssueFilter) -> bool:
+    if filters.fingerprint_id is not None and (
+        issue.fingerprint_id != filters.fingerprint_id
+    ):
+        return False
+    if filters.kind is not None and issue.kind != filters.kind:
+        return False
+    if filters.state is not None and issue.state != filters.state:
+        return False
+    if filters.severity is not None and issue.severity != filters.severity:
+        return False
+    if filters.session_id is not None and (
+        filters.session_id not in issue.affected_sessions
+    ):
+        return False
+    return True
+
+
+def _issue_sort_key(issue: StormlogIssue) -> tuple[int, int, str]:
+    last_seen = issue.last_seen_ns if issue.last_seen_ns is not None else -1
+    return (
+        _SEVERITY_RANK.get(issue.severity, 9),
+        -last_seen,
+        issue.fingerprint_id,
+    )
 
 
 def _summarize_peak(
@@ -1193,6 +1707,7 @@ __all__ = [
     "CatalogWarning",
     "EventFilter",
     "EventRow",
+    "IssueFilter",
     "OOMBundleFilter",
     "OOMBundleRow",
     "QueryStore",

--- a/stormlog/query.py
+++ b/stormlog/query.py
@@ -1287,10 +1287,6 @@ def _accumulate_oom_bundle_issue(
         dimensions={
             "backend": row.backend,
             "reason": row.reason,
-            "exception_module": row.exception_module,
-            "exception_type": row.exception_type,
-            "collector": "unknown",
-            "device_id": "unknown",
         },
     )
     seen_ns = _datetime_to_ns(_parse_datetime(row.created_at_utc))
@@ -1336,10 +1332,6 @@ def _accumulate_oom_event_issue(
         dimensions={
             "backend": _event_backend(event),
             "reason": reason,
-            "exception_module": metadata.get("exception_module"),
-            "exception_type": metadata.get("exception_type"),
-            "collector": event.collector,
-            "device_id": event.device_id,
         },
     )
     evidence = IssueEvidenceLink(

--- a/stormlog/query_cli.py
+++ b/stormlog/query_cli.py
@@ -86,6 +86,25 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
             ]
             _emit_rows(rows, output_mode, _OOM_COLUMNS)
+        elif args.command == "issues":
+            if output_mode.csv:
+                print(
+                    "Error: --csv is not supported for issue queries", file=sys.stderr
+                )
+                return 2
+            rows = [
+                row.as_dict()
+                for row in store.list_issues(
+                    query_api.IssueFilter(
+                        fingerprint_id=args.fingerprint_id,
+                        kind=args.kind,
+                        state=args.state,
+                        severity=args.severity,
+                        session_id=args.session_id,
+                    )
+                )
+            ]
+            _emit_rows(rows, output_mode, _ISSUE_COLUMNS)
         elif args.command == "summary":
             if output_mode.csv:
                 print(
@@ -156,6 +175,26 @@ def _build_parser() -> argparse.ArgumentParser:
     ooms.add_argument("--reason")
     ooms.add_argument("--created-after")
     ooms.add_argument("--created-before")
+
+    issues = subparsers.add_parser("issues", help="List grouped recurring issues")
+    _add_paths(issues)
+    _add_output_flags(issues, include_csv=True)
+    issues.add_argument("--fingerprint-id")
+    issues.add_argument(
+        "--kind",
+        choices=[
+            "oom",
+            "collector_degradation",
+            "alert",
+            "hidden_memory_anomaly",
+        ],
+    )
+    issues.add_argument(
+        "--state",
+        choices=["open", "resolved", "ignored", "regressed"],
+    )
+    issues.add_argument("--severity")
+    issues.add_argument("--session-id", "--session", dest="session_id")
 
     summary = subparsers.add_parser("summary", help="Run built-in summaries")
     _add_paths(summary)
@@ -315,6 +354,18 @@ _OOM_COLUMNS = (
     "session_status",
     "exception_type",
     "exception_module",
+)
+_ISSUE_COLUMNS = (
+    "fingerprint_id",
+    "kind",
+    "state",
+    "severity",
+    "title",
+    "hit_count",
+    "first_seen_ns",
+    "last_seen_ns",
+    "affected_sessions",
+    "representative_evidence",
 )
 _SUMMARY_COLUMNS = (
     "metric",

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from stormlog.issues import (
@@ -33,6 +35,32 @@ def test_fingerprint_id_is_deterministic_for_normalized_dimensions() -> None:
 
     assert first.fingerprint_id == second.fingerprint_id
     assert first.as_dict()["fingerprint_id"].startswith("issue:")
+
+
+def test_fingerprint_dimensions_are_recursively_immutable() -> None:
+    fingerprint = IssueFingerprint(
+        kind="collector_degradation",
+        dimensions={
+            "collector": "stormlog.cuda_tracker",
+            "partial_fields": ["device_total", "device_free"],
+            "nested": {"error": "RuntimeError: sample 42"},
+        },
+    )
+    original_id = fingerprint.fingerprint_id
+    dimensions: Any = fingerprint.dimensions
+
+    with pytest.raises(TypeError):
+        dimensions["collector"] = "stormlog.rocm_tracker"
+    with pytest.raises(AttributeError):
+        dimensions["partial_fields"].append("device_used")
+    with pytest.raises(TypeError):
+        dimensions["nested"]["error"] = "changed"
+
+    assert fingerprint.fingerprint_id == original_id
+    assert fingerprint.as_dict()["dimensions"]["partial_fields"] == [
+        "device_free",
+        "device_total",
+    ]
 
 
 def test_normalize_dimensions_removes_high_cardinality_numeric_text() -> None:

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import pytest
+
+from stormlog.issues import (
+    IssueEvidenceLink,
+    IssueFingerprint,
+    StormlogIssue,
+    categorize_alert_context,
+    normalize_dimensions,
+    normalize_issue_state,
+    normalized_error_stem,
+)
+
+
+def test_fingerprint_id_is_deterministic_for_normalized_dimensions() -> None:
+    first = IssueFingerprint(
+        kind="oom",
+        dimensions={
+            "backend": "CUDA",
+            "reason": "message_pattern:out of memory",
+            "partial_fields": ["device_free", "device_total"],
+        },
+    )
+    second = IssueFingerprint(
+        kind="oom",
+        dimensions={
+            "partial_fields": ["device_total", "device_free"],
+            "reason": "MESSAGE_PATTERN:OUT OF MEMORY",
+            "backend": "cuda",
+        },
+    )
+
+    assert first.fingerprint_id == second.fingerprint_id
+    assert first.as_dict()["fingerprint_id"].startswith("issue:")
+
+
+def test_normalize_dimensions_removes_high_cardinality_numeric_text() -> None:
+    normalized = normalize_dimensions(
+        {
+            "category": "High fragmentation: 43.5%",
+            "error": "CUDA error at 0x1234 after 125 retries",
+        }
+    )
+
+    assert normalized["category"] == "high fragmentation: <num>"
+    assert normalized["error"] == "cuda error at <hex> after <num> retries"
+
+
+def test_issue_state_validation() -> None:
+    assert normalize_issue_state(" RESOLVED ") == "resolved"
+
+    with pytest.raises(ValueError, match="unsupported issue state"):
+        normalize_issue_state("muted")
+
+
+def test_alert_category_and_error_stem_helpers() -> None:
+    assert categorize_alert_context("High fragmentation: 40.0%") == (
+        "high_fragmentation"
+    )
+    assert normalized_error_stem("RuntimeError: CUDA failed at step 42") == (
+        "runtimeerror"
+    )
+
+
+def test_stormlog_issue_serializes_evidence_and_sessions() -> None:
+    fingerprint = IssueFingerprint(
+        kind="collector_degradation",
+        dimensions={"collector": "stormlog.cuda_tracker", "status": "degraded"},
+    )
+    evidence = IssueEvidenceLink(
+        session_id="session-b",
+        timestamp_ns=20,
+        rank=1,
+        source_path="/tmp/track.json",
+        source_kind="telemetry_json",
+        event_type="collector_degraded",
+        metadata={"collector_health_status": "degraded"},
+    )
+    issue = StormlogIssue(
+        fingerprint=fingerprint,
+        title="Collector degraded",
+        severity="warning",
+        state="open",
+        hit_count=2,
+        first_seen_ns=10,
+        last_seen_ns=20,
+        affected_sessions=["session-b", "session-a", "session-a"],
+        representative_evidence=evidence,
+        evidence=[evidence],
+        details={"collector": "stormlog.cuda_tracker"},
+    )
+
+    payload = issue.as_dict()
+
+    assert payload["fingerprint_id"] == fingerprint.fingerprint_id
+    assert payload["affected_sessions"] == ["session-a", "session-b"]
+    assert payload["representative_evidence"]["event_type"] == "collector_degraded"
+    assert payload["details"]["collector"] == "stormlog.cuda_tracker"

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -26,6 +26,7 @@ def _event_record(
     reserved: int = 150,
     used: int = 175,
     metadata: dict[str, Any] | None = None,
+    context: str | None = None,
 ) -> dict[str, Any]:
     return {
         "schema_version": 3,
@@ -49,7 +50,7 @@ def _event_record(
         "device_used_bytes": used,
         "device_free_bytes": None,
         "device_total_bytes": 1000,
-        "context": event_type,
+        "context": context or event_type,
         "metadata": metadata or {"backend": "cuda"},
     }
 
@@ -348,3 +349,125 @@ def test_catalog_discovers_csv_telemetry(tmp_path: Path) -> None:
     assert len(rows) == 1
     assert rows[0].session_id == "session-csv"
     assert rows[0].source_kind == "telemetry_csv"
+
+
+def test_list_issues_groups_alerts_across_sessions(tmp_path: Path) -> None:
+    path = tmp_path / "track.json"
+    _write_json_events(
+        path,
+        [
+            _event_record(
+                session_id="session-alert-a",
+                timestamp_ns=10,
+                event_type="warning",
+                context="High fragmentation: 40.0%",
+            ),
+            _event_record(
+                session_id="session-alert-b",
+                timestamp_ns=20,
+                event_type="warning",
+                context="High fragmentation: 51.5%",
+            ),
+        ],
+    )
+
+    rows = query_api.open([path]).list_issues(
+        query_api.IssueFilter(kind="alert", session_id="session-alert-a")
+    )
+
+    assert len(rows) == 1
+    issue = rows[0]
+    assert issue.kind == "alert"
+    assert issue.state == "open"
+    assert issue.hit_count == 2
+    assert issue.first_seen_ns == 10
+    assert issue.last_seen_ns == 20
+    assert issue.affected_sessions == ("session-alert-a", "session-alert-b")
+    assert issue.fingerprint.dimensions["category"] == "high_fragmentation"
+    assert issue.representative_evidence.event_type == "warning"
+
+
+def test_list_issues_supports_state_overrides(tmp_path: Path) -> None:
+    path = tmp_path / "track.json"
+    _write_json_events(
+        path,
+        [
+            _event_record(
+                session_id="session-collector",
+                timestamp_ns=10,
+                event_type="collector_degraded",
+                metadata={
+                    "backend": "cuda",
+                    "collector_health_status": "degraded",
+                    "collector_partial_fields": ["device_free_bytes"],
+                    "collector_last_error": "RuntimeError: failed at sample 42",
+                },
+            )
+        ],
+    )
+    store = query_api.open([path])
+    original = store.list_issues(query_api.IssueFilter(kind="collector_degradation"))[0]
+
+    overridden = store.list_issues(
+        query_api.IssueFilter(state="ignored"),
+        state_overrides={original.fingerprint_id: "ignored"},
+    )
+
+    assert len(overridden) == 1
+    assert overridden[0].state == "ignored"
+    assert overridden[0].details["error_stem"] == "runtimeerror"
+
+
+def test_list_issues_includes_oom_bundles_and_telemetry_ooms(tmp_path: Path) -> None:
+    _write_oom_bundle(tmp_path, session_id="session-oom-bundle")
+    path = tmp_path / "track.json"
+    _write_json_events(
+        path,
+        [
+            _event_record(
+                session_id="session-oom-event",
+                timestamp_ns=50,
+                event_type="error",
+                metadata={
+                    "backend": "cuda",
+                    "oom_reason": "message_pattern:out of memory",
+                    "oom_dump_path": str(tmp_path / "oom"),
+                },
+            )
+        ],
+    )
+
+    rows = query_api.open([tmp_path]).list_issues(query_api.IssueFilter(kind="oom"))
+
+    assert len(rows) == 2
+    assert {row.severity for row in rows} == {"critical"}
+    assert {row.hit_count for row in rows} == {1}
+    assert {"session-oom-bundle", "session-oom-event"} == {
+        session for row in rows for session in row.affected_sessions
+    }
+
+
+def test_list_issues_includes_hidden_memory_anomalies(tmp_path: Path) -> None:
+    path = tmp_path / "track.json"
+    _write_json_events(
+        path,
+        [
+            _event_record(
+                session_id="session-gap",
+                timestamp_ns=timestamp_ns,
+                allocated=90,
+                reserved=100,
+                used=used,
+            )
+            for timestamp_ns, used in enumerate([160, 220, 280, 340, 400], start=1)
+        ],
+    )
+
+    rows = query_api.open([path]).list_issues(
+        query_api.IssueFilter(kind="hidden_memory_anomaly")
+    )
+
+    assert rows
+    assert rows[0].kind == "hidden_memory_anomaly"
+    assert rows[0].details["classification"] == "persistent_drift"
+    assert rows[0].affected_sessions == ("session-gap",)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -439,9 +439,13 @@ def test_list_issues_includes_oom_bundles_and_telemetry_ooms(tmp_path: Path) -> 
 
     rows = query_api.open([tmp_path]).list_issues(query_api.IssueFilter(kind="oom"))
 
-    assert len(rows) == 2
-    assert {row.severity for row in rows} == {"critical"}
-    assert {row.hit_count for row in rows} == {1}
+    assert len(rows) == 1
+    assert rows[0].severity == "critical"
+    assert rows[0].hit_count == 2
+    assert rows[0].fingerprint.dimensions == {
+        "backend": "cuda",
+        "reason": "message_pattern:out of memory",
+    }
     assert {"session-oom-bundle", "session-oom-event"} == {
         session for row in rows for session in row.affected_sessions
     }

--- a/tests/test_query_cli.py
+++ b/tests/test_query_cli.py
@@ -18,6 +18,7 @@ def _event_record(
     timestamp_ns: int = 1,
     event_type: str = "sample",
     rank: int = 0,
+    context: str | None = None,
 ) -> dict[str, Any]:
     return {
         "schema_version": 3,
@@ -41,7 +42,7 @@ def _event_record(
         "device_used_bytes": 200,
         "device_free_bytes": None,
         "device_total_bytes": 1000,
-        "context": event_type,
+        "context": context or event_type,
         "metadata": {"backend": "cuda"},
     }
 
@@ -132,6 +133,72 @@ def test_query_summary_rejects_csv(
         )
         == 2
     )
+
+    assert "--csv is not supported" in capsys.readouterr().err
+
+
+def test_query_issues_json_output(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = tmp_path / "track.json"
+    _write_json_events(
+        path,
+        [
+            _event_record(
+                timestamp_ns=1,
+                event_type="warning",
+                context="High fragmentation: 40.0%",
+            )
+        ],
+    )
+
+    assert query_main(["issues", str(path), "--kind", "alert", "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload) == 1
+    assert payload[0]["kind"] == "alert"
+    assert payload[0]["hit_count"] == 1
+    assert payload[0]["fingerprint"]["dimensions"]["category"] == ("high_fragmentation")
+
+
+def test_query_issues_table_output_filters_session(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = tmp_path / "track.json"
+    _write_json_events(
+        path,
+        [
+            _event_record(
+                session_id="session-visible",
+                timestamp_ns=1,
+                event_type="warning",
+            ),
+            _event_record(
+                session_id="session-hidden",
+                timestamp_ns=2,
+                event_type="critical",
+            ),
+        ],
+    )
+
+    assert query_main(["issues", str(path), "--session-id", "session-visible"]) == 0
+
+    output = capsys.readouterr().out
+    assert "Fingerprint Id" in output
+    assert "session-visible" in output
+    assert "session-hidden" not in output
+
+
+def test_query_issues_rejects_csv(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = tmp_path / "track.json"
+    _write_json_events(path, [_event_record(event_type="warning")])
+
+    assert query_main(["issues", str(path), "--csv"]) == 2
 
     assert "--csv is not supported" in capsys.readouterr().err
 


### PR DESCRIPTION
## Summary

Adds a durable grouped-issue model for recurring Stormlog failures, including deterministic fingerprints, evidence links back to raw artifacts, query API support, CLI output, and written fingerprinting strategy docs.

## Changes

- Added `stormlog.issues` with `IssueFingerprint`, `IssueEvidenceLink`, and `StormlogIssue`.
- Added `QueryStore.list_issues()` for OOMs, collector degradation, alerts, and hidden-memory anomaly findings.
- Added `stormlog query issues` with filters for kind, state, severity, session id, and fingerprint id.
- Added docs covering fingerprint dimensions, issue schema, worked examples, evidence linkage, and future `issues.json` persistence.
- Added tests for fingerprint determinism, state validation, issue serialization, query grouping, CLI JSON/table output, and filters.

## Research Notes

- Uses Sentry-style explicit fingerprint dimensions for durable grouping: https://docs.sentry.io/platforms/dotnet/guides/apple/usage/sdk-fingerprinting/
- Uses OpenTelemetry-style evidence linkage concepts to preserve traceability to raw events/sessions/artifacts: https://opentelemetry.io/docs/concepts/signals/traces/

## Validation

- Full non-interactive test suite passed.
- Formatting, lint, typing, docs build, and pre-commit all passed.