### PR TITLE
fix(issue): finalize durable fingerprinting support

### DIFF
--- a/stormlog/issues.py
+++ b/stormlog/issues.py
@@ -20,6 +20,9 @@ IssueState = Literal["open", "resolved", "ignored", "regressed"]
 
 ISSUE_FINGERPRINT_SCHEMA_VERSION = 1
 ISSUE_STATE_OPEN: IssueState = "open"
+ISSUE_STATE_RESOLVED: IssueState = "resolved"
+ISSUE_STATE_IGNORED: IssueState = "ignored"
+ISSUE_STATE_REGRESSED: IssueState = "regressed"
 
 _ISSUE_KINDS = frozenset(
     {
@@ -284,7 +287,10 @@ def _json_safe_dimension_value(value: Any) -> Any:
 
 __all__ = [
     "ISSUE_FINGERPRINT_SCHEMA_VERSION",
+    "ISSUE_STATE_IGNORED",
     "ISSUE_STATE_OPEN",
+    "ISSUE_STATE_REGRESSED",
+    "ISSUE_STATE_RESOLVED",
     "IssueEvidenceLink",
     "IssueFingerprint",
     "IssueKind",

--- a/stormlog/jax/profiler.py
+++ b/stormlog/jax/profiler.py
@@ -43,6 +43,14 @@ logger = logging.getLogger(__name__)
 
 F = TypeVar("F", bound=Callable[..., Any])
 
+
+def _device_zero(device: Any) -> Any:
+    """Create a scalar zero on a device using JAX's runtime-supported keyword."""
+
+    zeros = cast(Callable[..., Any], jax.numpy.zeros)
+    return zeros((), device=device)
+
+
 # ---------------------------------------------------------------------------
 # Data classes
 # ---------------------------------------------------------------------------
@@ -168,7 +176,7 @@ class JAXMemoryProfiler:
         self._sync_sentinel: Any = None
         if self._device is not None:
             try:
-                self._sync_sentinel = jax.numpy.zeros((), device=self._device)
+                self._sync_sentinel = _device_zero(self._device)
             except Exception:
                 pass
 
@@ -205,7 +213,7 @@ class JAXMemoryProfiler:
                 if self._sync_sentinel is not None:
                     self._sync_sentinel.block_until_ready()
                 else:
-                    jax.numpy.zeros((), device=self._device).block_until_ready()
+                    _device_zero(self._device).block_until_ready()
                 raw = self._device.memory_stats()
                 if raw is not None:
                     memory_stats = dict(raw)

--- a/stormlog/jax/tracker.py
+++ b/stormlog/jax/tracker.py
@@ -18,7 +18,7 @@ from collections import deque
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterator, List, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional, cast
 
 from stormlog.collector_health import (
     COLLECTOR_HEALTH_HEALTHY,
@@ -66,6 +66,13 @@ except ImportError:
     psutil = None
 
 logger = logging.getLogger(__name__)
+
+
+def _device_zero(device: Any) -> Any:
+    """Create a scalar zero on a device using JAX's runtime-supported keyword."""
+
+    zeros = cast(Callable[..., Any], jax.numpy.zeros)
+    return zeros((), device=device)
 
 
 @dataclass
@@ -199,7 +206,7 @@ class MemoryTracker:
         self._sync_sentinel: Any = None
         if self._device is not None:
             try:
-                self._sync_sentinel = jax.numpy.zeros((), device=self._device)
+                self._sync_sentinel = _device_zero(self._device)
             except Exception:
                 pass
 
@@ -359,7 +366,7 @@ class MemoryTracker:
         if self._sync_sentinel is not None:
             self._sync_sentinel.block_until_ready()
         elif hasattr(jax.numpy, "zeros"):
-            jax.numpy.zeros((), device=self._device).block_until_ready()
+            _device_zero(self._device).block_until_ready()
         stats = self._device.memory_stats()
         if stats:
             if "bytes_reserved" in stats:

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -5,6 +5,10 @@ from typing import Any
 import pytest
 
 from stormlog.issues import (
+    ISSUE_STATE_IGNORED,
+    ISSUE_STATE_OPEN,
+    ISSUE_STATE_REGRESSED,
+    ISSUE_STATE_RESOLVED,
     IssueEvidenceLink,
     IssueFingerprint,
     StormlogIssue,
@@ -76,6 +80,10 @@ def test_normalize_dimensions_removes_high_cardinality_numeric_text() -> None:
 
 
 def test_issue_state_validation() -> None:
+    assert ISSUE_STATE_OPEN == "open"
+    assert ISSUE_STATE_RESOLVED == "resolved"
+    assert ISSUE_STATE_IGNORED == "ignored"
+    assert ISSUE_STATE_REGRESSED == "regressed"
     assert normalize_issue_state(" RESOLVED ") == "resolved"
 
     with pytest.raises(ValueError, match="unsupported issue state"):


### PR DESCRIPTION
## Summary
- Added durable Stormlog issue fingerprints for OOMs, collector degradation, alerts, and hidden-memory anomalies.
- Added grouped issue rows with hit counts, first/last seen timestamps, affected sessions, representative evidence, state, and detailed evidence links.
- Exported explicit issue state constants for open, resolved, ignored, and regressed states.
- Fixed JAX sync-barrier typing compatibility with the CI-pinned JAX version.

## Validation
- `.venv/bin/python -m pytest tests/test_issues.py tests/test_query.py tests/test_query_cli.py`
- `.venv/bin/python -m pytest tests/ -m 'not tui_pilot and not tui_snapshot and not tui_pty'`
- `.venv/bin/python -m black --check stormlog/ tests/ examples/`
- `.venv/bin/python -m isort --check --diff stormlog/ tests/ examples/`
- `.venv/bin/python -m flake8 stormlog/ tests/ examples/ --show-source --statistics`
- `.venv/bin/python -m mypy stormlog/`
- `.venv/bin/python -m sphinx -W --keep-going -b html docs docs/_build/html`
- `.venv/bin/python -m pre_commit run --all-files`

Close #108 