### PR TITLE
Add OpenAI-compatible inference profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@
   <em>Current Overview tab from the shipped Textual interface.</em>
 </p>
 
-Stormlog is a memory-profiling toolkit for day-to-day PyTorch and TensorFlow work. It combines Python APIs, CLI commands, and a Textual TUI so you can move from "what is using memory?" to saved artifacts and shareable diagnostics without switching tools.
+Stormlog is a memory-profiling and inference-profiling toolkit for day-to-day
+PyTorch, TensorFlow, JAX, and OpenAI-compatible serving work. It combines
+Python APIs, CLI commands, and a Textual TUI so you can move from "what is
+using memory?" or "what is my endpoint doing under load?" to saved artifacts
+and shareable diagnostics without switching tools.
 
 Long-running `track` and `diagnose` flows are session-aware, so one capture can
 be reconstructed deterministically across sink segments, diagnose bundles, and
@@ -46,23 +50,30 @@ pip install "stormlog[viz]"
 pip install "stormlog[tui,torch]"
 pip install "stormlog[torch]"
 pip install "stormlog[tf]"
+pip install "stormlog[jax]"
+pip install "stormlog[infer-tokenizers]"
 pip install "stormlog[all]"
 ```
 
-`stormlog[all]` installs every runtime extra: visualization, TUI, PyTorch, and TensorFlow dependencies.
+`stormlog[all]` installs every runtime extra: visualization, TUI, PyTorch,
+TensorFlow, JAX, W&B, and inference tokenizer dependencies.
 
 ### Package and import names
 
 `stormlog` is the distribution name on PyPI and the primary Python import root.
-TensorFlow-specific APIs live under `stormlog.tensorflow`.
+TensorFlow-specific APIs live under `stormlog.tensorflow`; JAX-specific APIs
+live under `stormlog.jax`.
 
 | Task | Use |
 | --- | --- |
 | Install the package | `pip install stormlog` |
-| Launch the TUI | `stormlog` |
+| Launch the TUI | `stormlog` or `stormlog tui` |
+| Profile OpenAI-compatible inference | `stormlog infer profile` |
 | Import PyTorch APIs | `from stormlog import GPUMemoryProfiler, MemoryTracker` |
 | Import TensorFlow APIs | `from stormlog.tensorflow import TFMemoryProfiler` |
-| Run CLI automation | `gpumemprof` or `tfmemprof` |
+| Import JAX APIs | `from stormlog.jax import JAXMemoryProfiler` |
+| Query local artifacts | `stormlog query` |
+| Run framework memory CLI automation | `gpumemprof`, `tfmemprof`, or `jaxmemprof` |
 
 ### From source
 
@@ -96,10 +107,31 @@ gpumemprof diagnose --duration 0 --output /tmp/gpumemprof_diag
 
 tfmemprof info
 tfmemprof diagnose --duration 0 --output /tmp/tf_diag
+
+jaxmemprof info
+jaxmemprof diagnose --duration 0 --output /tmp/jax_diag
 ```
 
 If you reuse a sink directory across multiple runs, Stormlog separates those
 captures by `session_id` and defaults analysis to the newest clean session.
+
+### OpenAI-compatible inference workflow
+
+Use `stormlog infer` when you want client-observed latency, throughput,
+failure, token, and optional system telemetry from a Chat Completions endpoint:
+
+```bash
+stormlog infer profile \
+  --base-url http://localhost:8000/v1 \
+  --model Qwen/Qwen2.5-7B-Instruct \
+  --concurrency 1,4,8 \
+  --input-tokens 512,2048 \
+  --output-tokens 128,512 \
+  --requests 20 \
+  --output /tmp/stormlog_infer.jsonl
+
+stormlog infer analyze /tmp/stormlog_infer.jsonl
+```
 
 ### PyTorch API workflow
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,16 +6,18 @@ This page describes the current code-level architecture of Stormlog. It is a sou
 
 ## Repository surfaces
 
-Stormlog has three user-facing surfaces that share the same core data model:
+Stormlog has four user-facing surfaces:
 
 - Python APIs for bounded profiling and background tracking
 - CLI entrypoints for capture, analysis, and diagnose flows
+- OpenAI-compatible inference endpoint profiling
 - a Textual TUI for live monitoring, visualization export, and artifact review
 
 Those surfaces are implemented under one package root:
 
-- `stormlog` for PyTorch, CPU fallback utilities, telemetry normalization, and the TUI
+- `stormlog` for PyTorch, CPU fallback utilities, telemetry normalization, inference profiling, local artifact queries, and the TUI
 - `stormlog.tensorflow` for TensorFlow profiling, tracking, and TensorFlow-specific analysis helpers
+- `stormlog.jax` for JAX profiling, tracking, diagnostics, and JAX-specific analysis helpers
 
 ## Package boundaries
 
@@ -30,6 +32,8 @@ The `stormlog` package owns:
 - `MemoryAnalyzer`, `GapFinding`, and collective-attribution helpers
 - `TelemetryEventV2` plus telemetry conversion and validation utilities
 - device collector abstractions in `device_collectors.py`
+- OpenAI-compatible inference profiling under `stormlog.infer`
+- local artifact queries under `stormlog.query` and `stormlog.query_cli`
 - the Textual TUI under `stormlog.tui`
 
 ### `stormlog.tensorflow`
@@ -43,7 +47,17 @@ The `stormlog.tensorflow` subpackage owns:
 - `TensorFlowAnalyzer` and `TensorFlowGapFinding`
 - TensorFlow runtime and backend diagnostics in `stormlog.tensorflow.utils`
 
-The TensorFlow package does not ship a separate TUI. The shared terminal UI is the `stormlog` entrypoint implemented in `stormlog.tui`.
+The TensorFlow package does not ship a separate TUI. The shared terminal UI
+lives in `stormlog.tui`; `stormlog.entrypoint` dispatches to that TUI or to
+top-level command groups such as `stormlog query` and `stormlog infer`.
+
+### `stormlog.jax`
+
+The `stormlog.jax` subpackage owns:
+
+- `JAXMemoryProfiler` for bounded JAX profiling
+- JAX tracking, diagnostics, visualization, and analyzer helpers
+- JAX runtime and device discovery helpers in `stormlog.jax.utils`
 
 ## High-level layering
 
@@ -55,14 +69,17 @@ User code / shell
     |     +-- stormlog.MemoryTracker / CPUMemoryTracker
     |     +-- stormlog.tensorflow.TFMemoryProfiler
     |     +-- stormlog.tensorflow.TensorFlowMemoryTracker
+    |     +-- stormlog.jax.JAXMemoryProfiler
     |
     +-- CLI entrypoints
     |     +-- gpumemprof
     |     +-- tfmemprof
-    |     +-- stormlog
+    |     +-- jaxmemprof
+    |     +-- stormlog / stormlog query / stormlog infer
     |
     +-- Shared artifact layer
           +-- TelemetryEventV2 JSON/CSV exports
+          +-- inference JSONL exports
           +-- diagnose bundles
           +-- PNG / HTML visualization outputs
 ```
@@ -143,6 +160,21 @@ Current concrete collectors:
 - `ROCmDeviceCollector`
 - `MPSDeviceCollector`
 
+### Inference profiling
+
+`stormlog.infer` owns active OpenAI-compatible endpoint profiling. It is kept
+separate from `gpumemprof` and `tfmemprof` because the endpoint backend may be
+PyTorch, vLLM, SGLang, TensorRT-LLM, MLX-LM, a hosted gateway, or another
+server.
+
+Current responsibilities:
+
+- build workload cases from concurrency, prompt token targets, and output caps
+- send Chat Completions requests and parse streaming or non-streaming responses
+- record client-observed request traces with token count provenance
+- write inference-specific JSONL artifacts
+- analyze those artifacts into latency, throughput, failure, and memory summaries
+
 ### Analyzers
 
 Analyzers turn raw or normalized memory data into higher-level findings.
@@ -175,7 +207,10 @@ The PyTorch-side visualizer also underpins the TUI plot export path for:
 
 ## TUI architecture
 
-The `stormlog` console script points to `stormlog.tui:run_app`.
+The `stormlog` console script points to `stormlog.entrypoint:main`. Running
+`stormlog` with no arguments still launches `stormlog.tui:run_app`; command
+groups such as `stormlog query` and `stormlog infer` dispatch through the same
+top-level entrypoint.
 
 The TUI is assembled from:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,14 +2,17 @@
 
 # Command Line Guide
 
-Stormlog currently exposes three console scripts:
+Stormlog currently exposes four console scripts:
 
 - `gpumemprof`
 - `tfmemprof`
 - `jaxmemprof`
 - `stormlog`
 
-Use `gpumemprof` and `tfmemprof` for automation. Use `stormlog` when you want the Textual TUI.
+Use `gpumemprof`, `tfmemprof`, and `jaxmemprof` for framework memory
+automation. Use `stormlog` with no arguments when you want the Textual TUI,
+`stormlog query` when you want local artifact queries, or `stormlog infer` when
+you want OpenAI-compatible inference endpoint profiling.
 
 If you want task-oriented operational recipes instead of option-by-option
 guidance, use the [Production Cookbook](cookbook/index.md), especially
@@ -23,6 +26,9 @@ guidance, use the [Production Cookbook](cookbook/index.md), especially
 gpumemprof --help
 tfmemprof --help
 jaxmemprof --help
+stormlog --help
+stormlog query --help
+stormlog infer --help
 ```
 
 If you are working from a repository checkout, `pip install -e .` also exposes
@@ -35,9 +41,52 @@ pip install "stormlog[tui,torch]"
 stormlog
 ```
 
-The `stormlog` command is also a small dispatcher. Running it without
-arguments still launches the TUI, while `stormlog query ...` runs the local
-artifact query CLI without importing Textual.
+## `stormlog`
+
+The top-level `stormlog` command is TUI-first for compatibility:
+
+```bash
+stormlog       # launch the TUI
+stormlog tui   # launch the TUI explicitly
+```
+
+The command also dispatches non-TUI workflows without importing Textual:
+
+```bash
+stormlog query --help
+stormlog infer --help
+```
+
+### Profile OpenAI-compatible inference
+
+Use `stormlog infer profile` for active endpoint profiling:
+
+```bash
+stormlog infer profile \
+  --base-url http://localhost:8000/v1 \
+  --model Qwen/Qwen2.5-7B-Instruct \
+  --concurrency 1,4,8 \
+  --input-tokens 512,2048 \
+  --output-tokens 128,512 \
+  --requests 20 \
+  --output artifacts/infer_qwen.jsonl
+```
+
+The artifact is newline-delimited JSON with one session record, request traces,
+optional system samples, and a summary record. Analyze it with:
+
+```bash
+stormlog infer analyze artifacts/infer_qwen.jsonl
+stormlog infer analyze artifacts/infer_qwen.jsonl --format json --output report.json
+```
+
+For token fallback support beyond server usage metadata, install:
+
+```bash
+pip install "stormlog[infer-tokenizers]"
+```
+
+See [Inference Profiling](inference.md) for the full endpoint profiling guide.
 
 ## `gpumemprof`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,10 +2,11 @@
 
 # Stormlog Documentation
 
-Stormlog ships three surfaces that should be treated as one workflow:
+Stormlog ships four surfaces that should be treated as one workflow:
 
 - Python APIs for profiling or tracking inside code
 - CLI commands for telemetry capture and artifact generation
+- OpenAI-compatible inference endpoint profiling
 - a Textual TUI for live monitoring, visualization export, and diagnostics
 
 Use the guides below based on the job you are doing, not based on package internals.
@@ -15,8 +16,8 @@ Use the guides below based on the job you are doing, not based on package intern
 **If you installed Stormlog via `pip install stormlog`** (from PyPI):
 
 - The `examples/` package is **not** included. Commands like `python -m examples.cli.quickstart` will fail with `ModuleNotFoundError`.
-- Use the CLI commands and Python snippets in this documentation instead. The `gpumemprof`, `tfmemprof`, and `jaxmemprof` CLIs and the public Python APIs work with a pip install.
-- Install `stormlog[tui,torch]` if you want the `stormlog` TUI entrypoint from a pip install.
+- Use the CLI commands and Python snippets in this documentation instead. The `gpumemprof`, `tfmemprof`, and `jaxmemprof` CLIs, `stormlog query`, `stormlog infer`, and the public Python APIs work with a pip install.
+- Install `stormlog[tui,torch]` if you want `stormlog` or `stormlog tui` to launch the TUI from a pip install.
 - The TUI **Capability Matrix** and **OOM scenario** buttons run example modules. If those fail, use the inline command runner in the TUI with the equivalent CLI commands from this guide.
 
 **If you cloned the repository** and installed with `pip install -e .`:
@@ -30,6 +31,7 @@ Use the guides below based on the job you are doing, not based on package intern
 installation
 usage
 cli
+inference
 tui
 cookbook/index
 cookbook/always_on
@@ -71,9 +73,10 @@ examples/test_guides/README
 ### Debugging a real run
 
 1. [CLI](cli.md)
-2. [TUI](tui.md)
-3. [Production Cookbook](cookbook/index.md)
-4. [Troubleshooting](troubleshooting.md)
+2. [Inference Profiling](inference.md)
+3. [TUI](tui.md)
+4. [Production Cookbook](cookbook/index.md)
+5. [Troubleshooting](troubleshooting.md)
 
 ### Release or CI validation
 

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -1,0 +1,147 @@
+[← Back to main docs](index.md)
+
+# Inference Profiling
+
+Stormlog can actively profile OpenAI-compatible Chat Completions endpoints with
+the top-level `stormlog infer` command group. This surface is intentionally
+separate from `gpumemprof` and `tfmemprof`: the endpoint may be backed by
+PyTorch, vLLM, SGLang, TensorRT-LLM, MLX-LM, a hosted gateway, or another
+server that accepts the Chat Completions request shape.
+
+## Profile an endpoint
+
+```bash
+stormlog infer profile \
+  --endpoint http://localhost:8000/v1/chat/completions \
+  --model Qwen/Qwen2.5-7B-Instruct \
+  --concurrency 1,4,8 \
+  --input-tokens 512,2048 \
+  --output-tokens 128,512 \
+  --requests 20 \
+  --output artifacts/infer_qwen.jsonl
+```
+
+You can pass a `/v1` base URL instead of the full endpoint:
+
+```bash
+stormlog infer profile \
+  --base-url http://localhost:8000/v1 \
+  --model Qwen/Qwen2.5-7B-Instruct \
+  --concurrency 8 \
+  --input-tokens 2048 \
+  --output-tokens 512 \
+  --duration 120 \
+  --output artifacts/infer_steady_state.jsonl
+```
+
+The profiler sends controlled traffic for each workload case in the matrix:
+
+- `concurrency`
+- prompt token target
+- output token cap
+- streaming or non-streaming mode
+
+`--requests` is the total measured request count per workload case, shared
+across the configured workers. `--duration` instead runs each workload case for
+the requested wall-clock window.
+
+Warmup requests are recorded but excluded from analysis:
+
+```bash
+stormlog infer profile \
+  --base-url http://localhost:8000/v1 \
+  --model Qwen/Qwen2.5-7B-Instruct \
+  --warmup-requests 8 \
+  --requests 50 \
+  --output artifacts/infer_with_warmup.jsonl
+```
+
+## Analyze an artifact
+
+```bash
+stormlog infer analyze artifacts/infer_qwen.jsonl
+stormlog infer analyze artifacts/infer_qwen.jsonl --format json --output report.json
+```
+
+The report includes:
+
+- end-to-end latency percentiles
+- TTFT percentiles for streaming responses
+- first streamed chunk latency
+- requests/sec
+- output tokens/sec and total tokens/sec
+- failure rate
+- peak sampled device memory when system telemetry is available
+
+## Token accounting
+
+Server usage metadata is preferred whenever the endpoint returns it. If usage is
+missing, Stormlog falls back to the configured tokenizer and records the source
+on every request event:
+
+- `server_usage`
+- `tiktoken`
+- `transformers`
+- `estimated`
+- `unknown`
+
+Core endpoint profiling does not require tokenizer packages. Install tokenizer
+extras when you want better prompt sizing and fallback counts:
+
+```bash
+pip install "stormlog[infer-tokenizers]"
+```
+
+Useful tokenizer options:
+
+```bash
+stormlog infer profile \
+  --base-url http://localhost:8000/v1 \
+  --model Qwen/Qwen2.5-7B-Instruct \
+  --tokenizer transformers \
+  --tokenizer-model Qwen/Qwen2.5-7B-Instruct \
+  --output artifacts/infer_qwen.jsonl
+```
+
+For OpenAI-model tokenizers:
+
+```bash
+stormlog infer profile \
+  --endpoint https://api.openai.com/v1/chat/completions \
+  --model gpt-4o-mini \
+  --tokenizer tiktoken \
+  --tiktoken-encoding o200k_base \
+  --output artifacts/infer_openai.jsonl
+```
+
+## Metric boundaries
+
+Stormlog reports client-observed metrics in v1:
+
+- TTFT is measured from request start to the first non-empty streamed content
+  delta.
+- Non-streaming responses do not have TTFT or chunk timing.
+- Chunk inter-arrival timing is chunk-level timing. It is not treated as
+  token-level ITL unless a future engine adapter can prove token-level events.
+- Token throughput uses server usage when available; otherwise the configured
+  tokenizer or estimate is clearly recorded.
+
+## System telemetry
+
+Use `--system-sampler` to choose best-effort telemetry:
+
+```bash
+stormlog infer profile ... --system-sampler nvidia-smi
+stormlog infer profile ... --system-sampler psutil
+stormlog infer profile ... --system-sampler none
+```
+
+Remote endpoints may not expose memory. In that case memory fields are omitted,
+not filled with synthetic zeroes.
+
+## Future engine adapters
+
+The v1 request path is engine-agnostic. Future adapters can enrich the same run
+with engine-native telemetry such as vLLM scheduler metrics, SGLang cache
+metrics, TensorRT-LLM inflight batching metrics, or MLX Metal runtime stats
+without changing the core `stormlog infer profile` artifact shape.

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -85,6 +85,12 @@ on every request event:
 - `estimated`
 - `unknown`
 
+When streaming is enabled, Stormlog requests OpenAI-style streaming usage
+metadata with `stream_options.include_usage` by default. Use
+`--no-stream-usage` for endpoints that reject that request field. If streaming
+usage is unavailable, output token counts fall back to the configured tokenizer
+or estimate and the request event records that provenance.
+
 Core endpoint profiling does not require tokenizer packages. Install tokenizer
 extras when you want better prompt sizing and fallback counts:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,16 +9,17 @@ Use the smallest install that matches your workflow, then validate the console s
 ## Install name vs import names
 
 Install the distribution as `stormlog`, then import the Python APIs from
-`stormlog` or `stormlog.tensorflow`:
+`stormlog`, `stormlog.tensorflow`, or `stormlog.jax`:
 
 | Task | Use |
 | --- | --- |
 | Install from PyPI | `pip install stormlog` |
-| Launch the TUI | `stormlog` |
+| Launch the TUI | `stormlog` or `stormlog tui` |
+| Profile OpenAI-compatible inference | `stormlog infer profile` |
 | Import PyTorch APIs | `from stormlog import GPUMemoryProfiler, MemoryTracker` |
 | Import TensorFlow APIs | `from stormlog.tensorflow import TFMemoryProfiler` |
 | Import JAX APIs | `from stormlog.jax import JAXMemoryProfiler` |
-| Run CLI automation | `gpumemprof`, `tfmemprof`, or `jaxmemprof` |
+| Run framework memory CLI automation | `gpumemprof`, `tfmemprof`, or `jaxmemprof` |
 
 ### Core package
 
@@ -54,6 +55,21 @@ pip install "stormlog[tui,torch]"
 
 Installs the Textual stack plus the current PyTorch runtime dependency required by TUI startup. The `stormlog` console script is declared by the package; these extras make the app runnable.
 
+The `stormlog` command remains TUI-first: running it with no arguments launches
+the TUI. Use `stormlog query ...` for local artifact queries and
+`stormlog infer ...` for OpenAI-compatible inference profiling.
+
+### Inference tokenizer extras
+
+```bash
+pip install "stormlog[infer-tokenizers]"
+```
+
+Core `stormlog infer profile` uses the standard library HTTP stack and can run
+without tokenizer packages. Install this extra when you want `tiktoken` or
+`transformers` fallback token counts for endpoints that do not return usage
+metadata.
+
 ### Framework extras
 
 ```bash
@@ -63,7 +79,8 @@ pip install "stormlog[jax]"
 pip install "stormlog[all]"
 ```
 
-`stormlog[all]` installs every runtime extra: `viz`, `tui`, `torch`, `tf`, and `jax`.
+`stormlog[all]` installs every runtime extra: `viz`, `tui`, `torch`, `tf`,
+`jax`, `infer-tokenizers`, and W&B.
 
 ## Source checkout
 
@@ -120,6 +137,14 @@ If you installed the TUI dependencies:
 
 ```bash
 stormlog
+stormlog tui
+```
+
+### Inference verification
+
+```bash
+stormlog infer --help
+stormlog infer profile --help
 ```
 
 If TUI dependencies are missing after a source checkout, reinstall with:
@@ -158,10 +183,13 @@ gpumemprof --help
 ### `stormlog: command not found`
 
 ```bash
-pip install -e ".[tui,torch]"
+pip install -e .
 hash -r
-stormlog
+stormlog --help
 ```
+
+Install `stormlog[tui,torch]` as well if you want `stormlog` with no
+arguments to launch the TUI successfully.
 
 ### Missing framework imports
 
@@ -177,7 +205,8 @@ pip install "stormlog[jax]"
 
 1. Read the [Usage Guide](usage.md) for the Python API and CLI-first workflow.
 2. Read the [CLI Guide](cli.md) if you need telemetry, plots, or diagnose bundles.
-3. Read the [TUI Guide](tui.md) if you want an interactive terminal workflow.
+3. Read the [Inference Profiling Guide](inference.md) if you profile serving endpoints.
+4. Read the [TUI Guide](tui.md) if you want an interactive terminal workflow.
 
 ---
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -9,6 +9,10 @@ pip install "stormlog[tui,torch]"
 stormlog
 ```
 
+Running `stormlog` with no arguments still launches the TUI. The explicit
+`stormlog tui` form is also available when you want to distinguish the TUI from
+other top-level command groups such as `stormlog infer`.
+
 If you are working from a source checkout, reinstall with the TUI dependencies so the current app startup requirements are present:
 
 ```bash

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,6 +5,7 @@
 This guide focuses on the workflows that are stable in the current codebase:
 
 - profile a bounded section of code
+- profile an OpenAI-compatible inference endpoint
 - track memory over time
 - export telemetry and plots
 - move from runtime data to a diagnose bundle or TUI session
@@ -16,8 +17,10 @@ the [Production Cookbook](cookbook/index.md), especially
 [TensorFlow Production Recipes](cookbook/tensorflow.md).
 
 Install the distribution as `stormlog`, then import the Python APIs from
-`stormlog`, `stormlog.tensorflow`, or `stormlog.jax`. The CLI automation commands are
-`gpumemprof`, `tfmemprof`, and `jaxmemprof`.
+`stormlog`, `stormlog.tensorflow`, or `stormlog.jax`. The framework memory CLI
+automation commands are `gpumemprof`, `tfmemprof`, and `jaxmemprof`; local
+artifact queries live under `stormlog query`, and endpoint inference profiling
+lives under `stormlog infer`.
 
 ## Choose the right tool
 
@@ -51,6 +54,16 @@ Use when:
 - you need telemetry over time rather than one profiled call
 - you want backend-aware tracking on CUDA, ROCm, MPS, or CPU fallback paths
 - you want alerts, exported event streams, or diagnose bundles
+
+### `stormlog infer`
+
+Use when:
+
+- you want to profile an OpenAI-compatible Chat Completions endpoint
+- the backend may be vLLM, SGLang, TensorRT-LLM, MLX-LM, a hosted gateway, or
+  another OpenAI-compatible server
+- you care about client-observed TTFT, latency, throughput, token rates,
+  failures, and optional host/GPU telemetry
 
 ### `CPUMemoryProfiler` / `CPUMemoryTracker`
 
@@ -99,6 +112,38 @@ python -m examples.cli.capability_matrix --mode smoke --target both --oom-mode s
 ```
 
 The `examples/` package is not included in the PyPI distribution.
+
+## OpenAI-compatible inference profiling
+
+Use `stormlog infer profile` to send controlled traffic to a Chat Completions
+endpoint and write a JSONL artifact:
+
+```bash
+stormlog infer profile \
+  --base-url http://localhost:8000/v1 \
+  --model Qwen/Qwen2.5-7B-Instruct \
+  --concurrency 1,4,8 \
+  --input-tokens 512,2048 \
+  --output-tokens 128,512 \
+  --requests 20 \
+  --output /tmp/stormlog_infer.jsonl
+```
+
+Analyze the artifact later:
+
+```bash
+stormlog infer analyze /tmp/stormlog_infer.jsonl
+```
+
+Install optional tokenizer dependencies when server usage metadata is missing
+and you need stronger fallback token counts:
+
+```bash
+pip install "stormlog[infer-tokenizers]"
+```
+
+See the [Inference Profiling Guide](inference.md) for metric boundaries,
+token count provenance, streaming behavior, and system telemetry options.
 
 ## PyTorch profiling
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,11 @@ torch = [
 tf = [
     "tensorflow>=2.4.0",
 ]
+infer-tokenizers = [
+    "tiktoken>=0.7",
+    "transformers>=4.40",
+    "sentencepiece>=0.2",
+]
 wandb = [
     "wandb>=0.19.0",
 ]
@@ -70,6 +75,9 @@ all = [
     "dash-bootstrap-components>=1.6.0",
     "torch>=1.8.0",
     "tensorflow>=2.4.0",
+    "tiktoken>=0.7",
+    "transformers>=4.40",
+    "sentencepiece>=0.2",
     "textual>=0.57.0",
     "pyfiglet>=1.0.2",
     "wandb>=0.19.0",
@@ -136,7 +144,7 @@ Repository = "https://github.com/Silas-Asamoah/stormlog.git"
 gpumemprof = "stormlog.cli:main"
 tfmemprof = "stormlog.tensorflow.cli:main"
 jaxmemprof = "stormlog.jax.cli:main"
-stormlog = "stormlog.tui:run_app"
+stormlog = "stormlog.entrypoint:main"
 
 [tool.setuptools_scm]
 fallback_version = "0.0.0"

--- a/stormlog/__main__.py
+++ b/stormlog/__main__.py
@@ -1,0 +1,6 @@
+"""Module execution support for `python -m stormlog`."""
+
+from .entrypoint import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/stormlog/entrypoint.py
+++ b/stormlog/entrypoint.py
@@ -32,6 +32,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         from .infer.cli import main as infer_main
 
         return infer_main(resolved_argv[1:])
+    if command == "query":
+        from .query_cli import main as query_main
+
+        return query_main(resolved_argv[1:])
     if command in {"-h", "--help"}:
         _build_parser().print_help()
         return 0
@@ -51,7 +55,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "command",
         nargs="?",
-        choices=["tui", "infer"],
+        choices=["tui", "query", "infer"],
         help="Command group. Omit to launch the TUI.",
     )
     return parser

--- a/stormlog/entrypoint.py
+++ b/stormlog/entrypoint.py
@@ -1,0 +1,61 @@
+"""Top-level Stormlog console entrypoint."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Sequence
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Dispatch the `stormlog` console script."""
+    resolved_argv = list(sys.argv[1:] if argv is None else argv)
+    if not resolved_argv:
+        from .tui import run_app
+
+        run_app()
+        return 0
+
+    command = resolved_argv[0]
+    if command == "tui":
+        if len(resolved_argv) > 1:
+            tui_parser = argparse.ArgumentParser(
+                prog="stormlog tui",
+                description="Launch the Stormlog Textual TUI.",
+            )
+            tui_parser.parse_args(resolved_argv[1:])
+        from .tui import run_app
+
+        run_app()
+        return 0
+    if command == "infer":
+        from .infer.cli import main as infer_main
+
+        return infer_main(resolved_argv[1:])
+    if command in {"-h", "--help"}:
+        _build_parser().print_help()
+        return 0
+
+    parser = _build_parser()
+    parser.error(f"unknown command: {command}")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="stormlog",
+        description=(
+            "Stormlog command surface. Running `stormlog` with no arguments "
+            "opens the Textual TUI."
+        ),
+    )
+    parser.add_argument(
+        "command",
+        nargs="?",
+        choices=["tui", "infer"],
+        help="Command group. Omit to launch the TUI.",
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/stormlog/infer/__init__.py
+++ b/stormlog/infer/__init__.py
@@ -1,0 +1,17 @@
+"""Inference profiling helpers for OpenAI-compatible serving endpoints."""
+
+__all__ = ["InferenceProfiler", "analyze_inference_events", "run_profile"]
+
+
+def __getattr__(name: str) -> object:
+    if name == "analyze_inference_events":
+        from .analysis import analyze_inference_events
+
+        return analyze_inference_events
+    if name in {"InferenceProfiler", "run_profile"}:
+        from .profile import InferenceProfiler, run_profile
+
+        return {"InferenceProfiler": InferenceProfiler, "run_profile": run_profile}[
+            name
+        ]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/stormlog/infer/analysis.py
+++ b/stormlog/infer/analysis.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, TypeGuard
 
 
 def analyze_inference_events(path: str | Path) -> dict[str, Any]:
@@ -28,10 +28,12 @@ def analyze_inference_events(path: str | Path) -> dict[str, Any]:
         case_id = str(record.get("case_id", "unknown"))
         grouped.setdefault(case_id, []).append(record)
 
-    cases = {
-        case_id: _summarize_requests(case_requests, samples=samples)
-        for case_id, case_requests in sorted(grouped.items())
-    }
+    cases = {}
+    for case_id, case_requests in sorted(grouped.items()):
+        cases[case_id] = _summarize_requests(
+            case_requests,
+            samples=_samples_for_request_window(samples, case_requests),
+        )
     failed = [record for record in requests if record.get("status") != "ok"]
     return {
         "summary": {
@@ -149,11 +151,38 @@ def _summarize_requests(
     }
 
 
+def _samples_for_request_window(
+    samples: list[dict[str, Any]],
+    requests: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    started = [
+        _int_value(record.get("started_at_ns"))
+        for record in requests
+        if _is_number(record.get("started_at_ns"))
+    ]
+    ended = [
+        _int_value(record.get("ended_at_ns"))
+        for record in requests
+        if _is_number(record.get("ended_at_ns"))
+    ]
+    if not started or not ended:
+        return []
+
+    start_ns = min(started)
+    end_ns = max(ended)
+    return [
+        sample
+        for sample in samples
+        if _is_number(sample.get("timestamp_ns"))
+        and start_ns <= _int_value(sample.get("timestamp_ns")) <= end_ns
+    ]
+
+
 def _number_values(records: Iterable[dict[str, Any]], field: str) -> list[float]:
     values: list[float] = []
     for record in records:
         value = record.get(field)
-        if isinstance(value, (int, float)) and not isinstance(value, bool):
+        if _is_number(value):
             values.append(float(value))
     return values
 
@@ -177,6 +206,10 @@ def _int_value(value: Any) -> int:
     if isinstance(value, float):
         return int(value)
     return 0
+
+
+def _is_number(value: Any) -> TypeGuard[int | float]:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
 
 
 def _fmt(value: Any) -> str:

--- a/stormlog/infer/analysis.py
+++ b/stormlog/infer/analysis.py
@@ -1,0 +1,185 @@
+"""Analysis helpers for inference profiling artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+
+def analyze_inference_events(path: str | Path) -> dict[str, Any]:
+    """Analyze an inference profiling JSONL artifact."""
+    records = _load_jsonl(path)
+    requests = [
+        record
+        for record in records
+        if record.get("event_type") == "infer.request"
+        and record.get("phase") == "measured"
+    ]
+    samples = [
+        record
+        for record in records
+        if record.get("event_type") == "infer.system_sample"
+    ]
+    ok_requests = [record for record in requests if record.get("status") == "ok"]
+
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for record in ok_requests:
+        case_id = str(record.get("case_id", "unknown"))
+        grouped.setdefault(case_id, []).append(record)
+
+    cases = {
+        case_id: _summarize_requests(case_requests, samples=samples)
+        for case_id, case_requests in sorted(grouped.items())
+    }
+    failed = [record for record in requests if record.get("status") != "ok"]
+    return {
+        "summary": {
+            "total_requests": len(requests),
+            "successful_requests": len(ok_requests),
+            "failed_requests": len(failed),
+            "failure_rate": (len(failed) / len(requests)) if requests else 0.0,
+            "case_count": len(cases),
+        },
+        "cases": cases,
+    }
+
+
+def format_analysis_text(report: dict[str, Any]) -> str:
+    """Render an inference analysis report as text."""
+    summary = report.get("summary", {})
+    lines = [
+        "Inference Profile Analysis",
+        "-" * 28,
+        f"Total requests: {summary.get('total_requests', 0)}",
+        f"Successful requests: {summary.get('successful_requests', 0)}",
+        f"Failed requests: {summary.get('failed_requests', 0)}",
+        f"Failure rate: {float(summary.get('failure_rate', 0.0)):.2%}",
+    ]
+    cases = report.get("cases", {})
+    if isinstance(cases, dict) and cases:
+        lines.append("")
+        lines.append("Cases:")
+        for case_id, case in cases.items():
+            latency = case.get("latency_ms", {}) if isinstance(case, dict) else {}
+            throughput = case.get("throughput", {}) if isinstance(case, dict) else {}
+            lines.append(
+                f"- {case_id}: "
+                f"p50 E2E={_fmt(latency.get('e2e_p50'))} ms, "
+                f"p95 E2E={_fmt(latency.get('e2e_p95'))} ms, "
+                f"p50 TTFT={_fmt(latency.get('ttft_p50'))} ms, "
+                f"output={_fmt(throughput.get('output_tokens_per_second'))} tok/s, "
+                f"requests={_fmt(throughput.get('requests_per_second'))} req/s"
+            )
+    return "\n".join(lines)
+
+
+def _load_jsonl(path: str | Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    with Path(path).open("r", encoding="utf-8") as handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            payload = json.loads(line)
+            if not isinstance(payload, dict):
+                raise ValueError(f"Line {line_number} is not a JSON object")
+            records.append(payload)
+    return records
+
+
+def _summarize_requests(
+    requests: list[dict[str, Any]],
+    *,
+    samples: list[dict[str, Any]],
+) -> dict[str, Any]:
+    e2e = _number_values(requests, "e2e_latency_ms")
+    ttft = _number_values(requests, "ttft_ms")
+    first_chunk = _number_values(requests, "first_chunk_latency_ms")
+    output_tokens = sum(_int_value(record.get("output_tokens")) for record in requests)
+    total_tokens = sum(_int_value(record.get("total_tokens")) for record in requests)
+    started = [_int_value(record.get("started_at_ns")) for record in requests]
+    ended = [_int_value(record.get("ended_at_ns")) for record in requests]
+    duration_seconds = (
+        max(max(ended) - min(started), 0) / 1_000_000_000 if started else 0
+    )
+    request_count = len(requests)
+    output_tps = output_tokens / duration_seconds if duration_seconds > 0 else 0.0
+    total_tps = total_tokens / duration_seconds if duration_seconds > 0 else 0.0
+    request_rate = request_count / duration_seconds if duration_seconds > 0 else 0.0
+    peak_used = max(
+        (
+            _int_value(sample.get("device_used_bytes"))
+            for sample in samples
+            if sample.get("device_used_bytes") is not None
+        ),
+        default=None,
+    )
+    return {
+        "request_count": request_count,
+        "latency_ms": {
+            "e2e_p50": _percentile(e2e, 50),
+            "e2e_p95": _percentile(e2e, 95),
+            "e2e_p99": _percentile(e2e, 99),
+            "ttft_p50": _percentile(ttft, 50),
+            "ttft_p95": _percentile(ttft, 95),
+            "ttft_p99": _percentile(ttft, 99),
+            "first_chunk_p50": _percentile(first_chunk, 50),
+            "first_chunk_p95": _percentile(first_chunk, 95),
+        },
+        "throughput": {
+            "duration_seconds": duration_seconds,
+            "requests_per_second": request_rate,
+            "output_tokens_per_second": output_tps,
+            "total_tokens_per_second": total_tps,
+        },
+        "tokens": {
+            "output_tokens": output_tokens,
+            "total_tokens": total_tokens,
+            "output_token_sources": sorted(
+                {
+                    str(record.get("output_token_source", "unknown"))
+                    for record in requests
+                }
+            ),
+        },
+        "memory": {
+            "peak_device_used_bytes": peak_used,
+        },
+    }
+
+
+def _number_values(records: Iterable[dict[str, Any]], field: str) -> list[float]:
+    values: list[float] = []
+    for record in records:
+        value = record.get(field)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            values.append(float(value))
+    return values
+
+
+def _percentile(values: list[float], percentile: int) -> float | None:
+    if not values:
+        return None
+    sorted_values = sorted(values)
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    rank = (percentile / 100.0) * (len(sorted_values) - 1)
+    lower = int(rank)
+    upper = min(lower + 1, len(sorted_values) - 1)
+    weight = rank - lower
+    return sorted_values[lower] * (1.0 - weight) + sorted_values[upper] * weight
+
+
+def _int_value(value: Any) -> int:
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return 0
+
+
+def _fmt(value: Any) -> str:
+    if isinstance(value, (int, float)):
+        return f"{float(value):.2f}"
+    return "-"

--- a/stormlog/infer/cli.py
+++ b/stormlog/infer/cli.py
@@ -115,6 +115,19 @@ def build_parser() -> argparse.ArgumentParser:
         help="Use non-streaming chat completions",
     )
     profile_parser.add_argument(
+        "--stream-usage",
+        dest="stream_usage",
+        action="store_true",
+        default=True,
+        help="Request streaming usage metadata with stream_options.include_usage",
+    )
+    profile_parser.add_argument(
+        "--no-stream-usage",
+        dest="stream_usage",
+        action="store_false",
+        help="Do not send stream_options.include_usage for streaming requests",
+    )
+    profile_parser.add_argument(
         "--api-key",
         default=None,
         help="Bearer token. Defaults to OPENAI_API_KEY when set.",
@@ -213,6 +226,7 @@ def cmd_profile(args: argparse.Namespace) -> int:
         duration_seconds=args.duration,
         request_count=None if args.duration is not None else args.requests,
         stream=bool(args.stream),
+        stream_include_usage=bool(args.stream_usage),
         timeout_seconds=float(args.timeout),
         warmup_requests=int(args.warmup_requests),
         output_path=args.output,

--- a/stormlog/infer/cli.py
+++ b/stormlog/infer/cli.py
@@ -1,0 +1,253 @@
+"""CLI for Stormlog inference profiling."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from .analysis import analyze_inference_events, format_analysis_text
+from .config import ProfileConfig, parse_int_list, resolve_endpoint
+from .profile import run_profile
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the inference CLI."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.infer_command is None:
+        parser.print_help()
+        return 0
+    try:
+        if args.infer_command == "profile":
+            return cmd_profile(args)
+        if args.infer_command == "analyze":
+            return cmd_analyze(args)
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    parser.error(f"Unsupported infer command: {args.infer_command}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the `stormlog infer` parser."""
+    parser = argparse.ArgumentParser(
+        prog="stormlog infer",
+        description="Profile OpenAI-compatible inference endpoints",
+    )
+    subparsers = parser.add_subparsers(
+        dest="infer_command",
+        help="Inference commands",
+    )
+
+    profile_parser = subparsers.add_parser(
+        "profile",
+        help="Run active inference profiling traffic",
+    )
+    endpoint_group = profile_parser.add_mutually_exclusive_group(required=True)
+    endpoint_group.add_argument(
+        "--endpoint",
+        help="Full /v1/chat/completions endpoint URL",
+    )
+    endpoint_group.add_argument(
+        "--base-url",
+        help="OpenAI-compatible /v1 base URL",
+    )
+    profile_parser.add_argument("--model", required=True, help="Model name")
+    profile_parser.add_argument(
+        "--concurrency",
+        default="1",
+        help="Comma-separated concurrency levels (default: 1)",
+    )
+    profile_parser.add_argument(
+        "--input-tokens",
+        default="512",
+        help="Comma-separated prompt token targets (default: 512)",
+    )
+    profile_parser.add_argument(
+        "--output-tokens",
+        default="128",
+        help="Comma-separated output token caps (default: 128)",
+    )
+    profile_parser.add_argument(
+        "--duration",
+        type=float,
+        default=None,
+        help="Measured duration per workload case in seconds",
+    )
+    profile_parser.add_argument(
+        "--requests",
+        type=int,
+        default=1,
+        help="Total measured request count per workload case (default: 1)",
+    )
+    profile_parser.add_argument(
+        "--output",
+        required=True,
+        help="Output JSONL artifact path",
+    )
+    profile_parser.add_argument(
+        "--timeout",
+        type=float,
+        default=60.0,
+        help="Per-request timeout in seconds (default: 60)",
+    )
+    profile_parser.add_argument(
+        "--warmup-requests",
+        type=int,
+        default=0,
+        help="Warmup requests per workload case, excluded from analysis",
+    )
+    profile_parser.add_argument(
+        "--stream",
+        dest="stream",
+        action="store_true",
+        default=True,
+        help="Use streaming chat completions (default)",
+    )
+    profile_parser.add_argument(
+        "--no-stream",
+        dest="stream",
+        action="store_false",
+        help="Use non-streaming chat completions",
+    )
+    profile_parser.add_argument(
+        "--api-key",
+        default=None,
+        help="Bearer token. Defaults to OPENAI_API_KEY when set.",
+    )
+    profile_parser.add_argument(
+        "--max-tokens-field",
+        choices=["max_tokens", "max_completion_tokens"],
+        default="max_tokens",
+        help="Output cap field to send (default: max_tokens)",
+    )
+    profile_parser.add_argument(
+        "--tokenizer",
+        choices=["auto", "none", "tiktoken", "transformers"],
+        default="auto",
+        help="Tokenizer for prompt generation and fallback counts",
+    )
+    profile_parser.add_argument(
+        "--tokenizer-model",
+        default=None,
+        help="Tokenizer model/path override",
+    )
+    profile_parser.add_argument(
+        "--tiktoken-encoding",
+        default=None,
+        help="Explicit tiktoken encoding, such as cl100k_base or o200k_base",
+    )
+    profile_parser.add_argument(
+        "--strict-token-counts",
+        action="store_true",
+        help="Fail instead of falling back to estimated token counts",
+    )
+    profile_parser.add_argument(
+        "--system-sampler",
+        choices=["auto", "none", "psutil", "nvidia-smi"],
+        default="auto",
+        help="Best-effort telemetry sampler (default: auto)",
+    )
+    profile_parser.add_argument(
+        "--sample-interval",
+        type=float,
+        default=1.0,
+        help="System sample interval in seconds (default: 1)",
+    )
+    profile_parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="Deterministic prompt seed (default: 0)",
+    )
+
+    analyze_parser = subparsers.add_parser(
+        "analyze",
+        help="Analyze an inference profiling JSONL artifact",
+    )
+    analyze_parser.add_argument("input_file", help="Input inference JSONL artifact")
+    analyze_parser.add_argument(
+        "--output",
+        default=None,
+        help="Optional report output path",
+    )
+    analyze_parser.add_argument(
+        "--format",
+        choices=["txt", "json"],
+        default="txt",
+        help="Report format (default: txt)",
+    )
+    return parser
+
+
+def cmd_profile(args: argparse.Namespace) -> int:
+    """Run active inference profiling."""
+    if args.duration is not None and args.duration <= 0:
+        raise ValueError("--duration must be > 0")
+    if args.requests is not None and args.requests <= 0:
+        raise ValueError("--requests must be >= 1")
+    if args.duration is not None and args.requests != 1:
+        raise ValueError("Use either --duration or --requests, not both")
+    if args.timeout <= 0:
+        raise ValueError("--timeout must be > 0")
+    if args.warmup_requests < 0:
+        raise ValueError("--warmup-requests must be >= 0")
+    if args.sample_interval <= 0:
+        raise ValueError("--sample-interval must be > 0")
+
+    endpoint = resolve_endpoint(endpoint=args.endpoint, base_url=args.base_url)
+    config = ProfileConfig(
+        endpoint=endpoint,
+        model=args.model,
+        concurrency=tuple(parse_int_list(args.concurrency, field_name="concurrency")),
+        input_tokens=tuple(
+            parse_int_list(args.input_tokens, field_name="input-tokens")
+        ),
+        output_tokens=tuple(
+            parse_int_list(args.output_tokens, field_name="output-tokens")
+        ),
+        duration_seconds=args.duration,
+        request_count=None if args.duration is not None else args.requests,
+        stream=bool(args.stream),
+        timeout_seconds=float(args.timeout),
+        warmup_requests=int(args.warmup_requests),
+        output_path=args.output,
+        api_key=args.api_key or os.environ.get("OPENAI_API_KEY"),
+        max_tokens_field=args.max_tokens_field,
+        tokenizer=args.tokenizer,
+        tokenizer_model=args.tokenizer_model,
+        tiktoken_encoding=args.tiktoken_encoding,
+        strict_token_counts=bool(args.strict_token_counts),
+        system_sampler=args.system_sampler,
+        sample_interval_seconds=float(args.sample_interval),
+        seed=int(args.seed),
+    )
+    report = run_profile(config)
+    print(format_analysis_text(report))
+    print(f"Artifact saved to: {Path(args.output)}")
+    return 0
+
+
+def cmd_analyze(args: argparse.Namespace) -> int:
+    """Analyze an inference JSONL artifact."""
+    input_path = Path(args.input_file)
+    if not input_path.exists():
+        print(f"Error: Input file '{args.input_file}' not found", file=sys.stderr)
+        return 1
+    report = analyze_inference_events(input_path)
+    if args.format == "json":
+        payload = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    else:
+        payload = format_analysis_text(report) + "\n"
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(payload, encoding="utf-8")
+        print(f"Analysis report saved to: {output_path}")
+    else:
+        print(payload, end="")
+    return 0

--- a/stormlog/infer/cli.py
+++ b/stormlog/infer/cli.py
@@ -229,6 +229,13 @@ def cmd_profile(args: argparse.Namespace) -> int:
     report = run_profile(config)
     print(format_analysis_text(report))
     print(f"Artifact saved to: {Path(args.output)}")
+    summary = report.get("summary", {})
+    if (
+        int(summary.get("total_requests", 0)) > 0
+        and int(summary.get("successful_requests", 0)) == 0
+    ):
+        print("Error: no measured inference requests succeeded", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/stormlog/infer/config.py
+++ b/stormlog/infer/config.py
@@ -61,6 +61,7 @@ class ProfileConfig:
     duration_seconds: float | None = None
     request_count: int | None = 1
     stream: bool = True
+    stream_include_usage: bool = True
     timeout_seconds: float = 60.0
     warmup_requests: int = 0
     seed: int = 0

--- a/stormlog/infer/config.py
+++ b/stormlog/infer/config.py
@@ -1,0 +1,90 @@
+"""Configuration models for inference profiling."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+DEFAULT_ENDPOINT_PATH = "/chat/completions"
+
+
+def parse_int_list(value: str, *, field_name: str) -> list[int]:
+    """Parse a comma-separated positive integer list."""
+    parsed: list[int] = []
+    for raw_item in value.split(","):
+        item = raw_item.strip()
+        if not item:
+            continue
+        try:
+            number = int(item)
+        except ValueError as exc:
+            raise ValueError(f"{field_name} must contain integers") from exc
+        if number <= 0:
+            raise ValueError(f"{field_name} values must be >= 1")
+        parsed.append(number)
+    if not parsed:
+        raise ValueError(f"{field_name} must contain at least one value")
+    return parsed
+
+
+def resolve_endpoint(*, endpoint: str | None, base_url: str | None) -> str:
+    """Resolve either a full chat-completions endpoint or a /v1 base URL."""
+    if endpoint and base_url:
+        raise ValueError("Use either --endpoint or --base-url, not both")
+    if endpoint:
+        return endpoint
+    if not base_url:
+        raise ValueError("One of --endpoint or --base-url is required")
+    return base_url.rstrip("/") + DEFAULT_ENDPOINT_PATH
+
+
+@dataclass(frozen=True)
+class WorkloadCase:
+    """One inference profiling workload shape."""
+
+    case_id: str
+    concurrency: int
+    input_tokens: int
+    output_tokens: int
+
+
+@dataclass(frozen=True)
+class ProfileConfig:
+    """Resolved configuration for one inference profiling run."""
+
+    endpoint: str
+    model: str
+    concurrency: tuple[int, ...]
+    input_tokens: tuple[int, ...]
+    output_tokens: tuple[int, ...]
+    output_path: str
+    duration_seconds: float | None = None
+    request_count: int | None = 1
+    stream: bool = True
+    timeout_seconds: float = 60.0
+    warmup_requests: int = 0
+    seed: int = 0
+    api_key: str | None = None
+    max_tokens_field: Literal["max_tokens", "max_completion_tokens"] = "max_tokens"
+    tokenizer: str = "auto"
+    tokenizer_model: str | None = None
+    tiktoken_encoding: str | None = None
+    strict_token_counts: bool = False
+    system_sampler: str = "auto"
+    sample_interval_seconds: float = 1.0
+
+    def cases(self) -> list[WorkloadCase]:
+        cases: list[WorkloadCase] = []
+        for concurrency in self.concurrency:
+            for input_tokens in self.input_tokens:
+                for output_tokens in self.output_tokens:
+                    case_id = f"c{concurrency}_in{input_tokens}_out{output_tokens}"
+                    cases.append(
+                        WorkloadCase(
+                            case_id=case_id,
+                            concurrency=concurrency,
+                            input_tokens=input_tokens,
+                            output_tokens=output_tokens,
+                        )
+                    )
+        return cases

--- a/stormlog/infer/events.py
+++ b/stormlog/infer/events.py
@@ -1,0 +1,123 @@
+"""Inference profiling event records and JSONL persistence."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, TextIO
+
+INFER_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class InferenceRequestEvent:
+    """Client-observed request trace for one chat completion."""
+
+    session_id: str
+    request_id: str
+    case_id: str
+    phase: str
+    started_at_ns: int
+    ended_at_ns: int
+    endpoint: str
+    model: str
+    concurrency: int
+    target_input_tokens: int
+    target_output_tokens: int
+    stream: bool
+    status: str
+    e2e_latency_ms: float | None
+    ttft_ms: float | None
+    first_chunk_latency_ms: float | None
+    chunk_interarrival_ms: list[float] = field(default_factory=list)
+    prompt_tokens: int | None = None
+    prompt_token_source: str = "unknown"
+    prompt_token_exact: bool = False
+    output_tokens: int | None = None
+    output_token_source: str = "unknown"
+    output_token_exact: bool = False
+    total_tokens: int | None = None
+    finish_reason: str | None = None
+    error_type: str | None = None
+    error_message: str | None = None
+
+    def to_record(self) -> dict[str, Any]:
+        record = asdict(self)
+        record.update(
+            {
+                "schema_version": INFER_SCHEMA_VERSION,
+                "event_type": "infer.request",
+                "timestamp_ns": self.started_at_ns,
+            }
+        )
+        return record
+
+
+@dataclass(frozen=True)
+class InferenceSystemSample:
+    """Best-effort system telemetry sampled during an inference profiling run."""
+
+    session_id: str
+    timestamp_ns: int
+    sampler: str
+    device_id: int | None = None
+    device_name: str | None = None
+    device_used_bytes: int | None = None
+    device_free_bytes: int | None = None
+    device_total_bytes: int | None = None
+    gpu_utilization_percent: float | None = None
+    process_rss_bytes: int | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_record(self) -> dict[str, Any]:
+        record = asdict(self)
+        record.update(
+            {
+                "schema_version": INFER_SCHEMA_VERSION,
+                "event_type": "infer.system_sample",
+            }
+        )
+        return record
+
+
+@dataclass(frozen=True)
+class InferenceSummaryEvent:
+    """Aggregate summary emitted at the end of a profiling run."""
+
+    session_id: str
+    timestamp_ns: int
+    summary: dict[str, Any]
+
+    def to_record(self) -> dict[str, Any]:
+        return {
+            "schema_version": INFER_SCHEMA_VERSION,
+            "event_type": "infer.summary",
+            "session_id": self.session_id,
+            "timestamp_ns": self.timestamp_ns,
+            "summary": self.summary,
+        }
+
+
+class JsonlEventWriter:
+    """Append inference profiling records to a JSONL artifact."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._handle: TextIO | None = None
+
+    def __enter__(self) -> "JsonlEventWriter":
+        self._handle = self.path.open("w", encoding="utf-8")
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        if self._handle is not None:
+            self._handle.close()
+            self._handle = None
+
+    def append(self, record: dict[str, Any]) -> None:
+        if self._handle is None:
+            raise RuntimeError("JsonlEventWriter is not open")
+        self._handle.write(json.dumps(record, sort_keys=True) + "\n")
+        self._handle.flush()

--- a/stormlog/infer/openai_client.py
+++ b/stormlog/infer/openai_client.py
@@ -49,6 +49,7 @@ class OpenAIChatCompletionsClient:
         prompt: str,
         output_tokens: int,
         stream: bool,
+        stream_include_usage: bool,
     ) -> ChatCompletionResult:
         payload = {
             "model": self.model,
@@ -56,6 +57,8 @@ class OpenAIChatCompletionsClient:
             "stream": stream,
             self.max_tokens_field: output_tokens,
         }
+        if stream and stream_include_usage:
+            payload["stream_options"] = {"include_usage": True}
         body = json.dumps(payload).encode("utf-8")
         headers = {
             "Content-Type": "application/json",

--- a/stormlog/infer/openai_client.py
+++ b/stormlog/infer/openai_client.py
@@ -1,0 +1,205 @@
+"""OpenAI-compatible Chat Completions client used by inference profiling."""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+
+@dataclass(frozen=True)
+class ChatCompletionResult:
+    """Parsed response and client-observed timing metadata."""
+
+    text: str
+    started_at_ns: int
+    ended_at_ns: int
+    e2e_latency_ms: float
+    ttft_ms: float | None
+    first_chunk_latency_ms: float | None
+    chunk_interarrival_ms: list[float] = field(default_factory=list)
+    usage: dict[str, Any] | None = None
+    finish_reason: str | None = None
+
+
+class OpenAIChatCompletionsClient:
+    """Minimal OpenAI-compatible Chat Completions HTTP client."""
+
+    def __init__(
+        self,
+        *,
+        endpoint: str,
+        model: str,
+        timeout_seconds: float,
+        api_key: str | None = None,
+        max_tokens_field: Literal["max_tokens", "max_completion_tokens"] = "max_tokens",
+    ) -> None:
+        self.endpoint = endpoint
+        self.model = model
+        self.timeout_seconds = timeout_seconds
+        self.api_key = api_key
+        self.max_tokens_field = max_tokens_field
+
+    def complete(
+        self,
+        *,
+        prompt: str,
+        output_tokens: int,
+        stream: bool,
+    ) -> ChatCompletionResult:
+        payload = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "stream": stream,
+            self.max_tokens_field: output_tokens,
+        }
+        body = json.dumps(payload).encode("utf-8")
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream" if stream else "application/json",
+        }
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        request = urllib.request.Request(
+            self.endpoint,
+            data=body,
+            headers=headers,
+            method="POST",
+        )
+
+        started_at_ns = time.time_ns()
+        started_perf = time.perf_counter()
+        try:
+            with urllib.request.urlopen(
+                request,
+                timeout=self.timeout_seconds,
+            ) as response:
+                if stream:
+                    return self._read_streaming_response(
+                        response=response,
+                        started_at_ns=started_at_ns,
+                        started_perf=started_perf,
+                    )
+                return self._read_json_response(
+                    response=response,
+                    started_at_ns=started_at_ns,
+                    started_perf=started_perf,
+                )
+        except urllib.error.HTTPError as exc:
+            message = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"HTTP {exc.code}: {message}") from exc
+
+    def _read_json_response(
+        self,
+        *,
+        response: Any,
+        started_at_ns: int,
+        started_perf: float,
+    ) -> ChatCompletionResult:
+        payload = json.loads(response.read().decode("utf-8"))
+        ended_at_ns = time.time_ns()
+        ended_perf = time.perf_counter()
+        choice = _first_choice(payload)
+        message = choice.get("message") if isinstance(choice, dict) else None
+        text = ""
+        if isinstance(message, dict):
+            text = str(message.get("content") or "")
+        finish_reason = (
+            str(choice.get("finish_reason"))
+            if isinstance(choice, dict) and choice.get("finish_reason") is not None
+            else None
+        )
+        usage = payload.get("usage") if isinstance(payload.get("usage"), dict) else None
+        return ChatCompletionResult(
+            text=text,
+            started_at_ns=started_at_ns,
+            ended_at_ns=ended_at_ns,
+            e2e_latency_ms=(ended_perf - started_perf) * 1000.0,
+            ttft_ms=None,
+            first_chunk_latency_ms=None,
+            usage=usage,
+            finish_reason=finish_reason,
+        )
+
+    def _read_streaming_response(
+        self,
+        *,
+        response: Any,
+        started_at_ns: int,
+        started_perf: float,
+    ) -> ChatCompletionResult:
+        content_parts: list[str] = []
+        first_chunk_perf: float | None = None
+        first_content_perf: float | None = None
+        previous_content_perf: float | None = None
+        chunk_interarrival_ms: list[float] = []
+        usage: dict[str, Any] | None = None
+        finish_reason: str | None = None
+
+        for raw_line in response:
+            line = raw_line.decode("utf-8", errors="replace").strip()
+            if not line or not line.startswith("data:"):
+                continue
+            data = line.removeprefix("data:").strip()
+            if data == "[DONE]":
+                break
+            now_perf = time.perf_counter()
+            if first_chunk_perf is None:
+                first_chunk_perf = now_perf
+
+            chunk = json.loads(data)
+            if isinstance(chunk.get("usage"), dict):
+                usage = chunk["usage"]
+            choice = _first_choice(chunk)
+            if isinstance(choice, dict) and choice.get("finish_reason") is not None:
+                finish_reason = str(choice.get("finish_reason"))
+            delta = choice.get("delta") if isinstance(choice, dict) else None
+            piece = ""
+            if isinstance(delta, dict):
+                piece = str(delta.get("content") or "")
+            if not piece:
+                continue
+            content_parts.append(piece)
+            if first_content_perf is None:
+                first_content_perf = now_perf
+            if previous_content_perf is not None:
+                chunk_interarrival_ms.append(
+                    (now_perf - previous_content_perf) * 1000.0
+                )
+            previous_content_perf = now_perf
+
+        ended_at_ns = time.time_ns()
+        ended_perf = time.perf_counter()
+        return ChatCompletionResult(
+            text="".join(content_parts),
+            started_at_ns=started_at_ns,
+            ended_at_ns=ended_at_ns,
+            e2e_latency_ms=(ended_perf - started_perf) * 1000.0,
+            ttft_ms=(
+                (first_content_perf - started_perf) * 1000.0
+                if first_content_perf is not None
+                else None
+            ),
+            first_chunk_latency_ms=(
+                (first_chunk_perf - started_perf) * 1000.0
+                if first_chunk_perf is not None
+                else None
+            ),
+            chunk_interarrival_ms=chunk_interarrival_ms,
+            usage=usage,
+            finish_reason=finish_reason,
+        )
+
+
+def _first_choice(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {}
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return {}
+    first = choices[0]
+    return first if isinstance(first, dict) else {}

--- a/stormlog/infer/profile.py
+++ b/stormlog/infer/profile.py
@@ -75,6 +75,7 @@ class InferenceProfiler:
                         "duration_seconds": self.config.duration_seconds,
                         "request_count": self.config.request_count,
                         "stream": self.config.stream,
+                        "stream_include_usage": self.config.stream_include_usage,
                         "tokenizer": self.config.tokenizer,
                         "system_sampler": self.sampler.name,
                     },
@@ -263,6 +264,7 @@ class InferenceProfiler:
                     prompt=prompt,
                     output_tokens=case.output_tokens,
                     stream=self.config.stream,
+                    stream_include_usage=self.config.stream_include_usage,
                 ),
             )
             output_count = _resolve_output_count(

--- a/stormlog/infer/profile.py
+++ b/stormlog/infer/profile.py
@@ -1,0 +1,374 @@
+"""Active inference profiling runner."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from ..session import (
+    create_session_summary,
+    finalize_session_summary,
+    session_summary_to_dict,
+)
+from .analysis import analyze_inference_events
+from .config import ProfileConfig, WorkloadCase
+from .events import InferenceRequestEvent, InferenceSummaryEvent, JsonlEventWriter
+from .openai_client import OpenAIChatCompletionsClient
+from .samplers import SystemSampler, build_system_sampler
+from .tokens import TokenCount, TokenCounter, build_token_counter, generate_prompt
+
+
+class InferenceProfiler:
+    """Profile an OpenAI-compatible chat completions endpoint."""
+
+    def __init__(self, config: ProfileConfig) -> None:
+        self.config = config
+        self.session = create_session_summary(source="stormlog.infer.profile")
+        self.token_counter = build_token_counter(
+            tokenizer=config.tokenizer,
+            model=config.model,
+            tokenizer_model=config.tokenizer_model,
+            tiktoken_encoding=config.tiktoken_encoding,
+            strict=config.strict_token_counts,
+        )
+        self.sampler = build_system_sampler(config.system_sampler)
+        self.client = OpenAIChatCompletionsClient(
+            endpoint=config.endpoint,
+            model=config.model,
+            timeout_seconds=config.timeout_seconds,
+            api_key=config.api_key,
+            max_tokens_field=config.max_tokens_field,
+        )
+
+    def run(self) -> dict[str, Any]:
+        """Run profiling and return an aggregate report."""
+        return asyncio.run(self._run_async())
+
+    async def _run_async(self) -> dict[str, Any]:
+        output_path = Path(self.config.output_path)
+        with JsonlEventWriter(output_path) as writer:
+            writer.append(
+                {
+                    "schema_version": 1,
+                    "event_type": "infer.session",
+                    "session_id": self.session.session_id,
+                    "timestamp_ns": self.session.started_at_ns,
+                    "status": "running",
+                    "config": {
+                        "endpoint": self.config.endpoint,
+                        "model": self.config.model,
+                        "concurrency": list(self.config.concurrency),
+                        "input_tokens": list(self.config.input_tokens),
+                        "output_tokens": list(self.config.output_tokens),
+                        "duration_seconds": self.config.duration_seconds,
+                        "request_count": self.config.request_count,
+                        "stream": self.config.stream,
+                        "tokenizer": self.config.tokenizer,
+                        "system_sampler": self.sampler.name,
+                    },
+                }
+            )
+            stop_sampling = asyncio.Event()
+            sample_task = asyncio.create_task(
+                self._sample_system_loop(
+                    writer=writer,
+                    sampler=self.sampler,
+                    stop_event=stop_sampling,
+                )
+            )
+            try:
+                for case in self.config.cases():
+                    await self._run_case(case=case, writer=writer)
+            finally:
+                stop_sampling.set()
+                await sample_task
+
+        report = analyze_inference_events(output_path)
+        with output_path.open("a", encoding="utf-8") as handle:
+            event = InferenceSummaryEvent(
+                session_id=self.session.session_id,
+                timestamp_ns=time.time_ns(),
+                summary=report,
+            )
+            completed_session = finalize_session_summary(self.session)
+            handle.write(json.dumps(event.to_record(), sort_keys=True) + "\n")
+            handle.write(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "event_type": "infer.session",
+                        "session_id": self.session.session_id,
+                        "timestamp_ns": completed_session.ended_at_ns,
+                        "status": completed_session.status,
+                        "summary": session_summary_to_dict(completed_session),
+                    },
+                    sort_keys=True,
+                )
+                + "\n"
+            )
+        return report
+
+    async def _sample_system_loop(
+        self,
+        *,
+        writer: JsonlEventWriter,
+        sampler: SystemSampler,
+        stop_event: asyncio.Event,
+    ) -> None:
+        while not stop_event.is_set():
+            try:
+                sample = await asyncio.to_thread(
+                    sampler.sample,
+                    session_id=self.session.session_id,
+                )
+            except Exception:
+                sample = None
+            if sample is not None:
+                writer.append(sample.to_record())
+            try:
+                await asyncio.wait_for(
+                    stop_event.wait(),
+                    timeout=self.config.sample_interval_seconds,
+                )
+            except asyncio.TimeoutError:
+                pass
+
+    async def _run_case(
+        self,
+        *,
+        case: WorkloadCase,
+        writer: JsonlEventWriter,
+    ) -> None:
+        prompt = generate_prompt(
+            case.input_tokens,
+            self.token_counter,
+            seed=self.config.seed + case.input_tokens,
+        )
+        prompt_count = self.token_counter.count_text(prompt)
+
+        if self.config.warmup_requests > 0:
+            await self._run_phase(
+                case=case,
+                writer=writer,
+                prompt=prompt,
+                prompt_count=prompt_count,
+                phase="warmup",
+                total_requests=self.config.warmup_requests,
+                duration_seconds=None,
+            )
+
+        await self._run_phase(
+            case=case,
+            writer=writer,
+            prompt=prompt,
+            prompt_count=prompt_count,
+            phase="measured",
+            total_requests=self.config.request_count,
+            duration_seconds=self.config.duration_seconds,
+        )
+
+    async def _run_phase(
+        self,
+        *,
+        case: WorkloadCase,
+        writer: JsonlEventWriter,
+        prompt: str,
+        prompt_count: TokenCount,
+        phase: str,
+        total_requests: int | None,
+        duration_seconds: float | None,
+    ) -> None:
+        if total_requests is None and duration_seconds is None:
+            total_requests = 1
+        counter = _RequestCounter(limit=total_requests)
+        end_time = (
+            time.monotonic() + duration_seconds
+            if duration_seconds is not None
+            else None
+        )
+        tasks = [
+            asyncio.create_task(
+                self._worker(
+                    worker_id=index,
+                    case=case,
+                    writer=writer,
+                    prompt=prompt,
+                    prompt_count=prompt_count,
+                    phase=phase,
+                    counter=counter,
+                    end_time=end_time,
+                )
+            )
+            for index in range(case.concurrency)
+        ]
+        await asyncio.gather(*tasks)
+
+    async def _worker(
+        self,
+        *,
+        worker_id: int,
+        case: WorkloadCase,
+        writer: JsonlEventWriter,
+        prompt: str,
+        prompt_count: TokenCount,
+        phase: str,
+        counter: "_RequestCounter",
+        end_time: float | None,
+    ) -> None:
+        while True:
+            if end_time is not None and time.monotonic() >= end_time:
+                return
+            request_index = await counter.next()
+            if request_index is None:
+                return
+            request_id = f"{case.case_id}_{phase}_{worker_id}_{request_index}"
+            event = await self._run_one_request(
+                request_id=request_id,
+                case=case,
+                prompt=prompt,
+                prompt_count=prompt_count,
+                phase=phase,
+            )
+            writer.append(event.to_record())
+
+    async def _run_one_request(
+        self,
+        *,
+        request_id: str,
+        case: WorkloadCase,
+        prompt: str,
+        prompt_count: TokenCount,
+        phase: str,
+    ) -> InferenceRequestEvent:
+        started_at_ns = time.time_ns()
+        started_perf = time.perf_counter()
+        try:
+            result = await asyncio.to_thread(
+                self.client.complete,
+                prompt=prompt,
+                output_tokens=case.output_tokens,
+                stream=self.config.stream,
+            )
+            output_count = _resolve_output_count(
+                result.usage,
+                result.text,
+                self.token_counter,
+            )
+            prompt_count = _resolve_prompt_count(result.usage, prompt_count)
+            total_tokens = _resolve_total_tokens(
+                result.usage,
+                prompt_count,
+                output_count,
+            )
+            return InferenceRequestEvent(
+                session_id=self.session.session_id,
+                request_id=request_id,
+                case_id=case.case_id,
+                phase=phase,
+                started_at_ns=result.started_at_ns,
+                ended_at_ns=result.ended_at_ns,
+                endpoint=self.config.endpoint,
+                model=self.config.model,
+                concurrency=case.concurrency,
+                target_input_tokens=case.input_tokens,
+                target_output_tokens=case.output_tokens,
+                stream=self.config.stream,
+                status="ok",
+                e2e_latency_ms=result.e2e_latency_ms,
+                ttft_ms=result.ttft_ms,
+                first_chunk_latency_ms=result.first_chunk_latency_ms,
+                chunk_interarrival_ms=result.chunk_interarrival_ms,
+                prompt_tokens=prompt_count.value,
+                prompt_token_source=prompt_count.source,
+                prompt_token_exact=prompt_count.exact,
+                output_tokens=output_count.value,
+                output_token_source=output_count.source,
+                output_token_exact=output_count.exact,
+                total_tokens=total_tokens,
+                finish_reason=result.finish_reason,
+            )
+        except Exception as exc:
+            ended_at_ns = time.time_ns()
+            return InferenceRequestEvent(
+                session_id=self.session.session_id,
+                request_id=request_id,
+                case_id=case.case_id,
+                phase=phase,
+                started_at_ns=started_at_ns,
+                ended_at_ns=ended_at_ns,
+                endpoint=self.config.endpoint,
+                model=self.config.model,
+                concurrency=case.concurrency,
+                target_input_tokens=case.input_tokens,
+                target_output_tokens=case.output_tokens,
+                stream=self.config.stream,
+                status="error",
+                e2e_latency_ms=(time.perf_counter() - started_perf) * 1000.0,
+                ttft_ms=None,
+                first_chunk_latency_ms=None,
+                prompt_tokens=prompt_count.value,
+                prompt_token_source=prompt_count.source,
+                prompt_token_exact=prompt_count.exact,
+                error_type=type(exc).__name__,
+                error_message=str(exc),
+            )
+
+
+class _RequestCounter:
+    def __init__(self, *, limit: int | None) -> None:
+        self.limit = limit
+        self.value = 0
+        self.lock = asyncio.Lock()
+
+    async def next(self) -> int | None:
+        async with self.lock:
+            if self.limit is not None and self.value >= self.limit:
+                return None
+            current = self.value
+            self.value += 1
+            return current
+
+
+def run_profile(config: ProfileConfig) -> dict[str, Any]:
+    """Run an inference profile from a resolved config."""
+    return InferenceProfiler(config).run()
+
+
+def _resolve_prompt_count(
+    usage: dict[str, Any] | None,
+    fallback: TokenCount,
+) -> TokenCount:
+    if usage and isinstance(usage.get("prompt_tokens"), int):
+        return TokenCount(
+            value=int(usage["prompt_tokens"]),
+            source="server_usage",
+            exact=True,
+        )
+    return fallback
+
+
+def _resolve_output_count(
+    usage: dict[str, Any] | None,
+    text: str,
+    counter: TokenCounter,
+) -> TokenCount:
+    if usage and isinstance(usage.get("completion_tokens"), int):
+        return TokenCount(
+            value=int(usage["completion_tokens"]),
+            source="server_usage",
+            exact=True,
+        )
+    return counter.count_text(text)
+
+
+def _resolve_total_tokens(
+    usage: dict[str, Any] | None,
+    prompt: TokenCount,
+    output: TokenCount,
+) -> int | None:
+    if usage and isinstance(usage.get("total_tokens"), int):
+        return int(usage["total_tokens"])
+    return prompt.value + output.value

--- a/stormlog/infer/profile.py
+++ b/stormlog/infer/profile.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import json
 import time
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -42,10 +44,17 @@ class InferenceProfiler:
             api_key=config.api_key,
             max_tokens_field=config.max_tokens_field,
         )
+        self.request_executor = ThreadPoolExecutor(
+            max_workers=max(config.concurrency),
+            thread_name_prefix="stormlog-infer",
+        )
 
     def run(self) -> dict[str, Any]:
         """Run profiling and return an aggregate report."""
-        return asyncio.run(self._run_async())
+        try:
+            return asyncio.run(self._run_async())
+        finally:
+            self.request_executor.shutdown(wait=True, cancel_futures=True)
 
     async def _run_async(self) -> dict[str, Any]:
         output_path = Path(self.config.output_path)
@@ -246,11 +255,15 @@ class InferenceProfiler:
         started_at_ns = time.time_ns()
         started_perf = time.perf_counter()
         try:
-            result = await asyncio.to_thread(
-                self.client.complete,
-                prompt=prompt,
-                output_tokens=case.output_tokens,
-                stream=self.config.stream,
+            loop = asyncio.get_running_loop()
+            result = await loop.run_in_executor(
+                self.request_executor,
+                partial(
+                    self.client.complete,
+                    prompt=prompt,
+                    output_tokens=case.output_tokens,
+                    stream=self.config.stream,
+                ),
             )
             output_count = _resolve_output_count(
                 result.usage,

--- a/stormlog/infer/samplers.py
+++ b/stormlog/infer/samplers.py
@@ -1,0 +1,119 @@
+"""Best-effort system telemetry samplers for inference profiling."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from typing import Protocol
+
+from .events import InferenceSystemSample
+
+
+class SystemSampler(Protocol):
+    """System telemetry sampler contract."""
+
+    name: str
+
+    def sample(self, *, session_id: str) -> InferenceSystemSample | None:
+        """Return one telemetry sample, or None when unavailable."""
+
+
+class NoopSampler:
+    """Sampler used for remote endpoints or unsupported systems."""
+
+    name = "noop"
+
+    def sample(self, *, session_id: str) -> InferenceSystemSample | None:
+        return None
+
+
+class ProcessSampler:
+    """Sample the current Stormlog process RSS."""
+
+    name = "psutil"
+
+    def __init__(self) -> None:
+        import psutil
+
+        self._process = psutil.Process(os.getpid())
+
+    def sample(self, *, session_id: str) -> InferenceSystemSample | None:
+        return InferenceSystemSample(
+            session_id=session_id,
+            timestamp_ns=time.time_ns(),
+            sampler=self.name,
+            process_rss_bytes=int(self._process.memory_info().rss),
+        )
+
+
+class NvidiaSmiSampler:
+    """Sample NVIDIA device memory and utilization through nvidia-smi."""
+
+    name = "nvidia-smi"
+
+    def __init__(self, *, device_id: int = 0) -> None:
+        self.device_id = device_id
+
+    def sample(self, *, session_id: str) -> InferenceSystemSample | None:
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                (
+                    "--query-gpu=index,name,memory.total,memory.used,"
+                    "memory.free,utilization.gpu"
+                ),
+                "--format=csv,noheader,nounits",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if result.returncode != 0:
+            return None
+        lines = [line for line in result.stdout.splitlines() if line.strip()]
+        if self.device_id >= len(lines):
+            return None
+        values = [value.strip() for value in lines[self.device_id].split(",")]
+        if len(values) < 6:
+            return None
+        total_mb = int(values[2])
+        used_mb = int(values[3])
+        free_mb = int(values[4])
+        return InferenceSystemSample(
+            session_id=session_id,
+            timestamp_ns=time.time_ns(),
+            sampler=self.name,
+            device_id=int(values[0]),
+            device_name=values[1],
+            device_total_bytes=total_mb * 1024 * 1024,
+            device_used_bytes=used_mb * 1024 * 1024,
+            device_free_bytes=free_mb * 1024 * 1024,
+            gpu_utilization_percent=float(values[5]),
+        )
+
+
+def build_system_sampler(name: str) -> SystemSampler:
+    """Build a system sampler by name."""
+    normalized = name.strip().lower()
+    if normalized in {"none", "noop", "remote"}:
+        return NoopSampler()
+    if normalized in {"psutil", "process"}:
+        return ProcessSampler()
+    if normalized in {"nvidia-smi", "nvidia", "gpu"}:
+        return NvidiaSmiSampler()
+    if normalized != "auto":
+        raise ValueError(
+            "--system-sampler must be one of auto, none, psutil, nvidia-smi"
+        )
+
+    try:
+        sample = NvidiaSmiSampler()
+        if sample.sample(session_id="probe") is not None:
+            return sample
+    except Exception:
+        pass
+    try:
+        return ProcessSampler()
+    except Exception:
+        return NoopSampler()

--- a/stormlog/infer/tokens.py
+++ b/stormlog/infer/tokens.py
@@ -1,0 +1,146 @@
+"""Token counting helpers for inference profiling."""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class TokenCount:
+    """A token count plus provenance."""
+
+    value: int
+    source: str
+    exact: bool
+
+
+class TokenCounter(Protocol):
+    """Counter interface used by workload generation and fallback accounting."""
+
+    source: str
+    exact: bool
+
+    def count_text(self, text: str) -> TokenCount:
+        """Count tokens in a text payload."""
+
+
+class EstimatedTokenCounter:
+    """A deterministic fallback counter based on whitespace-like chunks."""
+
+    source = "estimated"
+    exact = False
+
+    def count_text(self, text: str) -> TokenCount:
+        chunks = [chunk for chunk in text.replace("\n", " ").split(" ") if chunk]
+        return TokenCount(value=max(1, len(chunks)), source=self.source, exact=False)
+
+
+class TiktokenCounter:
+    """Token counter backed by tiktoken."""
+
+    source = "tiktoken"
+    exact = True
+
+    def __init__(self, *, model: str | None, encoding_name: str | None) -> None:
+        tiktoken = importlib.import_module("tiktoken")
+        if encoding_name:
+            self._encoding = tiktoken.get_encoding(encoding_name)
+        elif model:
+            self._encoding = tiktoken.encoding_for_model(model)
+        else:
+            self._encoding = tiktoken.get_encoding("cl100k_base")
+
+    def count_text(self, text: str) -> TokenCount:
+        return TokenCount(
+            value=len(self._encoding.encode(text)),
+            source=self.source,
+            exact=True,
+        )
+
+
+class TransformersTokenCounter:
+    """Token counter backed by transformers.AutoTokenizer."""
+
+    source = "transformers"
+    exact = True
+
+    def __init__(self, *, model: str) -> None:
+        transformers = importlib.import_module("transformers")
+        auto_tokenizer = transformers.AutoTokenizer
+        self._tokenizer = auto_tokenizer.from_pretrained(model)
+
+    def count_text(self, text: str) -> TokenCount:
+        token_ids = self._tokenizer.encode(text, add_special_tokens=False)
+        return TokenCount(value=len(token_ids), source=self.source, exact=True)
+
+
+def build_token_counter(
+    *,
+    tokenizer: str,
+    model: str,
+    tokenizer_model: str | None = None,
+    tiktoken_encoding: str | None = None,
+    strict: bool = False,
+) -> TokenCounter:
+    """Build the requested token counter, falling back to estimates in auto mode."""
+    normalized = tokenizer.strip().lower()
+    resolved_model = tokenizer_model or model
+
+    if normalized in {"none", "estimate", "estimated"}:
+        return EstimatedTokenCounter()
+
+    if normalized == "tiktoken":
+        return TiktokenCounter(model=resolved_model, encoding_name=tiktoken_encoding)
+
+    if normalized in {"transformers", "hf", "huggingface"}:
+        return TransformersTokenCounter(model=resolved_model)
+
+    if normalized != "auto":
+        raise ValueError(
+            "--tokenizer must be one of auto, none, tiktoken, transformers"
+        )
+
+    try:
+        return TiktokenCounter(
+            model=resolved_model,
+            encoding_name=tiktoken_encoding,
+        )
+    except Exception:
+        pass
+
+    try:
+        return TransformersTokenCounter(model=resolved_model)
+    except Exception:
+        pass
+
+    if strict:
+        raise RuntimeError("No configured tokenizer is available")
+    return EstimatedTokenCounter()
+
+
+def generate_prompt(target_tokens: int, counter: TokenCounter, *, seed: int) -> str:
+    """Generate a deterministic prompt near the requested token count."""
+    base_words = [
+        "profile",
+        "inference",
+        "latency",
+        "throughput",
+        "memory",
+        "tokens",
+        "scheduler",
+        "request",
+        "streaming",
+        "capacity",
+    ]
+    words: list[str] = []
+    index = seed % len(base_words)
+    while len(words) < target_tokens * 2:
+        words.append(base_words[index % len(base_words)])
+        candidate = " ".join(words)
+        count = counter.count_text(candidate)
+        if count.value >= target_tokens:
+            return candidate
+        index += 1
+    return " ".join(words)

--- a/stormlog/query_cli.py
+++ b/stormlog/query_cli.py
@@ -10,8 +10,6 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
-from . import query as query_api
-
 
 @dataclass(frozen=True)
 class _OutputMode:
@@ -27,6 +25,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.command is None:
         parser.print_help()
         return 0
+
+    from . import query as query_api
 
     store = query_api.open(args.paths)
     output_mode = _OutputMode(

--- a/tests/test_docs_regressions.py
+++ b/tests/test_docs_regressions.py
@@ -43,6 +43,11 @@ _BANNED_DOC_SNIPPETS = {
     ],
     "docs/index.md": [
         "The `gpumemprof` and `tfmemprof` CLIs, the `stormlog` TUI entrypoint, and the public Python APIs work with a pip install.",
+        "Stormlog ships three surfaces",
+    ],
+    "docs/architecture.md": [
+        "The shared terminal UI is the `stormlog` entrypoint implemented in `stormlog.tui`.",
+        "The `stormlog` console script points to `stormlog.tui:run_app`.",
     ],
     "docs/cpu_compatibility.md": [
         "python -m examples.cli.quickstart",
@@ -90,12 +95,15 @@ _REQUIRED_DOC_SNIPPETS = {
     "docs/index.md": [
         "## Important: Pip vs Source Checkout",
         "The `examples/` package is **not** included.",
-        "Install `stormlog[tui,torch]` if you want the `stormlog` TUI entrypoint from a pip install.",
+        "Stormlog ships four surfaces",
+        "`stormlog infer`",
+        "Install `stormlog[tui,torch]` if you want `stormlog` or `stormlog tui` to launch the TUI from a pip install.",
     ],
     "README.md": [
         "source-checkout only",
         "gpumemprof info",
         "tfmemprof info",
+        "stormlog infer profile",
     ],
     "docs/article.md": [
         'pip install "stormlog[tui,torch]"',
@@ -104,6 +112,12 @@ _REQUIRED_DOC_SNIPPETS = {
     "docs/cli.md": [
         "**Pip users** should use this CLI-only sequence instead:",
         "`--device /CPU:0`",
+        "stormlog infer profile",
+    ],
+    "docs/inference.md": [
+        "stormlog infer profile",
+        "server_usage",
+        "Chunk inter-arrival timing is chunk-level timing.",
     ],
     "docs/cpu_compatibility.md": [
         "Do **not** use `examples.cli.quickstart` for pip installs",

--- a/tests/test_infer_profile.py
+++ b/tests/test_infer_profile.py
@@ -1,0 +1,321 @@
+import contextlib
+import io
+import json
+import tempfile
+import threading
+import time
+import unittest
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+from stormlog.infer.analysis import analyze_inference_events
+from stormlog.infer.cli import main as infer_main
+
+
+class _FakeOpenAIHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/v1/models":
+            body = json.dumps({"data": [{"id": "fake-model"}]}).encode("utf-8")
+            self._send_json(body)
+            return
+        self.send_error(404)
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path != "/v1/chat/completions":
+            self.send_error(404)
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        payload = json.loads(self.rfile.read(length).decode("utf-8"))
+        if "no-usage" in str(payload.get("model")):
+            body = json.dumps(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": "hello fallback",
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ]
+                }
+            ).encode("utf-8")
+            self._send_json(body)
+            return
+        if payload.get("stream"):
+            self._send_stream()
+            return
+        body = json.dumps(
+            {
+                "choices": [
+                    {
+                        "message": {"role": "assistant", "content": "hello world"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 5,
+                    "completion_tokens": 2,
+                    "total_tokens": 7,
+                },
+            }
+        ).encode("utf-8")
+        self._send_json(body)
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return None
+
+    def _send_json(self, body: bytes) -> None:
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_stream(self) -> None:
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Connection", "close")
+        self.end_headers()
+        chunks = [
+            {"choices": [{"delta": {"role": "assistant"}}]},
+            {"choices": [{"delta": {"content": "hello"}}]},
+            {
+                "choices": [
+                    {
+                        "delta": {"content": " world"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 5,
+                    "completion_tokens": 2,
+                    "total_tokens": 7,
+                },
+            },
+        ]
+        for chunk in chunks:
+            time.sleep(0.01)
+            self.wfile.write(f"data: {json.dumps(chunk)}\n\n".encode("utf-8"))
+            self.wfile.flush()
+        self.wfile.write(b"data: [DONE]\n\n")
+        self.wfile.flush()
+
+
+@contextlib.contextmanager
+def _fake_server() -> Iterator[str]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _FakeOpenAIHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/v1/chat/completions"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+class InferenceProfileTests(unittest.TestCase):
+    def test_profile_streaming_endpoint_writes_request_events(self) -> None:
+        with _fake_server() as endpoint:
+            with tempfile.TemporaryDirectory() as directory:
+                output = Path(directory) / "infer.jsonl"
+                with contextlib.redirect_stdout(io.StringIO()):
+                    exit_code = infer_main(
+                        [
+                            "profile",
+                            "--endpoint",
+                            str(endpoint),
+                            "--model",
+                            "fake-model",
+                            "--concurrency",
+                            "2",
+                            "--input-tokens",
+                            "8",
+                            "--output-tokens",
+                            "4",
+                            "--requests",
+                            "2",
+                            "--warmup-requests",
+                            "1",
+                            "--system-sampler",
+                            "none",
+                            "--tokenizer",
+                            "none",
+                            "--output",
+                            str(output),
+                        ]
+                    )
+
+                self.assertEqual(exit_code, 0)
+                records = [
+                    json.loads(line)
+                    for line in output.read_text(encoding="utf-8").splitlines()
+                ]
+                measured = [
+                    record
+                    for record in records
+                    if record.get("event_type") == "infer.request"
+                    and record.get("phase") == "measured"
+                ]
+                warmup = [
+                    record
+                    for record in records
+                    if record.get("event_type") == "infer.request"
+                    and record.get("phase") == "warmup"
+                ]
+                self.assertEqual(len(measured), 2)
+                self.assertEqual(len(warmup), 1)
+                first = measured[0]
+                self.assertEqual(first["status"], "ok")
+                self.assertEqual(first["timestamp_ns"], first["started_at_ns"])
+                self.assertGreater(first["ttft_ms"], 0)
+                self.assertGreater(first["e2e_latency_ms"], first["ttft_ms"])
+                self.assertEqual(first["output_tokens"], 2)
+                self.assertEqual(first["output_token_source"], "server_usage")
+                self.assertTrue(first["output_token_exact"])
+                self.assertTrue(
+                    any(
+                        record.get("event_type") == "infer.summary"
+                        for record in records
+                    )
+                )
+                self.assertTrue(
+                    any(
+                        record.get("event_type") == "infer.session"
+                        and record.get("status") == "completed"
+                        for record in records
+                    )
+                )
+
+    def test_analyze_reports_latency_and_throughput(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "infer.jsonl"
+            path.write_text(
+                "\n".join(
+                    [
+                        json.dumps(
+                            {
+                                "schema_version": 1,
+                                "event_type": "infer.request",
+                                "session_id": "s1",
+                                "request_id": "r1",
+                                "case_id": "c1_in8_out4",
+                                "phase": "measured",
+                                "started_at_ns": 1_000_000_000,
+                                "ended_at_ns": 2_000_000_000,
+                                "status": "ok",
+                                "e2e_latency_ms": 1000.0,
+                                "ttft_ms": 100.0,
+                                "first_chunk_latency_ms": 80.0,
+                                "output_tokens": 4,
+                                "total_tokens": 12,
+                                "output_token_source": "server_usage",
+                            }
+                        ),
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            report = analyze_inference_events(path)
+
+            self.assertEqual(report["summary"]["total_requests"], 1)
+            case = report["cases"]["c1_in8_out4"]
+            self.assertEqual(case["latency_ms"]["e2e_p50"], 1000.0)
+            self.assertEqual(case["throughput"]["output_tokens_per_second"], 4.0)
+
+    def test_profile_non_streaming_without_usage_records_estimated_tokens(
+        self,
+    ) -> None:
+        with _fake_server() as endpoint:
+            with tempfile.TemporaryDirectory() as directory:
+                output = Path(directory) / "infer.jsonl"
+                with contextlib.redirect_stdout(io.StringIO()):
+                    exit_code = infer_main(
+                        [
+                            "profile",
+                            "--endpoint",
+                            str(endpoint),
+                            "--model",
+                            "no-usage-model",
+                            "--input-tokens",
+                            "8",
+                            "--output-tokens",
+                            "4",
+                            "--requests",
+                            "1",
+                            "--no-stream",
+                            "--system-sampler",
+                            "none",
+                            "--tokenizer",
+                            "none",
+                            "--output",
+                            str(output),
+                        ]
+                    )
+
+                self.assertEqual(exit_code, 0)
+                request = next(
+                    record
+                    for record in (
+                        json.loads(line)
+                        for line in output.read_text(encoding="utf-8").splitlines()
+                    )
+                    if record.get("event_type") == "infer.request"
+                )
+                self.assertIsNone(request["ttft_ms"])
+                self.assertEqual(request["output_token_source"], "estimated")
+                self.assertFalse(request["output_token_exact"])
+
+    def test_analyze_writes_json_report(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            artifact = Path(directory) / "infer.jsonl"
+            report_path = Path(directory) / "report.json"
+            artifact.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "event_type": "infer.request",
+                        "session_id": "s1",
+                        "request_id": "r1",
+                        "case_id": "c1_in8_out4",
+                        "phase": "measured",
+                        "started_at_ns": 1_000_000_000,
+                        "ended_at_ns": 2_000_000_000,
+                        "status": "ok",
+                        "e2e_latency_ms": 1000.0,
+                        "ttft_ms": 100.0,
+                        "first_chunk_latency_ms": 80.0,
+                        "output_tokens": 4,
+                        "total_tokens": 12,
+                        "output_token_source": "server_usage",
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            with contextlib.redirect_stdout(io.StringIO()):
+                exit_code = infer_main(
+                    [
+                        "analyze",
+                        str(artifact),
+                        "--format",
+                        "json",
+                        "--output",
+                        str(report_path),
+                    ]
+                )
+
+            self.assertEqual(exit_code, 0)
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertEqual(report["summary"]["total_requests"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_infer_profile.py
+++ b/tests/test_infer_profile.py
@@ -8,6 +8,7 @@ import unittest
 from collections.abc import Iterator
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from typing import Any
 
 from stormlog.infer.analysis import analyze_inference_events
 from stormlog.infer.cli import main as infer_main
@@ -53,7 +54,9 @@ class _FakeOpenAIHandler(BaseHTTPRequestHandler):
             self._send_json(body)
             return
         if payload.get("stream"):
-            self._send_stream()
+            self._send_stream(
+                include_usage=payload.get("stream_options") == {"include_usage": True}
+            )
             return
         body = json.dumps(
             {
@@ -82,27 +85,29 @@ class _FakeOpenAIHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
-    def _send_stream(self) -> None:
+    def _send_stream(self, *, include_usage: bool) -> None:
         self.send_response(200)
         self.send_header("Content-Type", "text/event-stream")
         self.send_header("Connection", "close")
         self.end_headers()
+        final_chunk: dict[str, Any] = {
+            "choices": [
+                {
+                    "delta": {"content": " world"},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+        if include_usage:
+            final_chunk["usage"] = {
+                "prompt_tokens": 5,
+                "completion_tokens": 2,
+                "total_tokens": 7,
+            }
         chunks = [
             {"choices": [{"delta": {"role": "assistant"}}]},
             {"choices": [{"delta": {"content": "hello"}}]},
-            {
-                "choices": [
-                    {
-                        "delta": {"content": " world"},
-                        "finish_reason": "stop",
-                    }
-                ],
-                "usage": {
-                    "prompt_tokens": 5,
-                    "completion_tokens": 2,
-                    "total_tokens": 7,
-                },
-            },
+            final_chunk,
         ]
         for chunk in chunks:
             time.sleep(0.01)
@@ -197,6 +202,46 @@ class InferenceProfileTests(unittest.TestCase):
                         for record in records
                     )
                 )
+
+    def test_stream_usage_can_be_disabled_for_compatibility(self) -> None:
+        with _fake_server() as endpoint:
+            with tempfile.TemporaryDirectory() as directory:
+                output = Path(directory) / "infer.jsonl"
+                with contextlib.redirect_stdout(io.StringIO()):
+                    exit_code = infer_main(
+                        [
+                            "profile",
+                            "--endpoint",
+                            str(endpoint),
+                            "--model",
+                            "fake-model",
+                            "--input-tokens",
+                            "8",
+                            "--output-tokens",
+                            "4",
+                            "--requests",
+                            "1",
+                            "--no-stream-usage",
+                            "--system-sampler",
+                            "none",
+                            "--tokenizer",
+                            "none",
+                            "--output",
+                            str(output),
+                        ]
+                    )
+
+                self.assertEqual(exit_code, 0)
+                request = next(
+                    record
+                    for record in (
+                        json.loads(line)
+                        for line in output.read_text(encoding="utf-8").splitlines()
+                    )
+                    if record.get("event_type") == "infer.request"
+                    and record.get("phase") == "measured"
+                )
+                self.assertEqual(request["output_token_source"], "estimated")
 
     def test_analyze_reports_latency_and_throughput(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -481,6 +526,7 @@ class _BlockingClient:
         prompt: str,
         output_tokens: int,
         stream: bool,
+        stream_include_usage: bool,
     ) -> ChatCompletionResult:
         started_at_ns = time.time_ns()
         started_perf = time.perf_counter()

--- a/tests/test_infer_profile.py
+++ b/tests/test_infer_profile.py
@@ -11,6 +11,9 @@ from pathlib import Path
 
 from stormlog.infer.analysis import analyze_inference_events
 from stormlog.infer.cli import main as infer_main
+from stormlog.infer.config import ProfileConfig
+from stormlog.infer.openai_client import ChatCompletionResult
+from stormlog.infer.profile import InferenceProfiler
 
 
 class _FakeOpenAIHandler(BaseHTTPRequestHandler):
@@ -344,6 +347,30 @@ class InferenceProfileTests(unittest.TestCase):
                 self.assertEqual(request["output_token_source"], "estimated")
                 self.assertFalse(request["output_token_exact"])
 
+    def test_requested_concurrency_sets_request_executor_capacity(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "infer.jsonl"
+            profiler = InferenceProfiler(
+                ProfileConfig(
+                    endpoint="http://127.0.0.1:1/v1/chat/completions",
+                    model="fake-model",
+                    concurrency=(34,),
+                    input_tokens=(8,),
+                    output_tokens=(4,),
+                    request_count=34,
+                    output_path=str(output),
+                    stream=False,
+                    system_sampler="none",
+                    tokenizer="none",
+                )
+            )
+            client = _BlockingClient(target_active=34)
+            profiler.client = client  # type: ignore[assignment]
+
+            profiler.run()
+
+            self.assertEqual(client.max_active, 34)
+
     def test_analyze_writes_json_report(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             artifact = Path(directory) / "infer.jsonl"
@@ -387,6 +414,48 @@ class InferenceProfileTests(unittest.TestCase):
             self.assertEqual(exit_code, 0)
             report = json.loads(report_path.read_text(encoding="utf-8"))
             self.assertEqual(report["summary"]["total_requests"], 1)
+
+
+class _BlockingClient:
+    def __init__(self, *, target_active: int) -> None:
+        self.target_active = target_active
+        self.active = 0
+        self.max_active = 0
+        self.lock = threading.Lock()
+        self.release = threading.Event()
+
+    def complete(
+        self,
+        *,
+        prompt: str,
+        output_tokens: int,
+        stream: bool,
+    ) -> ChatCompletionResult:
+        started_at_ns = time.time_ns()
+        started_perf = time.perf_counter()
+        with self.lock:
+            self.active += 1
+            self.max_active = max(self.max_active, self.active)
+            if self.active >= self.target_active:
+                self.release.set()
+        self.release.wait(timeout=2)
+        with self.lock:
+            self.active -= 1
+        ended_at_ns = time.time_ns()
+        return ChatCompletionResult(
+            text="hello world",
+            started_at_ns=started_at_ns,
+            ended_at_ns=ended_at_ns,
+            e2e_latency_ms=(time.perf_counter() - started_perf) * 1000.0,
+            ttft_ms=None,
+            first_chunk_latency_ms=None,
+            usage={
+                "prompt_tokens": 5,
+                "completion_tokens": 2,
+                "total_tokens": 7,
+            },
+            finish_reason="stop",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_infer_profile.py
+++ b/tests/test_infer_profile.py
@@ -32,6 +32,10 @@ class _FakeOpenAIHandler(BaseHTTPRequestHandler):
             return
         length = int(self.headers.get("Content-Length", "0"))
         payload = json.loads(self.rfile.read(length).decode("utf-8"))
+        if "always-fail" in str(payload.get("model")):
+            body = json.dumps({"error": {"message": "forced failure"}}).encode("utf-8")
+            self._send_json(body, status=503)
+            return
         if "no-usage" in str(payload.get("model")):
             body = json.dumps(
                 {
@@ -71,8 +75,8 @@ class _FakeOpenAIHandler(BaseHTTPRequestHandler):
     def log_message(self, _format: str, *_args: object) -> None:
         return None
 
-    def _send_json(self, body: bytes) -> None:
-        self.send_response(200)
+    def _send_json(self, body: bytes, *, status: int = 200) -> None:
+        self.send_response(status)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
@@ -346,6 +350,53 @@ class InferenceProfileTests(unittest.TestCase):
                 self.assertIsNone(request["ttft_ms"])
                 self.assertEqual(request["output_token_source"], "estimated")
                 self.assertFalse(request["output_token_exact"])
+
+    def test_profile_returns_error_when_all_measured_requests_fail(self) -> None:
+        with _fake_server() as endpoint:
+            with tempfile.TemporaryDirectory() as directory:
+                output = Path(directory) / "infer.jsonl"
+                stderr = io.StringIO()
+                with contextlib.redirect_stdout(io.StringIO()):
+                    with contextlib.redirect_stderr(stderr):
+                        exit_code = infer_main(
+                            [
+                                "profile",
+                                "--endpoint",
+                                str(endpoint),
+                                "--model",
+                                "always-fail-model",
+                                "--input-tokens",
+                                "8",
+                                "--output-tokens",
+                                "4",
+                                "--requests",
+                                "2",
+                                "--system-sampler",
+                                "none",
+                                "--tokenizer",
+                                "none",
+                                "--output",
+                                str(output),
+                            ]
+                        )
+
+                self.assertEqual(exit_code, 1)
+                self.assertIn(
+                    "no measured inference requests succeeded",
+                    stderr.getvalue(),
+                )
+                records = [
+                    json.loads(line)
+                    for line in output.read_text(encoding="utf-8").splitlines()
+                ]
+                measured = [
+                    record
+                    for record in records
+                    if record.get("event_type") == "infer.request"
+                    and record.get("phase") == "measured"
+                ]
+                self.assertEqual(len(measured), 2)
+                self.assertTrue(all(record["status"] == "error" for record in measured))
 
     def test_requested_concurrency_sets_request_executor_capacity(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_infer_profile.py
+++ b/tests/test_infer_profile.py
@@ -229,6 +229,78 @@ class InferenceProfileTests(unittest.TestCase):
             self.assertEqual(case["latency_ms"]["e2e_p50"], 1000.0)
             self.assertEqual(case["throughput"]["output_tokens_per_second"], 4.0)
 
+    def test_analyze_filters_system_samples_to_case_window(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "infer.jsonl"
+            records = [
+                {
+                    "schema_version": 1,
+                    "event_type": "infer.system_sample",
+                    "session_id": "s1",
+                    "timestamp_ns": 500_000_000,
+                    "device_used_bytes": 700,
+                },
+                {
+                    "schema_version": 1,
+                    "event_type": "infer.request",
+                    "session_id": "s1",
+                    "request_id": "low",
+                    "case_id": "c1_in8_out4",
+                    "phase": "measured",
+                    "started_at_ns": 1_000_000_000,
+                    "ended_at_ns": 2_000_000_000,
+                    "status": "ok",
+                    "e2e_latency_ms": 1000.0,
+                    "output_tokens": 4,
+                    "total_tokens": 12,
+                    "output_token_source": "server_usage",
+                },
+                {
+                    "schema_version": 1,
+                    "event_type": "infer.system_sample",
+                    "session_id": "s1",
+                    "timestamp_ns": 1_500_000_000,
+                    "device_used_bytes": 100,
+                },
+                {
+                    "schema_version": 1,
+                    "event_type": "infer.request",
+                    "session_id": "s1",
+                    "request_id": "high",
+                    "case_id": "c2_in8_out4",
+                    "phase": "measured",
+                    "started_at_ns": 4_000_000_000,
+                    "ended_at_ns": 5_000_000_000,
+                    "status": "ok",
+                    "e2e_latency_ms": 1000.0,
+                    "output_tokens": 4,
+                    "total_tokens": 12,
+                    "output_token_source": "server_usage",
+                },
+                {
+                    "schema_version": 1,
+                    "event_type": "infer.system_sample",
+                    "session_id": "s1",
+                    "timestamp_ns": 4_500_000_000,
+                    "device_used_bytes": 900,
+                },
+            ]
+            path.write_text(
+                "\n".join(json.dumps(record) for record in records) + "\n",
+                encoding="utf-8",
+            )
+
+            report = analyze_inference_events(path)
+
+            self.assertEqual(
+                report["cases"]["c1_in8_out4"]["memory"]["peak_device_used_bytes"],
+                100,
+            )
+            self.assertEqual(
+                report["cases"]["c2_in8_out4"]["memory"]["peak_device_used_bytes"],
+                900,
+            )
+
     def test_profile_non_streaming_without_usage_records_estimated_tokens(
         self,
     ) -> None:

--- a/tests/test_packaging_contracts.py
+++ b/tests/test_packaging_contracts.py
@@ -27,10 +27,11 @@ def test_all_extra_covers_every_runtime_extra() -> None:
         set(extras["viz"])
         | set(extras["torch"])
         | set(extras["tf"])
+        | set(extras["infer-tokenizers"])
         | set(extras["tui"])
     )
 
     assert expected.issubset(set(extras["all"])), (
         "The all extra must cover every user-facing runtime extra "
-        "(viz, torch, tf, tui)."
+        "(viz, torch, tf, infer-tokenizers, tui)."
     )

--- a/tests/test_packaging_contracts.py
+++ b/tests/test_packaging_contracts.py
@@ -29,9 +29,10 @@ def test_all_extra_covers_every_runtime_extra() -> None:
         | set(extras["tf"])
         | set(extras["infer-tokenizers"])
         | set(extras["tui"])
+        | set(extras["jax"])
     )
 
     assert expected.issubset(set(extras["all"])), (
         "The all extra must cover every user-facing runtime extra "
-        "(viz, torch, tf, infer-tokenizers, tui)."
+        "(viz, torch, tf, infer-tokenizers, tui, jax)."
     )

--- a/tests/test_stormlog_entrypoint.py
+++ b/tests/test_stormlog_entrypoint.py
@@ -1,0 +1,68 @@
+import contextlib
+import io
+import unittest
+from unittest import mock
+
+import stormlog.entrypoint as entrypoint
+
+
+class StormlogEntrypointTests(unittest.TestCase):
+    def test_no_args_launches_tui(self) -> None:
+        with mock.patch("stormlog.tui.run_app") as run_app:
+            exit_code = entrypoint.main([])
+
+        self.assertEqual(exit_code, 0)
+        run_app.assert_called_once_with()
+
+    def test_tui_command_launches_tui(self) -> None:
+        with mock.patch("stormlog.tui.run_app") as run_app:
+            exit_code = entrypoint.main(["tui"])
+
+        self.assertEqual(exit_code, 0)
+        run_app.assert_called_once_with()
+
+    def test_tui_help_does_not_launch_tui(self) -> None:
+        output = io.StringIO()
+        with mock.patch("stormlog.tui.run_app") as run_app:
+            with contextlib.redirect_stdout(output):
+                with self.assertRaises(SystemExit) as raised:
+                    entrypoint.main(["tui", "--help"])
+
+        self.assertEqual(raised.exception.code, 0)
+        run_app.assert_not_called()
+        self.assertIn("Stormlog Textual TUI", output.getvalue())
+
+    def test_tui_unknown_arg_errors_before_launching_tui(self) -> None:
+        with mock.patch("stormlog.tui.run_app") as run_app:
+            with contextlib.redirect_stderr(io.StringIO()):
+                with self.assertRaises(SystemExit) as raised:
+                    entrypoint.main(["tui", "--bad"])
+
+        self.assertEqual(raised.exception.code, 2)
+        run_app.assert_not_called()
+
+    def test_infer_command_dispatches_to_infer_cli(self) -> None:
+        with mock.patch("stormlog.infer.cli.main", return_value=7) as infer_main:
+            exit_code = entrypoint.main(["infer", "analyze", "artifact.jsonl"])
+
+        self.assertEqual(exit_code, 7)
+        infer_main.assert_called_once_with(["analyze", "artifact.jsonl"])
+
+    def test_help_mentions_no_arg_tui_behavior(self) -> None:
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            exit_code = entrypoint.main(["--help"])
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("Textual TUI", output.getvalue())
+
+    def test_unknown_command_exits_with_parser_error(self) -> None:
+        with contextlib.redirect_stderr(io.StringIO()):
+            with self.assertRaises(SystemExit) as raised:
+                entrypoint.main(["unknown"])
+
+        self.assertEqual(raised.exception.code, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stormlog_entrypoint.py
+++ b/tests/test_stormlog_entrypoint.py
@@ -1,4 +1,5 @@
 import contextlib
+import importlib
 import io
 import unittest
 from unittest import mock
@@ -48,13 +49,25 @@ class StormlogEntrypointTests(unittest.TestCase):
         self.assertEqual(exit_code, 7)
         infer_main.assert_called_once_with(["analyze", "artifact.jsonl"])
 
+    def test_query_command_dispatches_to_query_cli(self) -> None:
+        importlib.import_module("stormlog.query_cli")
+
+        with mock.patch("stormlog.query_cli.main", return_value=8) as query_main:
+            exit_code = entrypoint.main(["query", "sessions", "artifacts"])
+
+        self.assertEqual(exit_code, 8)
+        query_main.assert_called_once_with(["sessions", "artifacts"])
+
     def test_help_mentions_no_arg_tui_behavior(self) -> None:
         output = io.StringIO()
         with contextlib.redirect_stdout(output):
             exit_code = entrypoint.main(["--help"])
 
         self.assertEqual(exit_code, 0)
-        self.assertIn("Textual TUI", output.getvalue())
+        help_text = output.getvalue()
+        self.assertIn("Textual TUI", help_text)
+        self.assertIn("query", help_text)
+        self.assertIn("infer", help_text)
 
     def test_unknown_command_exits_with_parser_error(self) -> None:
         with contextlib.redirect_stderr(io.StringIO()):


### PR DESCRIPTION
## Summary
- Add `stormlog infer profile` and `stormlog infer analyze` for OpenAI-compatible Chat Completions endpoints.
- Preserve no-argument TUI startup while adding the `stormlog infer` command group through the top-level dispatcher.
- Record request events, session summaries, optional system samples, tokenizer provenance, and analyzer output in inference JSONL artifacts.
- Document install extras, metric boundaries, tokenizer behavior, and the endpoint-first adapter boundary.

## Why
Stormlog inference profiling should work against serving endpoints that may be backed by vLLM, SGLang, TensorRT-LLM, MLX, hosted gateways, or framework-native servers. Keeping this v1 surface endpoint-based avoids coupling inference UX to framework memory commands while leaving room for backend adapters later.

## Validation
- `pre-commit` hooks passed on the changed file set.
- Targeted inference and entrypoint unit tests passed.
- Docs regression constants passed.
- Packaging contract for aggregate runtime extras passed.
- Top-level and inference command help checks passed.