### PR TITLE
Fix JAX profiling edge cases and test coverage

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,11 +10,12 @@ This guide documents the test layers that currently exist in the repo and the co
 python3 -m pip install -e ".[test]"
 ```
 
-Add framework extras when you want the full PyTorch or TensorFlow paths:
+Add framework extras when you want the full PyTorch, TensorFlow, or JAX paths:
 
 ```bash
 python3 -m pip install -e ".[torch]"
 python3 -m pip install -e ".[tf]"
+python3 -m pip install -e ".[jax]"
 python3 -m pip install -e ".[all]"
 ```
 
@@ -60,6 +61,12 @@ python3 -m pytest tests/ --ignore-glob="tests/test_tf*.py" -v -m "not tui_pilot 
 
 ```bash
 python3 -m pytest tests/ -o "python_files=test_tf*.py" -v -m "not tui_pilot and not tui_snapshot and not tui_pty"
+```
+
+### JAX-oriented test slice
+
+```bash
+python3 -m pytest tests/ -o "python_files=test_jax*.py" -v -m "not tui_pilot and not tui_snapshot and not tui_pty"
 ```
 
 ## TUI test layers

--- a/stormlog/jax/attributed_viz.py
+++ b/stormlog/jax/attributed_viz.py
@@ -33,7 +33,7 @@ def _compute_memory_stats(
     total_mem = 0
 
     for sample in profile_data.get("samples", []):
-        stack = sample["stack"][::-1]  # Root -> Leaf
+        stack = list(sample["stack"])  # Root -> leaf, as normalized by pprof_parser.
         if not stack:
             continue
 

--- a/stormlog/jax/cli.py
+++ b/stormlog/jax/cli.py
@@ -5,8 +5,10 @@ import json
 import logging
 import sys
 import time
+from contextlib import nullcontext
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from stormlog.telemetry import telemetry_event_from_record, telemetry_event_to_dict
 from stormlog.telemetry_sink import TelemetrySinkConfig
@@ -52,6 +54,56 @@ except ImportError:
 if JAX_AVAILABLE:
     from .diagnose import run_diagnose
     from .tracker import MemoryTracker
+else:
+
+    @dataclass
+    class _UnavailableTrackingResult:
+        peak_memory_bytes: int = 0
+        average_memory_bytes: int = 0
+        duration: float = 0.0
+        memory_usage: list[int] = field(default_factory=list)
+        timestamps: list[float] = field(default_factory=list)
+        alert_count: int = 0
+        telemetry_events: list[dict[str, Any]] = field(default_factory=list)
+        device_memory_profile_path: Optional[str] = None
+
+    class MemoryTracker:  # type: ignore[no-redef]
+        oom_buffer_size = 0
+        last_oom_dump_path: Optional[str] = None
+
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        def add_alert_callback(self, _callback: Any) -> None:
+            pass
+
+        def start_tracking(self) -> None:
+            raise ImportError("JAX not available")
+
+        def stop_tracking(self) -> _UnavailableTrackingResult:
+            return _UnavailableTrackingResult()
+
+        def get_current_memory(self) -> float:
+            return 0.0
+
+        def get_statistics(self) -> dict[str, Any]:
+            return {"total_events": 0, "peak_memory_mb": 0.0}
+
+        def capture_oom(self, *_args: Any, **_kwargs: Any) -> Any:
+            return nullcontext()
+
+        def get_session_summary(self) -> None:
+            return None
+
+    def run_diagnose(
+        output: Optional[str],
+        device_index: int,
+        duration: float,
+        interval: float,
+        command_line: str,
+    ) -> tuple[Path, int]:
+        _ = (output, device_index, duration, interval, command_line)
+        raise ImportError("JAX not available")
 
 
 def setup_logging(verbose: bool = False) -> None:
@@ -207,7 +259,11 @@ def cmd_monitor(args: argparse.Namespace) -> int:
                 f"\rCurrent memory usage: {current_memory:.1f} MB", end="", flush=True
             )
 
-            time.sleep(1.0)
+            sleep_for = args.interval
+            if args.duration:
+                remaining = args.duration - (time.time() - start_time)
+                sleep_for = min(sleep_for, max(remaining, 0.0))
+            time.sleep(sleep_for)
 
     except KeyboardInterrupt:
         print("\n\nStopping monitoring...")

--- a/stormlog/jax/context_profiler.py
+++ b/stormlog/jax/context_profiler.py
@@ -293,9 +293,8 @@ class JAXProfiler:
         if not JAX_AVAILABLE:
             raise ImportError("JAX is required for JAXProfiler.profile_training")
 
-        # Convert single-use iterators (like generators) to a list once
-        # so subsequent epochs can reuse the same data.
-        if iter(dataset) is dataset:
+        # Convert single-use iterators only when multiple epochs need replay.
+        if epochs > 1 and iter(dataset) is dataset:
             dataset = list(dataset)
 
         with self.profiler.profile_context("training"):

--- a/stormlog/jax/profiler.py
+++ b/stormlog/jax/profiler.py
@@ -114,10 +114,14 @@ class ProfileResult:
 
     @property
     def memory_growth_rate(self) -> float:
-        """Memory growth rate in bytes/second."""
+        """Memory growth rate in MB/second."""
         if self.duration <= 0:
             return 0.0
-        return (self.peak_memory_bytes - self.min_memory_bytes) / self.duration
+        return (
+            (self.peak_memory_bytes - self.min_memory_bytes)
+            / (1024 * 1024)
+            / self.duration
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_jax_analyzer.py
+++ b/tests/test_jax_analyzer.py
@@ -7,6 +7,7 @@ from unittest import mock
 import pytest
 
 pytest.importorskip("numpy")
+pytest.importorskip("jax")
 
 from stormlog.jax.analyzer import (
     MemoryAnalyzer,

--- a/tests/test_jax_attributed_viz.py
+++ b/tests/test_jax_attributed_viz.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import Any, cast
 
 import stormlog.attributed_viz as attributed_viz
 import stormlog.cuda_native_debug as native_debug
+from stormlog.jax.attributed_viz import render_jax_attributed_html
 
 
 def _extract_embedded_payload(html: str) -> dict[str, Any]:
@@ -477,3 +479,33 @@ def test_render_attributed_wandb_preview_labels_snapshot_only_view() -> None:
     assert "Static W&amp;B preview from the live allocator snapshot" in html
     assert "recorded events" not in html
     assert "Trace Events" in html
+
+
+def test_render_jax_attributed_html_keeps_root_to_leaf_order() -> None:
+    html = render_jax_attributed_html(
+        {"samples": [{"stack": ["root", "caller", "leaf"], "values": [1, 100]}]},
+        output_path="",
+    )
+
+    leaf_row = re.search(
+        r"<tr>\s*<td>\d+</td>\s*"
+        r'<td style="[^"]*">leaf</td>\s*'
+        r"<td>(?P<flat>.*?)</td>\s*"
+        r"<td>(?P<cum>.*?)</td>",
+        html,
+        re.DOTALL,
+    )
+    root_row = re.search(
+        r"<tr>\s*<td>\d+</td>\s*"
+        r'<td style="[^"]*">root</td>\s*'
+        r"<td>(?P<flat>.*?)</td>\s*"
+        r"<td>(?P<cum>.*?)</td>",
+        html,
+        re.DOTALL,
+    )
+
+    assert leaf_row is not None
+    assert root_row is not None
+    assert "100.00B" in leaf_row.group("flat")
+    assert "100.00B" in leaf_row.group("cum")
+    assert "0.00B" in root_row.group("flat")

--- a/tests/test_jax_cli_coverage.py
+++ b/tests/test_jax_cli_coverage.py
@@ -80,6 +80,7 @@ def test_cmd_diagnose_success(capsys: Any, tmp_path: Any) -> None:
     config = mock.Mock()
     config.enabled = False
     with (
+        mock.patch("stormlog.jax.cli.JAX_AVAILABLE", True),
         mock.patch("stormlog.jax.cli._resolve_wandb_config", return_value=config),
         mock.patch("stormlog.jax.cli.run_diagnose", return_value=(tmp_path, 2)),
     ):
@@ -210,6 +211,29 @@ def test_cmd_monitor_keyboard_interrupt(capsys: Any, tmp_path: Any) -> None:
 
         assert cli.cmd_monitor(args) == 0
         assert (tmp_path / "mon.json").exists()
+
+
+def test_cmd_monitor_uses_requested_interval(capsys: Any, tmp_path: Any) -> None:
+    args = argparse.Namespace(
+        interval=0.25,
+        duration=None,
+        threshold=100,
+        device=0,
+        output=str(tmp_path / "mon_interval.json"),
+        max_history=10000,
+    )
+    sleep_mock = mock.Mock(side_effect=KeyboardInterrupt)
+    with (
+        mock.patch("stormlog.jax.cli.JAX_AVAILABLE", True),
+        mock.patch("stormlog.jax.cli.MemoryTracker.start_tracking"),
+        mock.patch(
+            "stormlog.jax.cli.MemoryTracker.get_current_memory", return_value=50.0
+        ),
+        mock.patch("time.sleep", sleep_mock),
+    ):
+        assert cli.cmd_monitor(args) == 0
+
+    sleep_mock.assert_called_once_with(0.25)
 
 
 def test_main_no_args() -> None:

--- a/tests/test_jax_context_profiler.py
+++ b/tests/test_jax_context_profiler.py
@@ -73,6 +73,38 @@ def test_jax_profiler_training(mock_device: mock.Mock) -> None:
 
 
 @jax_mark
+def test_jax_profiler_training_streams_single_epoch_generator(
+    mock_device: mock.Mock,
+) -> None:
+    with mock.patch(
+        "stormlog.jax.profiler.jax.local_devices", return_value=[mock_device]
+    ):
+        with mock.patch("stormlog.jax.profiler.jax.numpy.zeros") as mock_zeros:
+            mock_zeros.return_value.block_until_ready.return_value = None
+            jp = JAXProfiler(device_index=0)
+            events: list[str] = []
+
+            def dataset() -> Any:
+                for batch in [1, 2, 3]:
+                    events.append(f"yield_{batch}")
+                    yield batch
+
+            def train_step(batch: int) -> None:
+                events.append(f"step_{batch}")
+
+            jp.profile_training(train_step, dataset(), epochs=1)
+
+            assert events == [
+                "yield_1",
+                "step_1",
+                "yield_2",
+                "step_2",
+                "yield_3",
+                "step_3",
+            ]
+
+
+@jax_mark
 def test_jax_profiler_inference_iterable(mock_device: mock.Mock) -> None:
     with mock.patch(
         "stormlog.jax.profiler.jax.local_devices", return_value=[mock_device]

--- a/tests/test_jax_profiler.py
+++ b/tests/test_jax_profiler.py
@@ -82,6 +82,7 @@ def test_profile_result_properties() -> None:
         function_profiles={},
     )
     assert result.duration == 2.0
+    assert result.memory_growth_rate == pytest.approx(4000 / (1024 * 1024) / 2.0)
 
 
 @jax_mark

--- a/tests/test_jax_tracker_coverage.py
+++ b/tests/test_jax_tracker_coverage.py
@@ -4,6 +4,10 @@ import time
 from typing import Any
 from unittest import mock
 
+import pytest
+
+pytest.importorskip("jax")
+
 from stormlog.jax.tracker import (
     COLLECTOR_HEALTH_HEALTHY,
     COLLECTOR_HEALTH_UNHEALTHY,

--- a/tests/test_jax_visualizer.py
+++ b/tests/test_jax_visualizer.py
@@ -3,6 +3,10 @@
 from typing import Any
 from unittest import mock
 
+import pytest
+
+pytest.importorskip("jax")
+
 from stormlog.jax.profiler import MemorySnapshot, ProfileResult
 from stormlog.jax.visualizer import MemoryVisualizer
 


### PR DESCRIPTION
## Summary
- Fix JAX pprof visualization stack attribution so flat memory is assigned to the leaf frame.
- Avoid materializing single-epoch generator datasets during JAX training profiling.
- Report JAX profile memory growth in MB/sec to match analyzer thresholds.
- Make JAX CLI module attributes patchable when JAX is not installed.
- Use --interval for jaxmemprof monitor sleep timing.
- Add regression tests and document the JAX test slice.

## Verification
- python3 -m compileall -q stormlog/jax test_jax_viz.py
- python3 -m black --check stormlog/jax tests/test_jax_attributed_viz.py tests/test_jax_cli_coverage.py tests/test_jax_profiler.py tests/test_jax_context_profiler.py tests/test_jax_analyzer.py tests/test_jax_visualizer.py tests/test_jax_tracker_coverage.py test_jax_viz.py
- python3 -m pytest tests/ -o "python_files=test_jax*.py" -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added telemetry rollup system with compact sidecar files for efficient session summaries and faster queries.
  * Query engine now uses rollup-based fast path for peak memory and alert metrics, with automatic fallback to event-based computation.
  * Added graceful handling when JAX is unavailable, with fallback implementations.

* **Bug Fixes**
  * Fixed memory growth rate reporting from bytes/second to MB/second.
  * Corrected stack ordering in memory analysis calculations.

* **Documentation**
  * Updated telemetry schema documentation with rollup sidecar details.
  * Expanded testing documentation with JAX-specific test guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->