### PR TITLE
Feature/investigate correlated investigation views

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -333,6 +333,29 @@ stormlog query summary ./live_sink \
   --group-by session-rank
 ```
 
+Find correlated evidence around a timestamp or projected telemetry record:
+
+```bash
+stormlog query correlate ./live_sink ./artifacts \
+  --at-ns 1800000000000000010 \
+  --session-id session-123 \
+  --window-ns 60000000000 \
+  --json
+
+stormlog query correlate ./distributed_runs \
+  --at-ns 1800000000000000010 \
+  --job-id train-42 \
+  --scope distributed \
+  --kind alert \
+  --kind oom_bundle
+```
+
+Correlation returns nearby evidence with confidence reasons instead of only
+listing artifacts. Evidence can include telemetry events, timeline markers,
+alerts, OOM bundles, diagnose bundles, rollup windows, and local attachment
+sidecars. Use `--record-id` instead of `--at-ns` to anchor on a projected
+telemetry record id.
+
 Supported output formats:
 
 - `--table`: readable table output, used by default

--- a/docs/correlation.md
+++ b/docs/correlation.md
@@ -72,6 +72,7 @@ Minimal shape:
   "format": "stormlog.attachments",
   "attachments": [
     {
+      "attachment_id": "wandb-run-123",
       "title": "W&B run",
       "kind": "experiment",
       "url": "https://wandb.ai/example/project/runs/run-123",
@@ -80,6 +81,7 @@ Minimal shape:
       "rank": 0,
       "start_ns": 1700000000000000000,
       "end_ns": 1700000060000000000,
+      "updated_at_utc": "2026-06-14T21:00:00Z",
       "metadata": {"owner": "training"}
     }
   ]
@@ -88,4 +90,6 @@ Minimal shape:
 
 Relative `path` values resolve against the sidecar directory. Each attachment
 must provide either `url` or `path`, and should provide identifiers and time
-bounds whenever possible.
+bounds whenever possible. `attachment_id` is optional but recommended for
+sidecars that are updated over time because it gives correlation output a stable
+evidence identity.

--- a/docs/correlation.md
+++ b/docs/correlation.md
@@ -1,0 +1,91 @@
+[← Back to main docs](index.md)
+
+# Correlation Workflow
+
+Stormlog correlation is a derived investigation view over existing artifacts. It
+does not change `TelemetryEvent v3`; instead, the query layer projects telemetry,
+markers, rollups, OOM bundles, diagnose manifests, and external attachments into
+one evidence list around an investigation anchor.
+
+## Minimum Contract
+
+A trustworthy correlation row needs enough identity, time, and provenance to let
+users understand why it appeared:
+
+- `session_id`: the strongest single-run grouping key
+- `job_id`: the distributed-run grouping key when ranks write separate sessions
+- `rank` and `world_size`: rank-local evidence placement
+- `start_ns` and `end_ns`: Unix epoch nanosecond bounds for point or interval evidence
+- `source_path` and `source_kind`: where the evidence came from
+- `metadata`: source-specific details such as event type, rollup counters, or
+  attachment attributes
+- `confidence` and `reasons`: a plain explanation of the match quality
+
+Correlation uses both identifiers and timestamps. Timestamp-only matches are
+kept as low-confidence fallbacks because they can be useful during partial
+recovery, but Stormlog labels them clearly instead of presenting them as proven
+links.
+
+## Single-Run And Distributed Correlation
+
+For a single run, `session_id` is the primary pivot. Evidence with the same
+session and an overlapping or nearby timestamp window is high confidence. When a
+rank is supplied, same-rank evidence is preferred; cross-rank evidence in the
+same session is still shown with a lower confidence reason.
+
+For distributed investigations, `job_id` links evidence across sessions and
+ranks. Stormlog keeps the same Unix epoch nanosecond clock domain used by
+telemetry records and reports cross-rank evidence when it overlaps the anchor
+window. If evidence lacks `session_id` and `job_id`, it can only match by time
+and is downgraded.
+
+Stormlog does not currently rewrite cross-host clocks. Producers should keep
+host clocks synchronized; consumers should inspect `observed_timestamp_ns`,
+source paths, and confidence reasons when debugging rank-to-rank timing.
+
+## Correlation Versus Listing
+
+Artifact listing answers "what exists?" Correlation answers "what evidence is
+near this suspicious point, and why is it related?" A correlated result is
+anchored by `--at-ns` or a projected telemetry `record_id`, filters evidence by
+identity and time, then sorts by confidence and distance from the anchor.
+
+This makes correlation suitable for pivots such as:
+
+- memory spikes to nearby phase markers
+- degraded collector periods to alert rows
+- OOM events to dump bundles and diagnose manifests
+- rollup windows to nearby raw telemetry
+- telemetry windows to external profiler or experiment-tracking links
+
+## External Attachments
+
+External attachments are discovered from `stormlog_attachments.json` sidecars.
+The sidecar is local JSON; Stormlog records URLs or local paths but does not
+fetch remote content during correlation.
+
+Minimal shape:
+
+```json
+{
+  "schema_version": 1,
+  "format": "stormlog.attachments",
+  "attachments": [
+    {
+      "title": "W&B run",
+      "kind": "experiment",
+      "url": "https://wandb.ai/example/project/runs/run-123",
+      "session_id": "session-123",
+      "job_id": "job-42",
+      "rank": 0,
+      "start_ns": 1700000000000000000,
+      "end_ns": 1700000060000000000,
+      "metadata": {"owner": "training"}
+    }
+  ]
+}
+```
+
+Relative `path` values resolve against the sidecar directory. Each attachment
+must provide either `url` or `path`, and should provide identifiers and time
+bounds whenever possible.

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,7 @@ telemetry_schema
 telemetry_projection
 query_layer
 issue_fingerprinting
+correlation
 pytorch_testing_guide
 tensorflow_testing_guide
 jax_testing_guide

--- a/docs/query_layer.md
+++ b/docs/query_layer.md
@@ -55,6 +55,10 @@ The row contracts are explicit and automation-friendly:
   `source_kind`, and `session_status`
 - `OOMBundleRow`: bundle path, creation time, backend, reason, event count,
   session linkage, and exception type/module
+- `ExternalAttachment`: local attachment sidecar rows that link URLs or local
+  paths to session/job/rank/time metadata
+- `CorrelationEvidence`: derived evidence rows with confidence and reasons for
+  investigation pivots around a timestamp or projected telemetry record
 - `StormlogIssue`: grouped issue fingerprint, state, hit count, first/last
   seen timestamps, affected sessions, representative evidence, and evidence
   links back to raw sessions/events/bundles
@@ -62,6 +66,14 @@ The row contracts are explicit and automation-friendly:
 
 The canonical telemetry schema remains the event contract. Query rows add
 provenance but do not mutate persisted telemetry records.
+
+`QueryStore.correlate(...)` is the first correlation-oriented query surface. It
+collects telemetry events, derived timeline markers, alerts, OOM bundles,
+diagnose manifests, fresh rollup windows, and `stormlog_attachments.json`
+sidecars into one evidence list. Correlation requires a timestamp anchor or a
+projected telemetry `record_id`; rows are ranked by identifier match, time-window
+overlap, and distance from the anchor. See [Correlation Workflow](correlation.md)
+for the matching contract.
 
 Issue grouping is also derived. `QueryStore.list_issues()` groups OOMs,
 collector degradation, alerts, and hidden-memory anomalies using deterministic

--- a/docs/schemas/stormlog_attachments_v1.schema.json
+++ b/docs/schemas/stormlog_attachments_v1.schema.json
@@ -40,6 +40,10 @@
           "type": "string",
           "minLength": 1
         },
+        "attachment_id": {
+          "type": ["string", "null"],
+          "minLength": 1
+        },
         "url": {
           "type": ["string", "null"],
           "minLength": 1
@@ -69,6 +73,9 @@
           "minimum": 0
         },
         "created_at_utc": {
+          "type": ["string", "null"]
+        },
+        "updated_at_utc": {
           "type": ["string", "null"]
         },
         "metadata": {

--- a/docs/schemas/stormlog_attachments_v1.schema.json
+++ b/docs/schemas/stormlog_attachments_v1.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Silas-Asamoah/stormlog/docs/schemas/stormlog_attachments_v1.schema.json",
+  "title": "Stormlog Attachments v1",
+  "description": "External evidence sidecar for local Stormlog correlation queries.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "format", "attachments"],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "format": {
+      "type": "string",
+      "const": "stormlog.attachments"
+    },
+    "attachments": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/attachment"
+      }
+    }
+  },
+  "$defs": {
+    "attachment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title", "kind", "metadata"],
+      "anyOf": [
+        {"required": ["url"]},
+        {"required": ["path"]}
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "url": {
+          "type": ["string", "null"],
+          "minLength": 1
+        },
+        "path": {
+          "type": ["string", "null"],
+          "minLength": 1
+        },
+        "session_id": {
+          "type": ["string", "null"],
+          "minLength": 1
+        },
+        "job_id": {
+          "type": ["string", "null"],
+          "minLength": 1
+        },
+        "rank": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        },
+        "start_ns": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        },
+        "end_ns": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        },
+        "created_at_utc": {
+          "type": ["string", "null"]
+        },
+        "metadata": {
+          "type": "object"
+        }
+      }
+    }
+  }
+}

--- a/docs/telemetry_schema.md
+++ b/docs/telemetry_schema.md
@@ -234,10 +234,11 @@ Each attachment includes:
 
 - `title`
 - `kind`
+- `attachment_id` for stable lifecycle-managed sidecars
 - `url` or `path`
 - `session_id`, `job_id`, and `rank` when known
 - `start_ns` and `end_ns` when the attachment is time-bounded
-- `created_at_utc`
+- `created_at_utc` and `updated_at_utc`
 - `metadata`
 
 Relative `path` values resolve against the sidecar directory. Stormlog records

--- a/docs/telemetry_schema.md
+++ b/docs/telemetry_schema.md
@@ -212,6 +212,37 @@ future sidecar or catalog layer. They can share the `TimelineMarker` shape, but
 they should use an annotation-specific `source` rather than mutating historical
 telemetry records.
 
+## External attachment sidecars
+
+Correlation queries can also discover local `stormlog_attachments.json`
+sidecars. These sidecars are not raw telemetry and do not change
+`TelemetryEvent v3`; they are catalog/query-layer metadata that links external
+evidence such as experiment-tracking URLs, profiler traces, or runbooks to a
+session/job/rank/time window.
+
+Schema file:
+
+- `docs/schemas/stormlog_attachments_v1.schema.json`
+
+Top-level fields:
+
+- `schema_version` (`1`)
+- `format` (`stormlog.attachments`)
+- `attachments`
+
+Each attachment includes:
+
+- `title`
+- `kind`
+- `url` or `path`
+- `session_id`, `job_id`, and `rank` when known
+- `start_ns` and `end_ns` when the attachment is time-bounded
+- `created_at_utc`
+- `metadata`
+
+Relative `path` values resolve against the sidecar directory. Stormlog records
+remote URLs but does not fetch them during local correlation.
+
 ## Analyzer phase attribution payloads
 
 Analyze and Diagnostics outputs may also include a derived

--- a/stormlog/correlation.py
+++ b/stormlog/correlation.py
@@ -1,0 +1,151 @@
+"""Derived correlation rows for local Stormlog artifact investigations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, Mapping, Sequence
+
+ATTACHMENTS_FILENAME = "stormlog_attachments.json"
+ATTACHMENTS_FORMAT = "stormlog.attachments"
+ATTACHMENTS_SCHEMA_VERSION = 1
+DEFAULT_CORRELATION_WINDOW_NS = 60_000_000_000
+
+CorrelationScope = Literal["session", "distributed"]
+
+
+@dataclass(frozen=True)
+class CorrelationFilter:
+    """Filters and anchor selection for a correlation query."""
+
+    session_id: str | None = None
+    job_id: str | None = None
+    rank: int | None = None
+    scope: CorrelationScope = "session"
+    at_ns: int | None = None
+    record_id: str | None = None
+    window_ns: int = DEFAULT_CORRELATION_WINDOW_NS
+    kinds: tuple[str, ...] = ()
+    limit: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.scope not in {"session", "distributed"}:
+            raise ValueError("scope must be 'session' or 'distributed'")
+        if self.window_ns < 0:
+            raise ValueError("window_ns must be >= 0")
+        if self.limit is not None and self.limit < 0:
+            raise ValueError("limit must be >= 0")
+
+
+@dataclass(frozen=True)
+class CorrelationEvidence:
+    """One piece of evidence related to a correlation anchor."""
+
+    evidence_id: str
+    kind: str
+    title: str
+    session_id: str | None
+    job_id: str | None
+    rank: int | None
+    world_size: int | None
+    start_ns: int | None
+    end_ns: int | None
+    source_path: str
+    source_kind: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    confidence: str = "low"
+    reasons: tuple[str, ...] = ()
+
+    def as_dict(self) -> dict[str, Any]:
+        """Serialize the evidence row to a JSON-safe dictionary."""
+        return {
+            "evidence_id": self.evidence_id,
+            "kind": self.kind,
+            "title": self.title,
+            "session_id": self.session_id,
+            "job_id": self.job_id,
+            "rank": self.rank,
+            "world_size": self.world_size,
+            "start_ns": self.start_ns,
+            "end_ns": self.end_ns,
+            "source_path": self.source_path,
+            "source_kind": self.source_kind,
+            "metadata": dict(self.metadata),
+            "confidence": self.confidence,
+            "reasons": list(self.reasons),
+        }
+
+
+@dataclass(frozen=True)
+class CorrelationResult:
+    """Correlation query output anchored to a timestamp or telemetry record."""
+
+    anchor: Mapping[str, Any]
+    evidence: Sequence[CorrelationEvidence] = ()
+    warnings: Sequence[str] = ()
+
+    def as_dict(self) -> dict[str, Any]:
+        """Serialize the result to a JSON-safe dictionary."""
+        return {
+            "anchor": dict(self.anchor),
+            "evidence": [row.as_dict() for row in self.evidence],
+            "warnings": list(self.warnings),
+        }
+
+
+@dataclass(frozen=True)
+class AttachmentFilter:
+    """Filters for external attachment sidecar rows."""
+
+    session_id: str | None = None
+    job_id: str | None = None
+    rank: int | None = None
+    kind: str | None = None
+
+
+@dataclass(frozen=True)
+class ExternalAttachment:
+    """External evidence discovered from a local attachment sidecar."""
+
+    title: str
+    kind: str
+    url: str | None
+    path: str | None
+    session_id: str | None
+    job_id: str | None
+    rank: int | None
+    start_ns: int | None
+    end_ns: int | None
+    created_at_utc: str | None
+    metadata: Mapping[str, Any]
+    sidecar_path: str
+
+    def as_dict(self) -> dict[str, Any]:
+        """Serialize the attachment row to a JSON-safe dictionary."""
+        return {
+            "title": self.title,
+            "kind": self.kind,
+            "url": self.url,
+            "path": self.path,
+            "session_id": self.session_id,
+            "job_id": self.job_id,
+            "rank": self.rank,
+            "start_ns": self.start_ns,
+            "end_ns": self.end_ns,
+            "created_at_utc": self.created_at_utc,
+            "metadata": dict(self.metadata),
+            "sidecar_path": self.sidecar_path,
+        }
+
+
+__all__ = [
+    "ATTACHMENTS_FILENAME",
+    "ATTACHMENTS_FORMAT",
+    "ATTACHMENTS_SCHEMA_VERSION",
+    "DEFAULT_CORRELATION_WINDOW_NS",
+    "AttachmentFilter",
+    "CorrelationEvidence",
+    "CorrelationFilter",
+    "CorrelationResult",
+    "CorrelationScope",
+    "ExternalAttachment",
+]

--- a/stormlog/correlation.py
+++ b/stormlog/correlation.py
@@ -8,6 +8,8 @@ from typing import Any, Literal, Mapping, Sequence
 ATTACHMENTS_FILENAME = "stormlog_attachments.json"
 ATTACHMENTS_FORMAT = "stormlog.attachments"
 ATTACHMENTS_SCHEMA_VERSION = 1
+CLOCK_DOMAIN_UNIX_EPOCH_NS = "unix_epoch_ns"
+CLOCK_NORMALIZATION_PRODUCER_EPOCH_NS = "producer_emitted_epoch_ns"
 DEFAULT_CORRELATION_WINDOW_NS = 60_000_000_000
 
 CorrelationScope = Literal["session", "distributed"]
@@ -108,6 +110,7 @@ class ExternalAttachment:
 
     title: str
     kind: str
+    attachment_id: str | None
     url: str | None
     path: str | None
     session_id: str | None
@@ -116,6 +119,7 @@ class ExternalAttachment:
     start_ns: int | None
     end_ns: int | None
     created_at_utc: str | None
+    updated_at_utc: str | None
     metadata: Mapping[str, Any]
     sidecar_path: str
 
@@ -124,6 +128,7 @@ class ExternalAttachment:
         return {
             "title": self.title,
             "kind": self.kind,
+            "attachment_id": self.attachment_id,
             "url": self.url,
             "path": self.path,
             "session_id": self.session_id,
@@ -132,6 +137,7 @@ class ExternalAttachment:
             "start_ns": self.start_ns,
             "end_ns": self.end_ns,
             "created_at_utc": self.created_at_utc,
+            "updated_at_utc": self.updated_at_utc,
             "metadata": dict(self.metadata),
             "sidecar_path": self.sidecar_path,
         }
@@ -141,6 +147,8 @@ __all__ = [
     "ATTACHMENTS_FILENAME",
     "ATTACHMENTS_FORMAT",
     "ATTACHMENTS_SCHEMA_VERSION",
+    "CLOCK_DOMAIN_UNIX_EPOCH_NS",
+    "CLOCK_NORMALIZATION_PRODUCER_EPOCH_NS",
     "DEFAULT_CORRELATION_WINDOW_NS",
     "AttachmentFilter",
     "CorrelationEvidence",

--- a/stormlog/query.py
+++ b/stormlog/query.py
@@ -1842,12 +1842,16 @@ def _evidence_distance_ns(
 ) -> int:
     if at_ns is None:
         return 0
-    starts = [
+    bounds = [
         value for value in (evidence.start_ns, evidence.end_ns) if value is not None
     ]
-    if not starts:
+    if not bounds:
         return 0
-    return min(abs(value - at_ns) for value in starts)
+    start_ns = min(bounds)
+    end_ns = max(bounds)
+    if start_ns <= at_ns <= end_ns:
+        return 0
+    return min(abs(start_ns - at_ns), abs(end_ns - at_ns))
 
 
 def _evidence_id(*parts: object) -> str:

--- a/stormlog/query.py
+++ b/stormlog/query.py
@@ -17,6 +17,8 @@ from .correlation import (
     ATTACHMENTS_FILENAME,
     ATTACHMENTS_FORMAT,
     ATTACHMENTS_SCHEMA_VERSION,
+    CLOCK_DOMAIN_UNIX_EPOCH_NS,
+    CLOCK_NORMALIZATION_PRODUCER_EPOCH_NS,
     AttachmentFilter,
     CorrelationEvidence,
     CorrelationFilter,
@@ -969,6 +971,9 @@ class QueryStore:
                     "event_type": row.event.event_type,
                     "scope": filters.scope,
                     "window_ns": filters.window_ns,
+                    "clock_domain": CLOCK_DOMAIN_UNIX_EPOCH_NS,
+                    "clock_normalization": CLOCK_NORMALIZATION_PRODUCER_EPOCH_NS,
+                    "clock_note": "correlation does not rewrite cross-host clocks",
                 }
             raise ValueError(f"record_id not found: {filters.record_id}")
         return {
@@ -983,6 +988,9 @@ class QueryStore:
             "event_type": None,
             "scope": filters.scope,
             "window_ns": filters.window_ns,
+            "clock_domain": CLOCK_DOMAIN_UNIX_EPOCH_NS,
+            "clock_normalization": CLOCK_NORMALIZATION_PRODUCER_EPOCH_NS,
+            "clock_note": "correlation does not rewrite cross-host clocks",
         }
 
     def _correlation_evidence(
@@ -1259,6 +1267,7 @@ def _attachment_from_payload(
     return ExternalAttachment(
         title=title,
         kind=kind,
+        attachment_id=_string_or_none(payload.get("attachment_id")),
         url=url,
         path=resolved_path,
         session_id=_string_or_none(payload.get("session_id")),
@@ -1267,6 +1276,7 @@ def _attachment_from_payload(
         start_ns=start_ns,
         end_ns=end_ns,
         created_at_utc=_string_or_none(payload.get("created_at_utc")),
+        updated_at_utc=_string_or_none(payload.get("updated_at_utc")),
         metadata=dict(metadata) if isinstance(metadata, Mapping) else {},
         sidecar_path=str(sidecar_path),
     )
@@ -1630,6 +1640,7 @@ def _attachment_correlation_evidence(
             CorrelationEvidence(
                 evidence_id=_evidence_id(
                     "attachment",
+                    attachment.attachment_id,
                     attachment.sidecar_path,
                     attachment.title,
                     attachment.url,

--- a/stormlog/query.py
+++ b/stormlog/query.py
@@ -4,14 +4,25 @@ from __future__ import annotations
 
 import builtins
 import csv
+import hashlib
 import json
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal, cast
 
+from .correlation import (
+    ATTACHMENTS_FILENAME,
+    ATTACHMENTS_FORMAT,
+    ATTACHMENTS_SCHEMA_VERSION,
+    AttachmentFilter,
+    CorrelationEvidence,
+    CorrelationFilter,
+    CorrelationResult,
+    ExternalAttachment,
+)
 from .gap_analysis import analyze_hidden_memory_gaps
 from .issues import (
     ISSUE_STATE_OPEN,
@@ -43,6 +54,7 @@ from .telemetry import (
     TelemetryEvent,
     TelemetryEventV2,
     load_telemetry_sessions,
+    project_telemetry_event,
     telemetry_event_from_record,
     telemetry_event_to_dict,
 )
@@ -66,6 +78,10 @@ from .telemetry_sink import (
     TelemetrySinkManifest,
     read_telemetry_sink_manifest,
     resolve_telemetry_sink_segment_paths,
+)
+from .timeline_markers import (
+    derive_session_timeline_markers,
+    timeline_marker_to_dict,
 )
 from .utils import format_bytes
 
@@ -334,9 +350,11 @@ class ArtifactCatalog:
         self.paths = tuple(Path(path) for path in paths)
         self.sources: list[CatalogSource] = []
         self.oom_bundles: list[CatalogOOMBundle] = []
+        self.attachments: list[ExternalAttachment] = []
         self.warnings: list[CatalogWarning] = []
         self._source_keys: set[tuple[Path, SourceKind]] = set()
         self._oom_bundle_paths: set[Path] = set()
+        self._attachment_sidecar_paths: set[Path] = set()
         self._covered_event_paths: set[Path] = set()
         self._discover()
 
@@ -345,6 +363,7 @@ class ArtifactCatalog:
             "paths": [str(path) for path in self.paths],
             "sources": [source.as_dict() for source in self.sources],
             "oom_bundles": [bundle.as_dict() for bundle in self.oom_bundles],
+            "attachments": [attachment.as_dict() for attachment in self.attachments],
             "warnings": [warning.as_dict() for warning in self.warnings],
         }
 
@@ -365,6 +384,7 @@ class ArtifactCatalog:
         self._discover_directory(path)
 
     def _discover_directory(self, directory: Path) -> None:
+        self._discover_attachment_sidecar(directory / ATTACHMENTS_FILENAME)
         manifest_path = directory / MANIFEST_FILENAME
         manifest_payload = _read_json_object(manifest_path)
         if manifest_payload is not None:
@@ -420,12 +440,18 @@ class ArtifactCatalog:
                     )
                 )
 
+        for attachment_sidecar in sorted(directory.rglob(ATTACHMENTS_FILENAME)):
+            self._discover_attachment_sidecar(attachment_sidecar)
+
         for candidate in self._discover_candidate_files(directory):
             if candidate in self._covered_event_paths:
                 continue
             self._discover_file(candidate)
 
     def _discover_file(self, path: Path) -> None:
+        if path.name == ATTACHMENTS_FILENAME:
+            self._discover_attachment_sidecar(path)
+            return
         if path.name == MANIFEST_FILENAME:
             payload = _read_json_object(path)
             if payload is None:
@@ -538,6 +564,34 @@ class ArtifactCatalog:
             )
         )
 
+    def _discover_attachment_sidecar(self, path: Path) -> None:
+        if not path.exists() or not path.is_file():
+            return
+        resolved = path.resolve()
+        if resolved in self._attachment_sidecar_paths:
+            return
+        self._attachment_sidecar_paths.add(resolved)
+        payload = _read_json_object(path)
+        if payload is None:
+            self._warn(path, "attachment sidecar is not a JSON object")
+            return
+        if not _is_attachment_sidecar(payload):
+            self._warn(path, "unrecognized attachment sidecar shape")
+            return
+        attachments = payload.get("attachments")
+        if not isinstance(attachments, Sequence) or isinstance(attachments, str):
+            self._warn(path, "attachment sidecar attachments must be a list")
+            return
+        for index, item in enumerate(attachments):
+            if not isinstance(item, Mapping):
+                self._warn(path, f"attachment {index} is not an object")
+                continue
+            attachment = _attachment_from_payload(item, path)
+            if attachment is None:
+                self._warn(path, f"attachment {index} is invalid")
+                continue
+            self.attachments.append(attachment)
+
     def _warn(self, path: Path, message: str) -> None:
         self.warnings.append(CatalogWarning(path=str(path), message=message))
 
@@ -632,6 +686,36 @@ class QueryStore:
         rows = [row for row in rows if _oom_matches(row, filters)]
         rows.sort(key=lambda row: (row.created_at_utc or "", row.bundle_path))
         return rows
+
+    def list_attachments(
+        self,
+        filters: AttachmentFilter | None = None,
+    ) -> list[ExternalAttachment]:
+        """Return filtered external attachment sidecar rows."""
+        filters = filters or AttachmentFilter()
+        rows = [
+            attachment
+            for attachment in self.catalog.attachments
+            if _attachment_matches(attachment, filters)
+        ]
+        rows.sort(
+            key=lambda row: (
+                row.start_ns if row.start_ns is not None else -1,
+                row.title,
+                row.sidecar_path,
+            )
+        )
+        return rows
+
+    def correlate(self, filters: CorrelationFilter) -> CorrelationResult:
+        """Return evidence related to a timestamp or telemetry record anchor."""
+        anchor = self._correlation_anchor(filters)
+        evidence = self._correlation_evidence(anchor, filters)
+        return CorrelationResult(
+            anchor=anchor,
+            evidence=evidence,
+            warnings=[warning.message for warning in self.catalog.warnings],
+        )
 
     def list_issues(
         self,
@@ -860,6 +944,215 @@ class QueryStore:
         self._loaded_sessions_by_source[key] = loaded
         return loaded
 
+    def _correlation_anchor(self, filters: CorrelationFilter) -> dict[str, Any]:
+        if filters.record_id is None and filters.at_ns is None:
+            raise ValueError("correlation requires --at-ns or --record-id")
+        if filters.record_id is not None:
+            for row in self.query_events(EventFilter()):
+                projected = project_telemetry_event(row.event)
+                if projected.record_id != filters.record_id:
+                    continue
+                if (
+                    filters.at_ns is not None
+                    and filters.at_ns != projected.timestamp_ns
+                ):
+                    raise ValueError("record_id timestamp does not match at_ns")
+                return {
+                    "at_ns": projected.timestamp_ns,
+                    "record_id": projected.record_id,
+                    "session_id": row.event.session_id,
+                    "job_id": row.event.job_id,
+                    "rank": row.event.rank,
+                    "world_size": row.event.world_size,
+                    "source_path": row.source_path,
+                    "source_kind": row.source_kind,
+                    "event_type": row.event.event_type,
+                    "scope": filters.scope,
+                    "window_ns": filters.window_ns,
+                }
+            raise ValueError(f"record_id not found: {filters.record_id}")
+        return {
+            "at_ns": filters.at_ns,
+            "record_id": None,
+            "session_id": filters.session_id,
+            "job_id": filters.job_id,
+            "rank": filters.rank,
+            "world_size": None,
+            "source_path": None,
+            "source_kind": None,
+            "event_type": None,
+            "scope": filters.scope,
+            "window_ns": filters.window_ns,
+        }
+
+    def _correlation_evidence(
+        self,
+        anchor: Mapping[str, Any],
+        filters: CorrelationFilter,
+    ) -> list[CorrelationEvidence]:
+        rows: list[CorrelationEvidence] = []
+        for candidate in self._candidate_correlation_evidence():
+            matched = _match_correlation_evidence(candidate, anchor, filters)
+            if matched is not None:
+                rows.append(matched)
+        rows.sort(key=lambda row: _correlation_sort_key(row, anchor))
+        if filters.limit is not None:
+            return rows[: filters.limit]
+        return rows
+
+    def _candidate_correlation_evidence(self) -> list[CorrelationEvidence]:
+        evidence: list[CorrelationEvidence] = []
+        event_rows = self.query_events(EventFilter())
+        evidence.extend(_event_correlation_evidence(event_rows))
+        evidence.extend(_alert_correlation_evidence(event_rows))
+        evidence.extend(self._marker_correlation_evidence())
+        evidence.extend(self._oom_correlation_evidence())
+        evidence.extend(self._diagnose_correlation_evidence())
+        evidence.extend(self._rollup_correlation_evidence())
+        evidence.extend(_attachment_correlation_evidence(self.catalog.attachments))
+        return evidence
+
+    def _marker_correlation_evidence(self) -> list[CorrelationEvidence]:
+        evidence: list[CorrelationEvidence] = []
+        for source in self.catalog.sources:
+            for loaded in self._load_sessions_for_source(source):
+                source_path = _event_source_path(loaded, source)
+                for marker in derive_session_timeline_markers(loaded):
+                    evidence.append(
+                        CorrelationEvidence(
+                            evidence_id=_evidence_id(
+                                "marker",
+                                marker.session_id,
+                                marker.kind,
+                                marker.start_ns,
+                                marker.rank,
+                                marker.label,
+                            ),
+                            kind="timeline_marker",
+                            title=marker.label,
+                            session_id=marker.session_id,
+                            job_id=loaded.summary.job_id,
+                            rank=marker.rank,
+                            world_size=marker.world_size,
+                            start_ns=marker.start_ns,
+                            end_ns=marker.end_ns,
+                            source_path=source_path,
+                            source_kind=source.source_kind,
+                            metadata=timeline_marker_to_dict(marker),
+                        )
+                    )
+        return evidence
+
+    def _oom_correlation_evidence(self) -> list[CorrelationEvidence]:
+        session_by_id = {
+            session.session_id: session for session in self.list_sessions()
+        }
+        evidence: list[CorrelationEvidence] = []
+        for row in self.list_oom_bundles():
+            summary = (
+                session_by_id.get(row.session_id)
+                if row.session_id is not None
+                else None
+            )
+            seen_ns = _datetime_to_ns(_parse_datetime(row.created_at_utc))
+            evidence.append(
+                CorrelationEvidence(
+                    evidence_id=_evidence_id("oom", row.bundle_path, row.session_id),
+                    kind="oom_bundle",
+                    title="OOM bundle",
+                    session_id=row.session_id,
+                    job_id=summary.job_id if summary is not None else None,
+                    rank=summary.rank if summary is not None else None,
+                    world_size=summary.world_size if summary is not None else None,
+                    start_ns=seen_ns,
+                    end_ns=seen_ns,
+                    source_path=row.bundle_path,
+                    source_kind="oom_bundle",
+                    metadata=row.as_dict(),
+                )
+            )
+        return evidence
+
+    def _diagnose_correlation_evidence(self) -> list[CorrelationEvidence]:
+        evidence: list[CorrelationEvidence] = []
+        for source in self.catalog.sources:
+            if source.source_kind != "diagnose_bundle":
+                continue
+            summary = _diagnose_session_summary(source.manifest_path)
+            if summary is None:
+                continue
+            evidence.append(
+                CorrelationEvidence(
+                    evidence_id=_evidence_id(
+                        "diagnose",
+                        str(source.manifest_path),
+                        summary.session_id,
+                    ),
+                    kind="diagnose_bundle",
+                    title="Diagnose bundle",
+                    session_id=summary.session_id,
+                    job_id=summary.job_id,
+                    rank=summary.rank,
+                    world_size=summary.world_size,
+                    start_ns=summary.started_at_ns,
+                    end_ns=summary.ended_at_ns,
+                    source_path=str(source.path),
+                    source_kind=source.source_kind,
+                    metadata={
+                        "manifest_path": (
+                            str(source.manifest_path)
+                            if source.manifest_path is not None
+                            else None
+                        ),
+                        "session_status": summary.status,
+                    },
+                )
+            )
+        return evidence
+
+    def _rollup_correlation_evidence(self) -> list[CorrelationEvidence]:
+        evidence: list[CorrelationEvidence] = []
+        for source in self.catalog.sources:
+            if source.source_kind != "sink":
+                continue
+            rollup = read_telemetry_rollups(source.path)
+            if rollup is None:
+                continue
+            for session in rollup.sessions:
+                for window in session.windows:
+                    evidence.append(
+                        CorrelationEvidence(
+                            evidence_id=_evidence_id(
+                                "rollup",
+                                session.session.session_id,
+                                window.index,
+                                window.start_ns,
+                            ),
+                            kind="rollup_window",
+                            title=f"Rollup window {window.index}",
+                            session_id=session.session.session_id,
+                            job_id=session.session.job_id,
+                            rank=None,
+                            world_size=session.session.world_size,
+                            start_ns=window.start_ns,
+                            end_ns=window.end_ns,
+                            source_path=str(source.path),
+                            source_kind="rollup",
+                            metadata={
+                                "event_count": window.event_count,
+                                "sample_count": window.sample_count,
+                                "rank_count": window.rank_count,
+                                "alert_count": window.alert_count,
+                                "collector_transition_count": (
+                                    window.collector_transition_count
+                                ),
+                                "oom_count": window.oom_count,
+                                "window_duration_ns": rollup.window_duration_ns,
+                            },
+                        )
+                    )
+        return evidence
+
     def _summarize_session_count_by_status(self) -> list[SummaryRow]:
         counts: dict[str, int] = defaultdict(int)
         for row in self.list_sessions(SessionFilter()):
@@ -930,6 +1223,52 @@ def _is_diagnose_manifest(payload: Mapping[str, Any]) -> bool:
         and "files" in payload
         and "risk_detected" in payload
         and "session_id" in payload
+    )
+
+
+def _is_attachment_sidecar(payload: Mapping[str, Any]) -> bool:
+    return (
+        payload.get("schema_version") == ATTACHMENTS_SCHEMA_VERSION
+        and payload.get("format") == ATTACHMENTS_FORMAT
+    )
+
+
+def _attachment_from_payload(
+    payload: Mapping[str, Any],
+    sidecar_path: Path,
+) -> ExternalAttachment | None:
+    title = _string_or_none(payload.get("title"))
+    kind = _string_or_none(payload.get("kind"))
+    if title is None or kind is None:
+        return None
+    url = _string_or_none(payload.get("url"))
+    raw_path = _string_or_none(payload.get("path"))
+    if url is None and raw_path is None:
+        return None
+    resolved_path: str | None = None
+    if raw_path is not None:
+        path = Path(raw_path)
+        if not path.is_absolute():
+            path = sidecar_path.parent / path
+        resolved_path = str(path.resolve())
+    start_ns = _int_or_none(payload.get("start_ns"))
+    end_ns = _int_or_none(payload.get("end_ns"))
+    if start_ns is not None and end_ns is not None and end_ns < start_ns:
+        return None
+    metadata = payload.get("metadata")
+    return ExternalAttachment(
+        title=title,
+        kind=kind,
+        url=url,
+        path=resolved_path,
+        session_id=_string_or_none(payload.get("session_id")),
+        job_id=_string_or_none(payload.get("job_id")),
+        rank=_int_or_none(payload.get("rank")),
+        start_ns=start_ns,
+        end_ns=end_ns,
+        created_at_utc=_string_or_none(payload.get("created_at_utc")),
+        metadata=dict(metadata) if isinstance(metadata, Mapping) else {},
+        sidecar_path=str(sidecar_path),
     )
 
 
@@ -1186,6 +1525,324 @@ def _oom_matches(row: OOMBundleRow, filters: OOMBundleFilter) -> bool:
     if before is not None and (created is None or created > before):
         return False
     return True
+
+
+def _attachment_matches(
+    row: ExternalAttachment,
+    filters: AttachmentFilter,
+) -> bool:
+    if filters.session_id is not None and row.session_id != filters.session_id:
+        return False
+    if filters.job_id is not None and row.job_id != filters.job_id:
+        return False
+    if filters.rank is not None and row.rank != filters.rank:
+        return False
+    if filters.kind is not None and row.kind != filters.kind:
+        return False
+    return True
+
+
+def _event_correlation_evidence(
+    rows: Sequence[EventRow],
+) -> list[CorrelationEvidence]:
+    evidence: list[CorrelationEvidence] = []
+    for row in rows:
+        event = row.event
+        projected = project_telemetry_event(event)
+        metadata = {
+            "record_id": projected.record_id,
+            "observed_timestamp_ns": projected.observed_timestamp_ns,
+            "event_type": event.event_type,
+            "collector": event.collector,
+            "context": event.context,
+            "session_status": row.session_status,
+            "metadata": event.metadata,
+        }
+        evidence.append(
+            CorrelationEvidence(
+                evidence_id=f"event:{projected.record_id}",
+                kind="telemetry_event",
+                title=f"{event.event_type} telemetry event",
+                session_id=event.session_id,
+                job_id=event.job_id,
+                rank=event.rank,
+                world_size=event.world_size,
+                start_ns=event.timestamp_ns,
+                end_ns=None,
+                source_path=row.source_path,
+                source_kind=row.source_kind,
+                metadata=metadata,
+            )
+        )
+    return evidence
+
+
+def _alert_correlation_evidence(
+    rows: Sequence[EventRow],
+) -> list[CorrelationEvidence]:
+    evidence: list[CorrelationEvidence] = []
+    for row in rows:
+        event = row.event
+        if not is_alert_event(event):
+            continue
+        evidence.append(
+            CorrelationEvidence(
+                evidence_id=_evidence_id(
+                    "alert",
+                    event.session_id,
+                    event.timestamp_ns,
+                    event.rank,
+                    event.event_type,
+                ),
+                kind="alert",
+                title=f"Alert: {event.event_type}",
+                session_id=event.session_id,
+                job_id=event.job_id,
+                rank=event.rank,
+                world_size=event.world_size,
+                start_ns=event.timestamp_ns,
+                end_ns=None,
+                source_path=row.source_path,
+                source_kind=row.source_kind,
+                metadata={
+                    "event_type": event.event_type,
+                    "severity": event_severity(event),
+                    "collector": event.collector,
+                    "context": event.context,
+                    "metadata": event.metadata,
+                },
+            )
+        )
+    return evidence
+
+
+def _attachment_correlation_evidence(
+    attachments: Sequence[ExternalAttachment],
+) -> list[CorrelationEvidence]:
+    evidence: list[CorrelationEvidence] = []
+    for attachment in attachments:
+        created_ns = _datetime_to_ns(_parse_datetime(attachment.created_at_utc))
+        start_ns = (
+            attachment.start_ns if attachment.start_ns is not None else created_ns
+        )
+        end_ns = attachment.end_ns if attachment.end_ns is not None else start_ns
+        evidence.append(
+            CorrelationEvidence(
+                evidence_id=_evidence_id(
+                    "attachment",
+                    attachment.sidecar_path,
+                    attachment.title,
+                    attachment.url,
+                    attachment.path,
+                ),
+                kind="attachment",
+                title=attachment.title,
+                session_id=attachment.session_id,
+                job_id=attachment.job_id,
+                rank=attachment.rank,
+                world_size=None,
+                start_ns=start_ns,
+                end_ns=end_ns,
+                source_path=attachment.url
+                or attachment.path
+                or attachment.sidecar_path,
+                source_kind="attachment",
+                metadata=attachment.as_dict(),
+            )
+        )
+    return evidence
+
+
+def _match_correlation_evidence(
+    evidence: CorrelationEvidence,
+    anchor: Mapping[str, Any],
+    filters: CorrelationFilter,
+) -> CorrelationEvidence | None:
+    if filters.kinds and evidence.kind not in filters.kinds:
+        return None
+    if not _explicit_correlation_filters_match(evidence, filters):
+        return None
+
+    anchor_at = cast(int | None, anchor.get("at_ns"))
+    if anchor_at is None:
+        return None
+
+    has_time = evidence.start_ns is not None or evidence.end_ns is not None
+    time_matches = (
+        _evidence_overlaps_anchor_window(evidence, anchor_at, filters.window_ns)
+        if has_time
+        else False
+    )
+    identity_match = _identity_match(evidence, anchor, filters.scope)
+    if has_time and not time_matches:
+        return None
+    if identity_match is None and not time_matches:
+        return None
+    if _has_identity_conflict(evidence, anchor, filters.scope):
+        return None
+
+    confidence, reasons = _correlation_confidence(
+        evidence,
+        anchor,
+        identity_match,
+        has_time,
+        time_matches,
+    )
+    return replace(evidence, confidence=confidence, reasons=tuple(reasons))
+
+
+def _explicit_correlation_filters_match(
+    evidence: CorrelationEvidence,
+    filters: CorrelationFilter,
+) -> bool:
+    if filters.session_id is not None and evidence.session_id != filters.session_id:
+        return False
+    if filters.job_id is not None and evidence.job_id != filters.job_id:
+        return False
+    if (
+        filters.rank is not None
+        and evidence.rank is not None
+        and evidence.rank != filters.rank
+    ):
+        return False
+    return True
+
+
+def _evidence_overlaps_anchor_window(
+    evidence: CorrelationEvidence,
+    at_ns: int,
+    window_ns: int,
+) -> bool:
+    evidence_start = (
+        evidence.start_ns if evidence.start_ns is not None else evidence.end_ns
+    )
+    evidence_end = evidence.end_ns if evidence.end_ns is not None else evidence.start_ns
+    if evidence_start is None or evidence_end is None:
+        return False
+    anchor_start = at_ns - window_ns
+    anchor_end = at_ns + window_ns
+    return evidence_start <= anchor_end and evidence_end >= anchor_start
+
+
+def _identity_match(
+    evidence: CorrelationEvidence,
+    anchor: Mapping[str, Any],
+    scope: str,
+) -> str | None:
+    anchor_session = _string_or_none(anchor.get("session_id"))
+    anchor_job = _string_or_none(anchor.get("job_id"))
+    if (
+        anchor_session is not None
+        and evidence.session_id is not None
+        and evidence.session_id == anchor_session
+    ):
+        return "session"
+    if (
+        scope == "distributed"
+        and anchor_job is not None
+        and evidence.job_id is not None
+        and evidence.job_id == anchor_job
+    ):
+        return "job"
+    return None
+
+
+def _has_identity_conflict(
+    evidence: CorrelationEvidence,
+    anchor: Mapping[str, Any],
+    scope: str,
+) -> bool:
+    anchor_session = _string_or_none(anchor.get("session_id"))
+    anchor_job = _string_or_none(anchor.get("job_id"))
+    same_job = (
+        anchor_job is not None
+        and evidence.job_id is not None
+        and evidence.job_id == anchor_job
+    )
+    if (
+        anchor_session is not None
+        and evidence.session_id is not None
+        and evidence.session_id != anchor_session
+        and not (scope == "distributed" and same_job)
+    ):
+        return True
+    if (
+        anchor_job is not None
+        and evidence.job_id is not None
+        and evidence.job_id != anchor_job
+        and evidence.session_id != anchor_session
+    ):
+        return True
+    return False
+
+
+def _correlation_confidence(
+    evidence: CorrelationEvidence,
+    anchor: Mapping[str, Any],
+    identity_match: str | None,
+    has_time: bool,
+    time_matches: bool,
+) -> tuple[str, list[str]]:
+    reasons: list[str] = []
+    if time_matches:
+        reasons.append("overlaps_anchor_window")
+    elif not has_time:
+        reasons.append("identifier_only_no_time")
+
+    anchor_rank = _int_or_none(anchor.get("rank"))
+    same_rank = (
+        anchor_rank is None or evidence.rank is None or evidence.rank == anchor_rank
+    )
+    if identity_match == "session":
+        reasons.append("same_session")
+        if same_rank:
+            reasons.append("same_rank_or_rank_agnostic")
+            return "high", reasons
+        reasons.append("cross_rank_same_session")
+        return "medium", reasons
+    if identity_match == "job":
+        reasons.append("same_job_distributed")
+        if same_rank:
+            reasons.append("same_rank_or_rank_agnostic")
+            return "high", reasons
+        reasons.append("cross_rank_same_job")
+        return "medium", reasons
+
+    reasons.append("time_only_missing_shared_identifier")
+    return "low", reasons
+
+
+def _correlation_sort_key(
+    evidence: CorrelationEvidence,
+    anchor: Mapping[str, Any],
+) -> tuple[int, int, str, str]:
+    confidence_rank = {"high": 0, "medium": 1, "low": 2}.get(
+        evidence.confidence,
+        9,
+    )
+    anchor_at = cast(int | None, anchor.get("at_ns"))
+    distance = _evidence_distance_ns(evidence, anchor_at)
+    return confidence_rank, distance, evidence.kind, evidence.title
+
+
+def _evidence_distance_ns(
+    evidence: CorrelationEvidence,
+    at_ns: int | None,
+) -> int:
+    if at_ns is None:
+        return 0
+    starts = [
+        value for value in (evidence.start_ns, evidence.end_ns) if value is not None
+    ]
+    if not starts:
+        return 0
+    return min(abs(value - at_ns) for value in starts)
+
+
+def _evidence_id(*parts: object) -> str:
+    payload = json.dumps([str(part) for part in parts], sort_keys=True)
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
+    return f"evidence-{digest}"
 
 
 def _parse_datetime(value: str | None) -> datetime | None:
@@ -1868,12 +2525,17 @@ def _int_or_none(value: object) -> int | None:
 
 
 __all__ = [
+    "AttachmentFilter",
     "ArtifactCatalog",
     "CatalogOOMBundle",
     "CatalogSource",
     "CatalogWarning",
+    "CorrelationEvidence",
+    "CorrelationFilter",
+    "CorrelationResult",
     "EventFilter",
     "EventRow",
+    "ExternalAttachment",
     "IssueFilter",
     "OOMBundleFilter",
     "OOMBundleRow",

--- a/stormlog/query_cli.py
+++ b/stormlog/query_cli.py
@@ -10,6 +10,8 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
+from .correlation import DEFAULT_CORRELATION_WINDOW_NS
+
 
 @dataclass(frozen=True)
 class _OutputMode:
@@ -116,6 +118,28 @@ def main(argv: Sequence[str] | None = None) -> int:
                 for row in store.summarize(args.metric, group_by=args.group_by)
             ]
             _emit_rows(rows, output_mode, _SUMMARY_COLUMNS)
+        elif args.command == "correlate":
+            result = store.correlate(
+                query_api.CorrelationFilter(
+                    session_id=args.session_id,
+                    job_id=args.job_id,
+                    rank=args.rank,
+                    scope=args.scope,
+                    at_ns=args.at_ns,
+                    record_id=args.record_id,
+                    window_ns=args.window_ns,
+                    kinds=tuple(args.kind or ()),
+                    limit=args.limit,
+                )
+            )
+            if output_mode.json:
+                print(json.dumps(result.as_dict(), indent=2, sort_keys=True))
+            else:
+                _emit_rows(
+                    [row.as_dict() for row in result.evidence],
+                    output_mode,
+                    _CORRELATION_COLUMNS,
+                )
     except BrokenPipeError:
         return 1
     except Exception as exc:
@@ -218,6 +242,43 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=["session", "session-rank", "rank", "status"],
         default=None,
     )
+
+    correlate = subparsers.add_parser(
+        "correlate",
+        help="Find evidence correlated with a timestamp or telemetry record",
+    )
+    _add_paths(correlate)
+    _add_output_flags(correlate, include_csv=False)
+    anchor = correlate.add_mutually_exclusive_group(required=True)
+    anchor.add_argument("--at-ns", type=int)
+    anchor.add_argument("--record-id")
+    correlate.add_argument("--session-id", "--session", dest="session_id")
+    correlate.add_argument("--job-id")
+    correlate.add_argument("--rank", type=int)
+    correlate.add_argument(
+        "--scope",
+        choices=["session", "distributed"],
+        default="session",
+    )
+    correlate.add_argument(
+        "--window-ns",
+        type=int,
+        default=DEFAULT_CORRELATION_WINDOW_NS,
+    )
+    correlate.add_argument(
+        "--kind",
+        action="append",
+        choices=[
+            "telemetry_event",
+            "timeline_marker",
+            "alert",
+            "oom_bundle",
+            "diagnose_bundle",
+            "rollup_window",
+            "attachment",
+        ],
+    )
+    correlate.add_argument("--limit", type=int)
     return parser
 
 
@@ -379,6 +440,19 @@ _SUMMARY_COLUMNS = (
     "latest_gap_bytes",
     "peak_gap_bytes",
     "sample_count",
+)
+_CORRELATION_COLUMNS = (
+    "confidence",
+    "kind",
+    "title",
+    "session_id",
+    "job_id",
+    "rank",
+    "start_ns",
+    "end_ns",
+    "source_kind",
+    "source_path",
+    "reasons",
 )
 
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -65,13 +66,14 @@ def _write_oom_bundle(
     *,
     session_id: str,
     session_status: str | None = SESSION_STATUS_INTERRUPTED,
+    created_at_utc: str = "2026-05-12T00:00:00Z",
 ) -> Path:
     bundle = root / "oom_dump_20260512T000000Z_123_cuda_1"
     bundle.mkdir(parents=True)
     manifest = {
         "schema_version": 2,
         "bundle_name": bundle.name,
-        "created_at_utc": "2026-05-12T00:00:00Z",
+        "created_at_utc": created_at_utc,
         "reason": "message_pattern:out of memory",
         "backend": "cuda",
         "event_count": 2,
@@ -87,6 +89,92 @@ def _write_oom_bundle(
     (bundle / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
     (bundle / "metadata.json").write_text(json.dumps(metadata), encoding="utf-8")
     return bundle
+
+
+def _iso_from_ns(timestamp_ns: int) -> str:
+    timestamp_s = timestamp_ns / 1_000_000_000
+    return (
+        datetime.fromtimestamp(timestamp_s, tz=timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _write_diagnose_bundle(
+    root: Path,
+    *,
+    session_id: str,
+    started_at_ns: int,
+    ended_at_ns: int,
+) -> Path:
+    summary = create_session_summary(
+        source="stormlog.test.diagnose",
+        status=SESSION_STATUS_COMPLETED,
+        session_id=session_id,
+        started_at_ns=started_at_ns,
+        ended_at_ns=ended_at_ns,
+        host="host-a",
+        pid=123,
+        job_id="job-a",
+        rank=0,
+        local_rank=0,
+        world_size=2,
+    )
+    diagnose = root / "diagnose_bundle"
+    diagnose.mkdir()
+    (diagnose / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "created_iso": _iso_from_ns(started_at_ns),
+                "command_line": "gpumemprof diagnose",
+                "files": ["manifest.json"],
+                "exit_code": 0,
+                "risk_detected": False,
+                "session_id": session_id,
+                "session_status": SESSION_STATUS_COMPLETED,
+                "session": session_summary_to_dict(summary),
+            }
+        ),
+        encoding="utf-8",
+    )
+    return diagnose
+
+
+def _write_attachment_sidecar(
+    root: Path,
+    *,
+    session_id: str,
+    start_ns: int,
+    end_ns: int | None = None,
+) -> Path:
+    trace_path = root / "profiler.trace"
+    trace_path.write_text("trace", encoding="utf-8")
+    sidecar = root / "stormlog_attachments.json"
+    sidecar.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "format": "stormlog.attachments",
+                "attachments": [
+                    {
+                        "title": "Profiler trace",
+                        "kind": "profiler",
+                        "path": trace_path.name,
+                        "session_id": session_id,
+                        "job_id": "job-a",
+                        "rank": 0,
+                        "start_ns": start_ns,
+                        "end_ns": end_ns,
+                        "created_at_utc": _iso_from_ns(start_ns),
+                        "metadata": {"tool": "profiler"},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return sidecar
 
 
 def test_list_sessions_uses_sink_manifest_without_loading_events(
@@ -116,6 +204,207 @@ def test_list_sessions_uses_sink_manifest_without_loading_events(
     assert rows[0].status == SESSION_STATUS_COMPLETED
     assert rows[0].source_kind == "sink"
     assert rows[0].event_count == 1
+
+
+def test_correlate_collects_same_session_evidence_across_artifacts(
+    tmp_path: Path,
+) -> None:
+    base_ns = 1_800_000_000_000_000_000
+    session_id = "session-correlate"
+    sink_dir = tmp_path / "sink"
+    sink = AppendOnlyTelemetrySink(
+        TelemetrySinkConfig(
+            root_dir=sink_dir,
+            flush_every_events=1,
+            flush_every_seconds=1.0,
+        )
+    )
+    sink.start_session(
+        create_session_summary(
+            source="stormlog.test",
+            status=SESSION_STATUS_COMPLETED,
+            session_id=session_id,
+            started_at_ns=base_ns,
+            host="host-a",
+            pid=123,
+            job_id="job-a",
+            rank=0,
+            local_rank=0,
+            world_size=2,
+        )
+    )
+    sink.append(
+        _event_record(
+            session_id=session_id,
+            timestamp_ns=base_ns,
+            event_type="phase_enter",
+            metadata={
+                "backend": "cuda",
+                "phase_scope": {
+                    "action": "enter",
+                    "name": "forward",
+                    "path": ["train", "forward"],
+                    "depth": 2,
+                    "scope_id": "scope-1",
+                    "parent_scope_id": None,
+                    "thread_id": 1,
+                    "thread_name": "MainThread",
+                    "sequence": 1,
+                },
+            },
+        )
+    )
+    sink.append(
+        _event_record(
+            session_id=session_id,
+            timestamp_ns=base_ns + 10,
+            event_type="warning",
+            context="High fragmentation: 40.0%",
+        )
+    )
+    sink.append(
+        _event_record(
+            session_id=session_id,
+            timestamp_ns=base_ns + 20,
+            event_type="phase_exit",
+            metadata={
+                "backend": "cuda",
+                "phase_scope": {
+                    "action": "exit",
+                    "name": "forward",
+                    "path": ["train", "forward"],
+                    "depth": 2,
+                    "scope_id": "scope-1",
+                    "parent_scope_id": None,
+                    "thread_id": 1,
+                    "thread_name": "MainThread",
+                    "sequence": 2,
+                },
+            },
+        )
+    )
+    sink.close()
+    _write_oom_bundle(
+        tmp_path,
+        session_id=session_id,
+        session_status=SESSION_STATUS_COMPLETED,
+        created_at_utc=_iso_from_ns(base_ns + 10),
+    )
+    _write_diagnose_bundle(
+        tmp_path,
+        session_id=session_id,
+        started_at_ns=base_ns,
+        ended_at_ns=base_ns + 30,
+    )
+    _write_attachment_sidecar(
+        tmp_path,
+        session_id=session_id,
+        start_ns=base_ns,
+        end_ns=base_ns + 30,
+    )
+
+    result = query_api.open([tmp_path]).correlate(
+        query_api.CorrelationFilter(
+            session_id=session_id,
+            at_ns=base_ns + 10,
+            window_ns=1_000,
+        )
+    )
+
+    kinds = {row.kind for row in result.evidence}
+    assert {
+        "telemetry_event",
+        "timeline_marker",
+        "alert",
+        "rollup_window",
+        "oom_bundle",
+        "diagnose_bundle",
+        "attachment",
+    }.issubset(kinds)
+    assert all(row.confidence in {"high", "medium"} for row in result.evidence)
+    attachment = next(row for row in result.evidence if row.kind == "attachment")
+    assert attachment.source_path.endswith("profiler.trace")
+
+
+def test_correlate_distributed_scope_uses_job_id_across_ranks(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "track.json"
+    _write_json_events(
+        path,
+        [
+            _event_record(session_id="session-r0", timestamp_ns=100, rank=0),
+            _event_record(session_id="session-r1", timestamp_ns=105, rank=1),
+        ],
+    )
+
+    result = query_api.open([path]).correlate(
+        query_api.CorrelationFilter(
+            job_id="job-a",
+            scope="distributed",
+            at_ns=100,
+            window_ns=10,
+        )
+    )
+
+    event_rows = [row for row in result.evidence if row.kind == "telemetry_event"]
+    assert {row.rank for row in event_rows} == {0, 1}
+    assert {row.confidence for row in event_rows} <= {"high", "medium"}
+    assert any("same_job_distributed" in row.reasons for row in event_rows)
+
+
+def test_correlate_allows_low_confidence_time_only_matches(tmp_path: Path) -> None:
+    path = tmp_path / "track.json"
+    _write_json_events(
+        path,
+        [_event_record(session_id="session-time-only", timestamp_ns=100)],
+    )
+
+    result = query_api.open([path]).correlate(
+        query_api.CorrelationFilter(at_ns=100, window_ns=0)
+    )
+
+    assert result.evidence
+    assert {row.confidence for row in result.evidence} == {"low"}
+    assert all(
+        "time_only_missing_shared_identifier" in row.reasons for row in result.evidence
+    )
+
+
+def test_attachment_sidecar_discovery_resolves_paths_and_reports_warnings(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    sidecar = _write_attachment_sidecar(
+        tmp_path,
+        session_id="session-attachment",
+        start_ns=100,
+    )
+    bad_sidecar_dir = tmp_path / "bad"
+    bad_sidecar_dir.mkdir()
+    (bad_sidecar_dir / "stormlog_attachments.json").write_text(
+        json.dumps({"schema_version": 1, "format": "wrong"}),
+        encoding="utf-8",
+    )
+
+    def _fail_load(*args: Any, **kwargs: Any) -> list[Any]:
+        raise AssertionError("attachment listing should not materialize telemetry")
+
+    monkeypatch.setattr(query_api, "load_telemetry_sessions", _fail_load)
+
+    store = query_api.open([tmp_path])
+    rows = store.list_attachments(
+        query_api.AttachmentFilter(session_id="session-attachment")
+    )
+
+    assert len(rows) == 1
+    assert rows[0].sidecar_path == str(sidecar)
+    assert rows[0].path is not None
+    assert rows[0].path.endswith("profiler.trace")
+    assert any(
+        "unrecognized attachment sidecar" in item.message
+        for item in store.catalog.warnings
+    )
 
 
 def test_list_sessions_discovers_sink_manifest_file(tmp_path: Path) -> None:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -158,6 +158,7 @@ def _write_attachment_sidecar(
                 "format": "stormlog.attachments",
                 "attachments": [
                     {
+                        "attachment_id": "profiler-trace-1",
                         "title": "Profiler trace",
                         "kind": "profiler",
                         "path": trace_path.name,
@@ -167,6 +168,7 @@ def _write_attachment_sidecar(
                         "start_ns": start_ns,
                         "end_ns": end_ns,
                         "created_at_utc": _iso_from_ns(start_ns),
+                        "updated_at_utc": _iso_from_ns(start_ns),
                         "metadata": {"tool": "profiler"},
                     }
                 ],
@@ -324,6 +326,8 @@ def test_correlate_collects_same_session_evidence_across_artifacts(
     assert all(row.confidence in {"high", "medium"} for row in result.evidence)
     attachment = next(row for row in result.evidence if row.kind == "attachment")
     assert attachment.source_path.endswith("profiler.trace")
+    assert result.anchor["clock_domain"] == "unix_epoch_ns"
+    assert result.anchor["clock_normalization"] == "producer_emitted_epoch_ns"
 
 
 def test_correlate_distributed_scope_uses_job_id_across_ranks(
@@ -399,6 +403,8 @@ def test_attachment_sidecar_discovery_resolves_paths_and_reports_warnings(
 
     assert len(rows) == 1
     assert rows[0].sidecar_path == str(sidecar)
+    assert rows[0].attachment_id == "profiler-trace-1"
+    assert rows[0].updated_at_utc == rows[0].created_at_utc
     assert rows[0].path is not None
     assert rows[0].path.endswith("profiler.trace")
     assert any(

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -375,6 +375,36 @@ def test_correlate_allows_low_confidence_time_only_matches(tmp_path: Path) -> No
     )
 
 
+def test_correlate_sorts_interval_containing_anchor_as_nearest(
+    tmp_path: Path,
+) -> None:
+    session_id = "session-interval"
+    path = tmp_path / "track.json"
+    _write_json_events(
+        path,
+        [_event_record(session_id=session_id, timestamp_ns=110)],
+    )
+    _write_attachment_sidecar(
+        tmp_path,
+        session_id=session_id,
+        start_ns=50,
+        end_ns=150,
+    )
+
+    result = query_api.open([tmp_path]).correlate(
+        query_api.CorrelationFilter(
+            session_id=session_id,
+            at_ns=100,
+            window_ns=100,
+        )
+    )
+
+    assert [row.kind for row in result.evidence[:2]] == [
+        "attachment",
+        "telemetry_event",
+    ]
+
+
 def test_attachment_sidecar_discovery_resolves_paths_and_reports_warnings(
     tmp_path: Path,
     monkeypatch: Any,

--- a/tests/test_query_cli.py
+++ b/tests/test_query_cli.py
@@ -204,6 +204,81 @@ def test_query_issues_rejects_csv(
     assert "unrecognized arguments: --csv" in capsys.readouterr().err
 
 
+def test_query_correlate_json_output(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = tmp_path / "track.json"
+    _write_json_events(path, [_event_record(timestamp_ns=100)])
+
+    assert query_main(["correlate", str(path), "--at-ns", "100", "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["anchor"]["at_ns"] == 100
+    assert payload["evidence"][0]["kind"] == "telemetry_event"
+    assert payload["evidence"][0]["confidence"] == "low"
+
+
+def test_query_correlate_table_filters_kind_rank_and_scope(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = tmp_path / "track.json"
+    _write_json_events(
+        path,
+        [
+            _event_record(session_id="session-r0", timestamp_ns=100, rank=0),
+            _event_record(
+                session_id="session-r1",
+                timestamp_ns=101,
+                rank=1,
+                event_type="warning",
+            ),
+        ],
+    )
+
+    assert (
+        query_main(
+            [
+                "correlate",
+                str(path),
+                "--at-ns",
+                "100",
+                "--job-id",
+                "job-a",
+                "--scope",
+                "distributed",
+                "--rank",
+                "1",
+                "--kind",
+                "alert",
+            ]
+        )
+        == 0
+    )
+
+    output = capsys.readouterr().out
+    assert "Confidence" in output
+    assert "Alert: warning" in output
+    assert "Telemetry Event" not in output
+
+
+def test_query_correlate_requires_anchor(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = tmp_path / "track.json"
+    _write_json_events(path, [_event_record(timestamp_ns=100)])
+
+    with pytest.raises(SystemExit) as excinfo:
+        query_main(["correlate", str(path)])
+
+    assert excinfo.value.code == 2
+    assert "one of the arguments --at-ns --record-id is required" in (
+        capsys.readouterr().err
+    )
+
+
 def test_stormlog_dispatcher_preserves_no_arg_tui(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_query_cli.py
+++ b/tests/test_query_cli.py
@@ -215,6 +215,7 @@ def test_query_correlate_json_output(
 
     payload = json.loads(capsys.readouterr().out)
     assert payload["anchor"]["at_ns"] == 100
+    assert payload["anchor"]["clock_domain"] == "unix_epoch_ns"
     assert payload["evidence"][0]["kind"] == "telemetry_event"
     assert payload["evidence"][0]["confidence"] == "low"
 


### PR DESCRIPTION
## Summary

- Added a derived correlation workflow for local Stormlog artifacts through `QueryStore.correlate(...)` and `stormlog query correlate`.
- Added `stormlog_attachments.json` sidecar discovery for external evidence such as profiler traces, experiment-tracking links, and runbooks.
- Correlation now surfaces telemetry events, timeline markers, alerts, OOM bundles, diagnose bundles, rollup windows, and attachments with confidence reasons around a timestamp or projected telemetry `record_id`.
- Documented the correlation contract, CLI usage, query-layer behavior, and attachment sidecar schema without changing `TelemetryEvent v3`.

## Tests

- `.venv/bin/python -m pytest tests/test_query.py tests/test_query_cli.py tests/test_timeline_markers.py tests/test_telemetry_rollups.py tests/test_telemetry_model.py -q`
- `.venv/bin/python -m pytest tests/ -m "not tui_pilot and not tui_snapshot and not tui_pty"`
- `.venv/bin/python -m isort --check --diff stormlog/ tests/ examples/`
- `.venv/bin/python -m black --check stormlog/ tests/ examples/`
- `.venv/bin/python -m flake8 stormlog/ tests/ examples/ --show-source --statistics`
- `.venv/bin/python -m mypy --no-incremental stormlog/`
- `.venv/bin/pre-commit run --all-files`
- `.venv/bin/python -m sphinx -W --keep-going -b html docs docs/_build/html`

## Design Notes

- Correlation is query-time and manifest-first; no persistent index or database is introduced.
- Same-session, time-overlapping evidence is high confidence. Distributed evidence uses `job_id`; time-only matches are retained as low confidence with explicit reasons.
- Attachment sidecars resolve local relative paths against the sidecar directory and record URLs without fetching remote content.

## Risks / Follow-ups

- TUI integration is intentionally left for a follow-up after the API/CLI row contract gets review.
- Cross-host clock normalization still depends on producers emitting comparable Unix epoch nanosecond timestamps.
- Richer attachment lifecycle management can be added later if users need a persistent registry instead of local sidecars.

Closes #115 