### PR TITLE
fix(tracker): lock MemoryTracker event snapshots

### DIFF
--- a/stormlog/tracker.py
+++ b/stormlog/tracker.py
@@ -173,6 +173,7 @@ class MemoryTracker:
 
         # Tracking state
         self.events: deque[TrackingEvent] = deque(maxlen=max_events)
+        self._events_lock = threading.Lock()
         self._history_dropped_events = 0
         self.is_tracking = False
         self._tracking_thread: Optional[threading.Thread] = None
@@ -245,8 +246,9 @@ class MemoryTracker:
 
     def _reset_tracking_state_for_new_session(self) -> None:
         """Clear per-session in-memory state before starting a new run."""
-        self.events.clear()
-        self._history_dropped_events = 0
+        with self._events_lock:
+            self.events.clear()
+            self._history_dropped_events = 0
         self._last_sink_diagnostics = self._empty_sink_diagnostics()
         self.last_oom_dump_path = None
         self.stats.update(
@@ -660,9 +662,10 @@ class MemoryTracker:
             backend=self.backend,
         )
 
-        if len(self.events) == self.max_events:
-            self._history_dropped_events += 1
-        self.events.append(event)
+        with self._events_lock:
+            if len(self.events) == self.max_events:
+                self._history_dropped_events += 1
+            self.events.append(event)
         self._oom_flight_recorder.record_event(self._tracking_event_payload(event))
         self._append_to_telemetry_sink(event)
 
@@ -1129,7 +1132,8 @@ class MemoryTracker:
         Returns:
             List of filtered events
         """
-        events = list(self.events)
+        with self._events_lock:
+            events = list(self.events)
 
         # Filter by type
         if event_type:
@@ -1155,12 +1159,15 @@ class MemoryTracker:
         Returns:
             Dictionary with timeline data
         """
-        if not self.events:
+        with self._events_lock:
+            events_snapshot = list(self.events)
+
+        if not events_snapshot:
             return {"timestamps": [], "allocated": [], "reserved": []}
 
         # Group events by time intervals
-        start_time = self.events[0].timestamp
-        end_time = self.events[-1].timestamp
+        start_time = events_snapshot[0].timestamp
+        end_time = events_snapshot[-1].timestamp
 
         timestamps = []
         allocated_values = []
@@ -1171,7 +1178,7 @@ class MemoryTracker:
             # Find events in this interval
             interval_events = [
                 e
-                for e in self.events
+                for e in events_snapshot
                 if current_time <= e.timestamp < current_time + interval
             ]
 
@@ -1193,7 +1200,10 @@ class MemoryTracker:
     def get_statistics(self) -> Dict[str, Any]:
         """Get comprehensive tracking statistics."""
         current_stats = self.stats.copy()
-        recent_events = [e for e in self.events if e.timestamp > time.time() - 3600]
+        with self._events_lock:
+            events_snapshot = list(self.events)
+            history_dropped_events = self._history_dropped_events
+        recent_events = [e for e in events_snapshot if e.timestamp > time.time() - 3600]
         sample = (
             self._last_observed_sample
             if self._collector_health.status != COLLECTOR_HEALTH_UNHEALTHY
@@ -1202,11 +1212,11 @@ class MemoryTracker:
 
         current_stats.update(
             {
-                "total_events": len(self.events),
+                "total_events": len(events_snapshot),
                 "events_last_hour": len(recent_events),
                 "history_window_limit_events": self.max_events,
-                "history_retained_events": len(self.events),
-                "history_dropped_events": self._history_dropped_events,
+                "history_retained_events": len(events_snapshot),
+                "history_dropped_events": history_dropped_events,
                 "backend": self.backend,
                 "oom_flight_recorder_enabled": self._oom_flight_recorder.config.enabled,
                 "last_oom_dump_path": self.last_oom_dump_path,
@@ -1266,11 +1276,16 @@ class MemoryTracker:
 
         import pandas as pd
 
-        if not self.events:
+        with self._events_lock:
+            events_snapshot = list(self.events)
+
+        if not events_snapshot:
             return
 
         # Convert events to canonical telemetry records.
-        records = [self._telemetry_record_from_event(event) for event in self.events]
+        records = [
+            self._telemetry_record_from_event(event) for event in events_snapshot
+        ]
 
         if format == "csv":
             df = pd.DataFrame(records)
@@ -1283,8 +1298,9 @@ class MemoryTracker:
 
     def clear_events(self) -> None:
         """Clear all tracking events."""
-        self.events.clear()
-        self._history_dropped_events = 0
+        with self._events_lock:
+            self.events.clear()
+            self._history_dropped_events = 0
 
         # Reset statistics
         self.stats.update(
@@ -1314,7 +1330,9 @@ class MemoryTracker:
     def get_alerts(self, last_n: Optional[int] = None) -> List[TrackingEvent]:
         """Get all alert events (warnings, critical, errors)."""
         alert_types = ["warning", "critical", "error"]
-        alerts = [e for e in self.events if e.event_type in alert_types]
+        with self._events_lock:
+            events_snapshot = list(self.events)
+        alerts = [e for e in events_snapshot if e.event_type in alert_types]
 
         if last_n:
             alerts = alerts[-last_n:]

--- a/tests/test_tracker_resilience.py
+++ b/tests/test_tracker_resilience.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import threading
 from collections import deque
+from functools import partial
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Callable, Iterator, cast
 
 import pytest
 
@@ -105,6 +107,57 @@ class _SequencedStopEvent:
 
     def clear(self) -> None:
         return None
+
+
+class _PausingDeque(deque):
+    def __init__(
+        self,
+        values: list[tracker_mod.TrackingEvent],
+        iter_started: threading.Event,
+        writer_finished: threading.Event,
+    ) -> None:
+        super().__init__(values)
+        self.iter_started = iter_started
+        self.writer_finished = writer_finished
+
+    def __iter__(self) -> Iterator[tracker_mod.TrackingEvent]:
+        for index, item in enumerate(super().__iter__()):
+            if index == 0:
+                self.iter_started.set()
+                self.writer_finished.wait(timeout=0.05)
+            yield item
+
+
+def _assert_reader_snapshots_events_under_lock(
+    tracker: tracker_mod.MemoryTracker,
+    reader: Callable[[], object],
+) -> None:
+    iter_started = threading.Event()
+    writer_finished = threading.Event()
+    writer_errors: list[Exception] = []
+    tracker.events = _PausingDeque(list(tracker.events), iter_started, writer_finished)
+
+    def writer() -> None:
+        try:
+            if not iter_started.wait(timeout=1.0):
+                writer_errors.append(AssertionError("reader did not iterate events"))
+                return
+            tracker._add_event("sample", 0, "concurrent writer")
+        except Exception as exc:
+            writer_errors.append(exc)
+        finally:
+            writer_finished.set()
+
+    writer_thread = threading.Thread(target=writer)
+    writer_thread.start()
+    try:
+        reader()
+    finally:
+        writer_finished.set()
+        writer_thread.join(timeout=1.0)
+
+    assert not writer_thread.is_alive(), "writer thread timed out"
+    assert writer_errors == []
 
 
 class _FailingFlushSink:
@@ -414,6 +467,37 @@ def test_memory_tracker_records_bounded_history_drops(
     assert stats["history_window_limit_events"] == 3
     assert stats["history_retained_events"] == 3
     assert stats["history_dropped_events"] == 2
+
+
+def test_memory_tracker_read_apis_snapshot_events_under_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reader_names = (
+        "get_events",
+        "get_memory_timeline",
+        "get_statistics",
+        "get_alerts",
+    )
+
+    for reader_name in reader_names:
+        collector = _SequencedCollector(
+            [DeviceMemorySampleResult(sample=_sample(allocated=128, reserved=256))]
+        )
+        tracker = _build_tracker(monkeypatch, collector, max_events=100)
+        tracker._add_event("warning", 0, "seed-warning")
+        tracker._add_event("sample", 0, "seed-sample")
+
+        reader: Callable[[], object]
+        if reader_name == "get_events":
+            reader = partial(tracker.get_events, last_n=1)
+        elif reader_name == "get_memory_timeline":
+            reader = partial(tracker.get_memory_timeline, interval=1.0)
+        elif reader_name == "get_statistics":
+            reader = tracker.get_statistics
+        else:
+            reader = partial(tracker.get_alerts, last_n=1)
+
+        _assert_reader_snapshots_events_under_lock(tracker, reader)
 
 
 def test_memory_tracker_disables_failing_sink_and_keeps_tracking(


### PR DESCRIPTION
## Summary

- Add a shared `_events_lock` to `MemoryTracker` for the event deque.
- Use that lock for appends, clears, exports, and read-side snapshots.
- Keep filtering, statistics, timeline aggregation, and alert selection outside the critical section by working from a copied list.
- Add deterministic regression coverage for the read APIs that raced the sampler thread.

## Why

`MemoryTracker` readers could iterate `self.events` while the background sampling thread appended to the same deque. Python detects that mutation during deque iteration and raises `RuntimeError: deque mutated during iteration`. The CPU tracker and OOM flight recorder already use this shared-lock snapshot pattern, so this brings the GPU tracker in line with the rest of the codebase.

## Repro Behavior

The repro shape changes after the fix: before, a reader could be halfway through a deque iteration while a writer appended into the same deque. After the fix, the reader first takes a list snapshot under `_events_lock`; a concurrent writer waits for that short snapshot window, and the reader then processes a stable list.

## Coverage

Regression coverage models a writer attempting to append while each read API snapshots events: `get_events()`, `get_memory_timeline()`, `get_statistics()`, and `get_alerts()`.